### PR TITLE
Hypr tweaks: external-display bindings, screen-share rule, keybindings menu fix

### DIFF
--- a/.config/hypr/bindings/workspaces.lua
+++ b/.config/hypr/bindings/workspaces.lua
@@ -1,12 +1,42 @@
 for ws = 1, 10 do
-  local key = tostring(ws % 10) -- 10 maps to "0" to match the .conf bindings
-  hl.bind("SUPER + " .. key,         hl.dsp.focus({ workspace = tostring(ws) }),       { description = "Workspace " .. ws })
-  hl.bind("SUPER + SHIFT + " .. key, hl.dsp.window.move({ workspace = tostring(ws) }), { description = "Move to Workspace " .. ws })
+	local key = tostring(ws % 10) -- 10 maps to "0" to match the .conf bindings
+	hl.bind("SUPER + " .. key, hl.dsp.focus({ workspace = tostring(ws) }), { description = "Workspace " .. ws })
+	hl.bind(
+		"SUPER + SHIFT + " .. key,
+		hl.dsp.window.move({ workspace = tostring(ws) }),
+		{ description = "Move to Workspace " .. ws }
+	)
 end
 
 -- Scratchpad
-hl.bind("SUPER + SHIFT + S", hl.dsp.window.move({ workspace = "special:magic" }), { description = "Move to Scratchpad" })
+hl.bind(
+	"SUPER + SHIFT + S",
+	hl.dsp.window.move({ workspace = "special:magic" }),
+	{ description = "Move to Scratchpad" }
+)
+
+-- Move the whole workspace to another monitor (external display / presentations)
+hl.bind(
+	"SUPER + SHIFT + ALT + LEFT",
+	hl.dsp.workspace.move({ monitor = "l" }),
+	{ description = "Move Workspace to Left Monitor" }
+)
+hl.bind(
+	"SUPER + SHIFT + ALT + RIGHT",
+	hl.dsp.workspace.move({ monitor = "r" }),
+	{ description = "Move Workspace to Right Monitor" }
+)
+hl.bind(
+	"SUPER + SHIFT + ALT + UP",
+	hl.dsp.workspace.move({ monitor = "u" }),
+	{ description = "Move Workspace to Up Monitor" }
+)
+hl.bind(
+	"SUPER + SHIFT + ALT + DOWN",
+	hl.dsp.workspace.move({ monitor = "d" }),
+	{ description = "Move Workspace to Down Monitor" }
+)
 
 -- Scroll through workspaces
 hl.bind("SUPER + mouse_down", hl.dsp.focus({ workspace = "e+1" }), { description = "Next Workspace" })
-hl.bind("SUPER + mouse_up",   hl.dsp.focus({ workspace = "e-1" }), { description = "Previous Workspace" })
+hl.bind("SUPER + mouse_up", hl.dsp.focus({ workspace = "e-1" }), { description = "Previous Workspace" })

--- a/.config/hypr/windows.lua
+++ b/.config/hypr/windows.lua
@@ -43,6 +43,9 @@ hl.window_rule({
 	tag = "-default-opacity",
 })
 
+-- Hide the "<app> is sharing your screen" notification bar
+hl.window_rule({ match = { title = ".*is sharing.*" }, workspace = "special silent" })
+
 -- Force chromium-based browsers into a tile (chromium --app bug workaround)
 hl.window_rule({ match = { tag = "chromium-based-browser" }, tile = true })
 

--- a/.local/bin/monitor-mirror-toggle.sh
+++ b/.local/bin/monitor-mirror-toggle.sh
@@ -2,19 +2,61 @@
 
 # Toggle between extended and mirror mode
 # Auto-detects primary (built-in) and external monitors
+#
+# Usage: monitor-mirror-toggle.sh [on|off|toggle]
+#   on     - force mirror mode
+#   off    - force extended mode
+#   toggle - flip current mode (default)
+#
+# "on" is used by the monitor.added handler in hypr/autostart.lua so an
+# external display (projector) mirrors the laptop screen by default.
+
+MODE="${1:-toggle}"
+QUIET="${2:-}"
+
+case "$MODE" in
+on | off | toggle) ;;
+*)
+  echo "Usage: $(basename "$0") [on|off|toggle]" >&2
+  exit 2
+  ;;
+esac
 
 PRIMARY=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^eDP")) | .name' | head -1)
 EXTERNAL=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^eDP") | not) | .name' | head -1)
 
 if [[ -z $EXTERNAL ]]; then
