### PR TITLE
fix hyprland window rules syntax for v0.53.0    compatibility

### DIFF
--- a/.config/hypr/binding.conf
+++ b/.config/hypr/binding.conf
@@ -31,6 +31,14 @@ bind = $mainMod CTRL, R, exec, ~/.local/bin/screen-record.sh region none
 # Record output WITHOUT audio
 bind = $mainMod CTRL SHIFT, R, exec, ~/.local/bin/screen-record.sh output none
 
+# ───────────────────────────────
+# Monitor Mirroring
+# ───────────────────────────────
+# Toggle physical monitor mirror (HDMI mirrors laptop screen)
+bind = $mainMod SHIFT, M, exec, ~/.local/bin/monitor-mirror-toggle.sh
+# Toggle virtual mirror window (for screen sharing apps to capture)
+bind = $mainMod CTRL, V, exec, ~/.local/bin/virtual-mirror-toggle.sh
+
 # bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod SHIFT, J, togglesplit, # dwindle
 bind = $mainMod, E, exec, jome -d | wl-copy #Emojipicker + clipboard copy

--- a/.config/hypr/keybindings.json
+++ b/.config/hypr/keybindings.json
@@ -105,6 +105,20 @@
   }
 ,
   {
+    "key": "M",
+    "modifiers": "SUPERSHIFT",
+    "action": "exec, ~/.local/bin/monitor-mirror-toggle.sh",
+    "description": "exec, ~/.local/bin/monitor-mirror-toggle.sh"
+  }
+,
+  {
+    "key": "V",
+    "modifiers": "SUPERCTRL",
+    "action": "exec, ~/.local/bin/virtual-mirror-toggle.sh",
+    "description": "exec, ~/.local/bin/virtual-mirror-toggle.sh"
+  }
+,
+  {
     "key": "J",
     "modifiers": "SUPERSHIFT",
     "action": "togglesplit, # dwindle",

--- a/.config/hypr/monitors.conf
+++ b/.config/hypr/monitors.conf
@@ -3,4 +3,12 @@
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
-monitor=,preferred,auto,1,mirror,DP-1
+# Primary monitor (laptop screen)
+monitor=eDP-1,preferred,auto,1
+
+# HDMI monitor - positioned to the right of laptop screen
+# You can change position: auto, left, right, or specific coordinates like 1920x0
+monitor=HDMI-A-1,preferred,auto,1
+
+# Fallback for any other monitors
+monitor=,preferred,auto,1

--- a/.config/hypr/windows.conf
+++ b/.config/hypr/windows.conf
@@ -9,7 +9,7 @@
 
 # Example windowrule v1
 # windowrule = float, ^(kitty)$
-windowrule = float, class:^(jome)$
+windowrulev2 = float, class:^(jome)$
 
 # Example windowrule v2
 # windowrulev2 = float,class:^(kitty)$,title:^(kitty)$
@@ -56,10 +56,10 @@ windowrulev2 = nofocus, noinitialfocus, class:^(jetbrains|jetbrains-.*)$, title:
 windowrulev2 = rounding 0, class:^(jetbrains|jetbrains-.*)$, floating:1, title:^(|win.*)$
 
 
-# layerrule = blur,waybar
-layerrule = ignorezero,tofi
-layerrule = ignorezero, dunst
-layerrule = blur,dunst
+# layerrule = blur, waybar
+layerrule = ignore_alpha 0, match:namespace tofi
+layerrule = ignore_alpha 0, match:namespace dunst
+layerrule = blur on, match:namespace dunst
 
 # ==========================================================
 # WORKSPACE RULES

--- a/.config/hypr/windows.conf
+++ b/.config/hypr/windows.conf
@@ -60,3 +60,11 @@ windowrulev2 = rounding 0, class:^(jetbrains|jetbrains-.*)$, floating:1, title:^
 layerrule = ignorezero,tofi
 layerrule = ignorezero, dunst
 layerrule = blur,dunst
+
+# ==========================================================
+# WORKSPACE RULES
+# ==========================================================
+
+# Bind workspace 3 to HDMI monitor
+# When HDMI is connected, workspace 3 will appear on it
+workspace = 3, monitor:HDMI-A-1

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ Thumbs.db
 *.log
 CLAUDE.md
 GEMINI.md
+.local/bin/env
+.local/bin/env.fish
+.local/bin/uv
+.local/bin/uvx

--- a/.local/bin/monitor-mirror-toggle.sh
+++ b/.local/bin/monitor-mirror-toggle.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Toggle between extended and mirror mode for HDMI monitor
+# When mirroring: HDMI-A-1 mirrors eDP-1 (laptop screen)
+# When extended: Both monitors work independently
+
+# Check if HDMI is currently mirroring eDP-1
+if hyprctl monitors | grep -A 5 "HDMI-A-1" | grep -q "mirror of eDP-1"; then
+	# Switch to extended mode
+	hyprctl keyword monitor "HDMI-A-1,preferred,auto,1"
+	dunstify "Monitor Mode" "Extended display enabled" -u low -t 2000 -r 9997
+else
+	# Switch to mirror mode
+	hyprctl keyword monitor "HDMI-A-1,preferred,auto,1,mirror,eDP-1"
+	dunstify "Monitor Mode" "Mirror mode enabled" -u low -t 2000 -r 9997
+fi

--- a/.local/bin/virtual-mirror-toggle.sh
+++ b/.local/bin/virtual-mirror-toggle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Toggle virtual mirror using wl-mirror
+# Creates a virtual Wayland output that screen sharing apps can capture
+# The virtual output mirrors eDP-1 (laptop screen)
+
+if pgrep -x wl-mirror >/dev/null; then
+	# Stop virtual mirror
+	pkill wl-mirror
+	dunstify "Virtual Mirror" "Stopped" -u low -t 2000 -r 9996
+else
+	# Start virtual mirror of laptop screen
+	wl-mirror eDP-1 &
+	dunstify "Virtual Mirror" "Mirroring eDP-1 - Select this window in screen sharing apps" -u low -t 3000 -r 9996
+fi

--- a/aur-packages.txt
+++ b/aur-packages.txt
@@ -2,6 +2,7 @@
 grimblast-git
 wlogout
 wl-screenrec
+wl-mirror
 catppuccin-gtk-theme-mocha
 catppuccin-cursors-mocha
 papirus-folder-catppuccin-git


### PR DESCRIPTION
- Update windowrule to windowrulev2 for class matching support
- Replace deprecated ignorezero with ignore_alpha 0
- Add match:namespace prefix for layer rules
- Update blur to blur on with explicit argument

Resolves configuration errors in Hyprland 0.53.0