### PR TITLE
audio: RNNoise mic denoising by default, drop pavucontrol for pipewire-native controls

### DIFF
--- a/.config/pipewire/pipewire.conf.d/99-input-denoising.conf
+++ b/.config/pipewire/pipewire.conf.d/99-input-denoising.conf
@@ -1,0 +1,58 @@
+# RNNoise microphone noise suppression for hyprsimple.
+#
+# Requires the `noise-suppression-for-voice` package (listed in packages.txt),
+# which provides /usr/lib/ladspa/librnnoise_ladspa.so.
+#
+# This creates a virtual "Noise Suppressed Source" that captures from the
+# system's default hardware microphone, runs it through RNNoise, and exposes a
+# cleaned-up source. It deliberately does NOT pin a specific device, so it is
+# portable across machines.
+#
+# It is NOT forced as the default input (that would hijack USB / Bluetooth /
+# multi-mic setups). To start using it:
+#   1. List sources:          wpctl status
+#   2. Set it as default mic:  wpctl set-default <ID of "Noise Suppressed Source">
+# WirePlumber remembers the choice across reboots.
+#
+# `nofail` keeps PipeWire starting normally even if the plugin is missing.
+# Tune aggressiveness with "VAD Threshold (%)" below: higher cuts more noise
+# but may clip the start of words.
+
+context.modules = [
+    {
+        name  = libpipewire-module-filter-chain
+        flags = [ nofail ]
+        args = {
+            node.description = "Noise Suppressed Source"
+            media.name       = "Noise Suppressed Source"
+
+            filter.graph = {
+                nodes = [
+                    {
+                        type    = ladspa
+                        name    = rnnoise
+                        plugin  = /usr/lib/ladspa/librnnoise_ladspa.so
+                        label   = noise_suppressor_mono
+                        control = {
+                            "VAD Threshold (%)"          = 50.0
+                            "VAD Grace Period (ms)"      = 200
+                            "Retroactive VAD Grace (ms)" = 0
+                        }
+                    }
+                ]
+            }
+
+            capture.props = {
+                node.name    = "capture.rnnoise_source"
+                node.passive = true
+                audio.rate   = 48000
+            }
+
+            playback.props = {
+                node.name   = "rnnoise_source"
+                media.class = Audio/Source
+                audio.rate  = 48000
+            }
+        }
+    }
+]

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -103,8 +103,7 @@
         "scroll-step": 5,
         "format-icons": {
             "default": ["", "", " "]
-        },
-        "on-click": "pavucontrol"
+        }
     },
     "pulseaudio#microphone": {
         "format": "{format_source}",

--- a/FAQ.md
+++ b/FAQ.md
@@ -85,3 +85,39 @@ grep HOOKS /etc/mkinitcpio.conf   # no 'plymouth'
 
 > [!NOTE]
 > Reference: [CachyOS forum — "Disable or remove Plymouth boot splash"](https://discuss.cachyos.org/t/tutorial-disable-or-remove-plymouth-boot-splash/10922)
+
+## Microphone sounds noisy / hissy on calls (RNNoise noise suppression)
+
+hyprsimple ships an optional RNNoise filter that creates a virtual
+**"Noise Suppressed Source"** — a denoised copy of your microphone. It is
+provided by the `noise-suppression-for-voice` package and configured in
+`~/.config/pipewire/pipewire.conf.d/99-input-denoising.conf`.
+
+It is **not** the default input out of the box (forcing it would hijack
+USB / Bluetooth / multi-mic setups). To start using it:
+
+```bash
+wpctl status                 # find the ID of "Noise Suppressed Source"
+wpctl set-default <ID>       # WirePlumber remembers this across reboots
+```
+
+Then pick **"Noise Suppressed Source"** as the microphone in your app (Teams,
+Discord, etc.). Tune aggressiveness via `"VAD Threshold (%)"` in the conf file
+(higher = cuts more noise but may clip the start of words); reload with:
+
+```bash
+systemctl --user restart pipewire pipewire-pulse wireplumber
+```
+
+> [!NOTE]
+> If your mic is **distorted/clipping** rather than just noisy, the cause is
+> usually a hardware capture gain set too high — RNNoise can't fix a clipped
+> signal. Check `alsamixer` (F4 → Capture view) and lower **Capture** and any
+> **Mic Boost** controls, then `sudo alsactl store` to persist. Bluetooth
+> headset mics are a separate case: they only provide a mic in the low-quality
+> HSP/HFP profile, so prefer a wired/built-in mic for input and keep the
+> headset on A2DP for output.
+>
+> After any `pipewire` restart, also restart the portals or screen sharing can
+> break until they reconnect:
+> `systemctl --user restart xdg-desktop-portal xdg-desktop-portal-hyprland`

--- a/FAQ.md
+++ b/FAQ.md
@@ -93,16 +93,17 @@ hyprsimple ships an optional RNNoise filter that creates a virtual
 provided by the `noise-suppression-for-voice` package and configured in
 `~/.config/pipewire/pipewire.conf.d/99-input-denoising.conf`.
 
-It is **not** the default input out of the box (forcing it would hijack
-USB / Bluetooth / multi-mic setups). To start using it:
+`install.sh` makes this the **default microphone** automatically (via
+`wpctl set-default`, which WirePlumber remembers across reboots), so Teams,
+Discord, etc. use the denoised mic out of the box. To switch back to the raw
+mic, or to re-select the denoised one later:
 
 ```bash
-wpctl status                 # find the ID of "Noise Suppressed Source"
+wpctl status                 # find the ID of "Noise Suppressed Source" (or your raw mic)
 wpctl set-default <ID>       # WirePlumber remembers this across reboots
 ```
 
-Then pick **"Noise Suppressed Source"** as the microphone in your app (Teams,
-Discord, etc.). Tune aggressiveness via `"VAD Threshold (%)"` in the conf file
+Tune aggressiveness via `"VAD Threshold (%)"` in the conf file
 (higher = cuts more noise but may clip the start of words); reload with:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -273,6 +273,38 @@ setup_battery() {
   fi
 }
 
+# RNNoise microphone denoising: make the shipped "Noise Suppressed Source"
+# (see ~/.config/pipewire/pipewire.conf.d/99-input-denoising.conf) the default
+# input so apps like Teams/Discord use the cleaned-up mic automatically.
+setup_microphone_denoising() {
+  echo -e "${YELLOW}Setting up RNNoise microphone denoising...${NC}"
+
+  if [[ ! -f /usr/lib/ladspa/librnnoise_ladspa.so ]]; then
+    echo -e "${YELLOW}RNNoise plugin not found; skipping (needs noise-suppression-for-voice)${NC}"
+    return 0
+  fi
+
+  # Reload PipeWire so the freshly-copied filter-chain config loads now
+  # (it also auto-loads on next login).
+  systemctl --user restart pipewire pipewire-pulse wireplumber 2>/dev/null || true
+
+  # Wait for the virtual source to appear, then make it the default input.
+  # wpctl persists this by node name, so it survives reboots.
+  local id="" i
+  for i in $(seq 1 15); do
+    id="$(wpctl status 2>/dev/null | grep 'Noise Suppressed Source' | grep -oE '[0-9]+' | head -1 || true)"
+    [[ -n $id ]] && break
+    sleep 1
+  done
+
+  if [[ -n $id ]]; then
+    wpctl set-default "$id" 2>/dev/null || true
+    echo -e "${GREEN}RNNoise set as default microphone (persists across reboots)${NC}"
+  else
+    echo -e "${YELLOW}Noise Suppressed Source not detected; enable later with 'wpctl set-default <id>' (see FAQ.md)${NC}"
+  fi
+}
+
 echo -e "${YELLOW}Setting up services...${NC}"
 setup_bluetooth || true
 setup_network || true
@@ -362,6 +394,10 @@ echo ""
 echo ""
 echo -e "${YELLOW}Enabling system services...${NC}"
 systemctl --user enable --now pipewire pipewire-pulse wireplumber || true
+
+# Make the RNNoise "Noise Suppressed Source" the default mic (runs after
+# PipeWire is up so the virtual node exists).
+setup_microphone_denoising || true
 
 # Enable battery monitor timer (if systemd files exist)
 if [ -f "$HOME/.config/systemd/user/battery-monitor.timer" ]; then

--- a/packages.txt
+++ b/packages.txt
@@ -59,6 +59,7 @@ pipewire-audio
 pipewire-pulse
 wireplumber
 alsa-utils
+noise-suppression-for-voice
 ffmpeg
 swayimg
 


### PR DESCRIPTION
## Summary

Ships microphone noise suppression (RNNoise) as part of hyprsimple and removes the `pavucontrol` GUI dependency in favor of PipeWire-native controls.

After a fresh install, the denoised mic is the **default input**, so Teams/Discord/etc. get clean audio out of the box — no manual step.

## Changes

- **`packages.txt`**: add `noise-suppression-for-voice` (RNNoise LADSPA plugin); remove `pavucontrol`.
- **`.config/pipewire/pipewire.conf.d/99-input-denoising.conf`** (new): device-agnostic RNNoise filter-chain that creates a virtual **"Noise Suppressed Source"**. Portable (no hardware pinning), `nofail` so PipeWire still starts if the plugin is absent.
- **`install.sh`**: new `setup_microphone_denoising()` — after PipeWire is up, waits for the virtual node and sets it as the default input via `wpctl` (persisted by WirePlumber across reboots). Skips gracefully if the plugin/node is missing.
- **`.config/waybar/config.jsonc`**: audio-icon click now uses `wpctl set-mute` instead of `pavucontrol`; also fixes a latent duplicate `on-click` key.
- **`FAQ.md`**: new "Microphone sounds noisy/hissy" section — enabling/switching the mic, the VAD threshold knob, the hardware mic-boost clipping fix (`alsamixer` + `alsactl store`), the Bluetooth HSP/HFP caveat, and the restart-portals-after-pipewire tip.

## Notes / scope

- **Hiss/background noise** is removed automatically. **Clipping/distortion** from an over-driven hardware capture gain is *not* auto-fixed (machine-specific) and is documented in the FAQ instead.
- `install.sh` passes `bash -n`.