-  notify-send "Monitor Mode" "No external monitor detected"
+  [[ $QUIET == "quiet" ]] || notify-send "Monitor Mode" "No external monitor detected"
   exit 1
 fi
 
-if hyprctl monitors | grep -A 5 "$EXTERNAL" | grep -q "mirror of $PRIMARY"; then
-  hyprctl keyword monitor "$EXTERNAL,preferred,auto,1"
-  notify-send "Monitor Mode" "Extended display enabled"
-else
+if [[ -z $PRIMARY ]]; then
+  [[ $QUIET == "quiet" ]] || notify-send "Monitor Mode" "No built-in (eDP) display detected"
+  exit 1
+fi
+
+mirror_on() {
   hyprctl keyword monitor "$EXTERNAL,preferred,auto,1,mirror,$PRIMARY"
   notify-send "Monitor Mode" "Mirror mode enabled"
-fi
+}
+
+mirror_off() {
+  hyprctl keyword monitor "$EXTERNAL,preferred,auto,1"
+  notify-send "Monitor Mode" "Extended display enabled"
+}
+
+is_mirrored() {
+  hyprctl monitors | grep -A 5 "$EXTERNAL" | grep -q "mirror of $PRIMARY"
+}
+
+case "$MODE" in
+on) mirror_on ;;
+off) mirror_off ;;
+toggle)
+  if is_mirrored; then
+    mirror_off
+  else
+    mirror_on
+  fi
+  ;;
+esac

--- a/.local/bin/show-keybindings.sh
+++ b/.local/bin/show-keybindings.sh
@@ -1,41 +1,49 @@
 #!/bin/bash
 
 # Show all Hyprland keybindings in rofi with fuzzy search
+#
+# NOTE: this parses the plain-text output of `hyprctl binds`, not `hyprctl -j binds`.
+# Hyprland 0.56.0 emits malformed JSON for the `binds` endpoint (keys and values are
+# misaligned, yielding unquoted tokens like `"keycode": T`), which makes jq bail out
+# and leaves rofi with an empty list. The plain-text output is unaffected.
 
-hyprctl -j binds |
-  jq -r '.[] | {modmask, key, description, dispatcher, arg} | "\(.modmask),\(.key),\(.description),\(.dispatcher),\(.arg)"' |
-  sed -r \
-    -e 's/null//g' \
-    -e 's/^0,/,/' \
-    -e 's/^1,/SHIFT + /' \
-    -e 's/^4,/CTRL + /' \
-    -e 's/^8,/ALT + /' \
-    -e 's/^64,/SUPER + /' \
-    -e 's/^65,/SUPER SHIFT + /' \
-    -e 's/^68,/SUPER CTRL + /' \
-    -e 's/^72,/SUPER ALT + /' \
-    -e 's/^73,/SUPER SHIFT ALT + /' \
-    -e 's/^76,/SUPER CTRL ALT + /' \
-    -e 's/^69,/SUPER CTRL SHIFT + /' \
-    -e 's/^5,/CTRL SHIFT + /' \
-    -e 's/^9,/SHIFT ALT + /' \
-    -e 's/^12,/CTRL ALT + /' |
-  awk -F, '{
-    key = $1
-    gsub(/^[ \t]*\+?[ \t]*/, "", key)
-    gsub(/[ \t]+$/, "", key)
-
-    desc = $2
-    gsub(/^[ \t]+|[ \t]+$/, "", desc)
-
-    if (desc == "") {
-      for (i = 3; i <= NF; i++) desc = desc $i (i < NF ? "," : "")
-      sub(/,$/, "", desc)
-      gsub(/(^|,)[[:space:]]*exec[[:space:]]*,?/, "", desc)
-      gsub(/^[ \t]+|[ \t]+$/, "", desc)
+hyprctl binds |
+  gawk '
+    function modstr(m,   s) {
+      s = ""
+      if (and(m, 64)) s = s "SUPER + "
+      if (and(m, 4))  s = s "CTRL + "
+      if (and(m, 8))  s = s "ALT + "
+      if (and(m, 1))  s = s "SHIFT + "
+      return s
+    }
+    function val(   s) { s = $0; sub(/^[^:]*:[ \t]*/, "", s); return s }
+    # Mouse buttons report as raw evdev codes; name them (as omarchy-menu-keybindings does).
+    function keyname(k) {
+      if (k == "mouse:272") return "LEFT MOUSE BUTTON"
+      if (k == "mouse:273") return "RIGHT MOUSE BUTTON"
+      if (k == "mouse:274") return "MIDDLE MOUSE BUTTON"
+      return k
+    }
+    function flush(   d) {
+      if (key == "" && keycode != "" && keycode != "0") key = "code:" keycode
+      if (key == "") return
+      d = desc
+      # Lua-backed binds carry no readable dispatcher text, so skip undescribed ones.
+      if (d == "" && dispatcher != "__lua")
+        d = dispatcher (arg != "" ? " " arg : "")
+      if (d == "") return
+      printf "%-30s  %s\n", modstr(modmask) keyname(key), d
     }
 
-    if (desc != "") printf "%-30s  %s\n", key, desc
-  }' |
+    /^bind/        { flush(); modmask=0; key=""; keycode=""; desc=""; dispatcher=""; arg=""; next }
+    /modmask:/     { modmask = $2 + 0; next }
+    /key:/         { key = val(); next }
+    /keycode:/     { keycode = val(); next }
+    /description:/ { desc = val(); next }
+    /dispatcher:/  { dispatcher = val(); next }
+    /arg:/         { arg = val(); next }
+    END            { flush() }
+  ' |
   sort -u |
   rofi -dmenu -p "󰌌" -i -theme ~/.config/rofi/keybindings/style.rasi

