### PR TITLE
fix(hyprlock): stuck on hyprlock when turning on the screen

### DIFF
--- a/.config/hypr/hyprlock.conf
+++ b/.config/hypr/hyprlock.conf
@@ -26,12 +26,12 @@ input-field {
     font_color = $font_color
     fade_on_empty = true
     fade_timeout = 1000
-    placeholder_text = Input Password
+    placeholder_text = Enter Password
     hide_input = false
+    rounding = 8
     check_color = $check_color
     fail_color = rgb(204, 34, 34)
     fail_text = $FAIL <b>($ATTEMPTS)</b>
-    fail_transition = 100
     capslock_color = rgb(233, 173, 12)
     numlock_color = -1
     bothlock_color = -1


### PR DESCRIPTION
Closes #14 

## Summary

After `hyprlock` version 0.9.6, parameter `fail_transition` is not valid anymore, using this parameter can make hyprlock crash and causes user stuck on lock screen, to solve this, i remove this invalid parameter and test it with `hyprlock --verbose` then the crash log is gone