### PR TITLE
install: apply tuned starting mic levels on install

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -95,8 +95,12 @@ provided by the `noise-suppression-for-voice` package and configured in
 
 `install.sh` makes this the **default microphone** automatically (via
 `wpctl set-default`, which WirePlumber remembers across reboots), so Teams,
-Discord, etc. use the denoised mic out of the box. To switch back to the raw
-mic, or to re-select the denoised one later:
+Discord, etc. use the denoised mic out of the box. It also applies a set of
+**starting mic levels** (capture gain, mic boost, and the raw / RNNoise software
+volumes). These are tuned for a typical built-in laptop mic — sensitivity varies
+per machine, so if you clip or sound too quiet, adjust them with `mic-tune.sh`.
+
+To switch back to the raw mic, or to re-select the denoised one later:
 
 ```bash
 wpctl status                 # find the ID of "Noise Suppressed Source" (or your raw mic)

--- a/install.sh
+++ b/install.sh
@@ -303,6 +303,36 @@ setup_microphone_denoising() {
   else
     echo -e "${YELLOW}Noise Suppressed Source not detected; enable later with 'wpctl set-default <id>' (see FAQ.md)${NC}"
   fi
+
+  # --- Tuned starting mic levels --------------------------------------------
+  # Sane defaults for a typical built-in laptop mic. Mic sensitivity varies per
+  # machine, so verify with 'mic-tune.sh' and adjust if you clip or sound too
+  # quiet. (Capture is set for completeness; WirePlumber manages it and forces
+  # it toward 100% regardless.)
+  local TARGET_CAPTURE=100      # ALSA hardware capture gain (%)
+  local TARGET_MIC_BOOST=33     # ALSA mic boost (% — ~+10dB on a 0-3 control)
+  local TARGET_RAW_VOL=50       # raw hardware mic software volume (%)
+  local TARGET_RNNOISE_VOL=40   # "Noise Suppressed Source" software volume (%)
+
+  local hw_src card boost
+  hw_src="$(pactl list sources short 2>/dev/null | awk '/alsa_input/{print $2; exit}')"
+  card="$(pactl list sources 2>/dev/null \
+        | awk -v s="$hw_src" '$0 ~ "Name: "s{f=1} f&&/alsa.card =/{gsub(/[^0-9]/,"");print;exit}')"
+  card="${card:-0}"
+
+  amixer -c "$card" sset "Capture" "${TARGET_CAPTURE}%" >/dev/null 2>&1 || true
+  for boost in "Internal Mic Boost" "Mic Boost" "Front Mic Boost" "Boost"; do
+    if amixer -c "$card" sget "$boost" &>/dev/null; then
+      amixer -c "$card" sset "$boost" "${TARGET_MIC_BOOST}%" >/dev/null 2>&1 || true
+      break
+    fi
+  done
+  sudo alsactl store >/dev/null 2>&1 || true   # persist ALSA gains across reboot
+
+  [[ -n $hw_src ]] && pactl set-source-volume "$hw_src" "${TARGET_RAW_VOL}%" 2>/dev/null || true
+  pactl set-source-volume rnnoise_source "${TARGET_RNNOISE_VOL}%" 2>/dev/null || true
+
+  echo -e "${GREEN}Applied starting mic levels (capture/boost + software volumes); fine-tune with mic-tune.sh${NC}"
 }
 
 echo -e "${YELLOW}Setting up services...${NC}"


### PR DESCRIPTION
## Summary

Extends `setup_microphone_denoising()` in `install.sh` to apply a set of starting microphone levels after enabling the RNNoise "Noise Suppressed Source", so a fresh install lands on a usable mic level instead of whatever the hardware defaults to.

Applied levels (editable constants at the top of the block):
- Hardware **Capture** gain → 100%
- **Mic Boost** → ~+10 dB (33% of a 0–3 control)
- Raw hardware mic **software volume** → 50%
- **RNNoise source** software volume → 40%

The ALSA **card index** and **mic-boost control name** are auto-detected (no hardcoded device names). ALSA gains are persisted with `alsactl store`; software volumes persist via WirePlumber state.

## Notes / caveats

- These values are tuned for a **typical built-in laptop mic**. Mic sensitivity varies per machine, so they are a *starting point* — the FAQ documents fine-tuning with `mic-tune.sh` (record-and-measure test).
- `Capture=100%` is set for completeness only; WirePlumber manages that control and forces it toward 100% regardless.
- All steps are guarded (`|| true`) so they never fail the install if a control/device is absent.
- `install.sh` passes `bash -n`.