--- a/install.sh
+++ b/install.sh
@@ -423,6 +423,7 @@ systemctl --user enable --now hyprpaper.service || true
 systemctl --user enable --now hyprpolkitagent.service || true
 muslimtify daemon install || true
 muslimtify daemon status || true
+sudo systemctl enable --now thermald || true
 
 echo ""
 echo -e "${GREEN}======================================"


### PR DESCRIPTION
## Summary

Five small, independent changes to the Hyprland config and helper scripts. Each commit is one file and one logical change, so any can be reverted on its own.

## Changes

**`fix(scripts)`: repair keybindings menu on Hyprland 0.56.0**

`SUPER + /` silently stopped working. `hyprctl -j binds` emits malformed JSON in 0.56.0 — keys and values are misaligned, producing unquoted tokens like `"keycode": T`. `jq` aborts, rofi receives an empty list, and the menu appears to do nothing. Other endpoints (`monitors`, `clients`, `devices`, `workspaces`, `layers`) are unaffected.

`show-keybindings.sh` now parses the plain-text `hyprctl binds` output with gawk. Side benefits: modifiers are derived bitwise instead of from a hardcoded modmask table (so combos absent from that table render correctly), descriptions containing commas are no longer split, and mouse buttons get readable names.

Note: `omarchy-menu-keybindings` hits the same upstream bug.

**`feat(hypr)`: move-workspace-to-monitor bindings**

`SUPER + SHIFT + ALT + arrow` moves the whole workspace to the monitor in that direction. A newly connected display claims the lowest free workspace id, so this relocates the workspace you actually want onto the projector.

**`feat(hypr)`: hide screen sharing notification bar**

Sends the "<app> is sharing your screen" window to a silent special workspace. Ported from omarchy's `default/hypr/apps/browser.lua`.

**`feat(scripts)`: `on|off|toggle` for monitor-mirror-toggle**

Defaults to `toggle`, so `SUPER + SHIFT + M` is unchanged. Also guards against a missing eDP panel, which previously produced a malformed trailing `mirror,` argument to hyprctl.

**`feat(install)`: enable thermald service**

Completes the thermald addition from cef59bc, which added the package but never enabled the unit.

## Testing

- `hyprctl reload` clean, `hyprctl configerrors` empty after each config change
- Keybindings menu parses 85 bindings, 0 malformed rows; `SUPER + slash` present and working
- Swept every `hyprctl` JSON caller in the repo — `binds` was the only broken endpoint; `capslock-notify`, `virtual-mirror-toggle`, `monitor-mirror-toggle`, and `hypr-logout` pipelines smoke-tested against a live session
- `bash -n` clean on both modified scripts; argument handling verified (`badarg` → rc=2, `on` with no external display → rc=1)

**Not tested:** the mirror path has not been exercised against a real external display — only an internal panel was connected. Worth confirming on first projector use.