### PR TITLE
Only enable thermald on Intel laptops

### DIFF
--- a/.local/bin/hyprsimple-hw-intel-laptop.sh
+++ b/.local/bin/hyprsimple-hw-intel-laptop.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Exit 0 if this machine is an Intel laptop new enough for thermald to help.
+#
+# thermald is Intel-specific and only meaningful from Sandy Bridge (CPU model 42)
+# onwards, and only on machines that actually run warm and on battery. Used as a
+# condition, not run for output:
+#
+#   if hyprsimple-hw-intel-laptop.sh; then ...
+
+# Intel CPU
+grep -q "GenuineIntel" /proc/cpuinfo || exit 1
+
+# Sandy Bridge or newer. The "model" line is distinct from "model name".
+cpu_model=$(grep -m1 '^model[[:space:]]*:' /proc/cpuinfo | cut -d: -f2 | tr -d ' ')
+[[ -n $cpu_model ]] || exit 1
+(( cpu_model >= 42 )) || exit 1
+
+# Has a battery, i.e. is a laptop
+compgen -G "/sys/class/power_supply/BAT*" >/dev/null || exit 1
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Minimal Hyprland dotfiles for Arch Linux. Clean, functional, no bloat.
 - **17 themes** with one-key switching, all apps update at once (waybar, rofi, ghostty, hyprlock, dunst, btop)
 - **Per-theme wallpapers** with picker and cycle support
 - **Per-theme backgrounds** for app launcher and power menu
-- **Hardware auto-detection** at install (NVIDIA, Vulkan, Intel iGPU, WiFi, battery)
+- **Hardware auto-detection** at install (NVIDIA, Vulkan, Intel iGPU, WiFi, battery, thermald)
 - **Wayland-native** session via uwsm, no X11 dependencies
 - **Modular Hyprland config** split into focused files
 - **GTK/QT theming** with auto light/dark mode per theme
@@ -243,6 +243,7 @@ Most are wired to keybindings or waybar; all can also be run directly from a ter
 | `battery-monitor.sh` | Low-battery notifications and automatic brightness reduction |
 | `bluetooth-toggle.sh` | Toggle Bluetooth adapter power |
 | `toggle_cpu_mode.sh` | Switch CPU governor between performance and powersave |
+| `hyprsimple-hw-intel-laptop.sh` | Exit 0 on an Intel laptop new enough for thermald (used as a condition) |
 | `toggle-idle.sh` | Toggle hypridle (lock-on-idle) on/off |
 | `hypr-logout.sh` | Gracefully close all windows and stop the Hyprland session |
 

--- a/install.sh
+++ b/install.sh
@@ -540,7 +540,14 @@ systemctl --user enable --now hyprpaper.service || true
 systemctl --user enable --now hyprpolkitagent.service || true
 muslimtify daemon install || true
 muslimtify daemon status || true
-sudo systemctl enable --now thermald || true
+# thermald is Intel-only and pointless on AMD or on a desktop, so gate it
+if bash "$HOME/.local/bin/hyprsimple-hw-intel-laptop.sh"; then
+  sudo pacman -S --needed --noconfirm thermald >/dev/null 2>&1 || FAILED_PACKAGES+=(thermald)
+  sudo systemctl enable --now thermald || true
+  echo -e "${GREEN}thermald enabled (Intel laptop detected)${NC}"
+else
+  echo -e "${YELLOW}Skipping thermald (not an Intel laptop)${NC}"
+fi
 
 echo ""
 if (( ${#FAILED_PACKAGES[@]} > 0 )); then

--- a/migrations/1787388492.sh
+++ b/migrations/1787388492.sh
@@ -1,0 +1,23 @@
+echo "Enable thermald only on Intel laptops, disable it elsewhere"
+
+# thermald is an Intel-specific thermal policy daemon. hyprsimple used to install
+# and enable it unconditionally, so AMD machines and desktops have been running a
+# daemon that does nothing for them.
+
+CHECK="$HOME/.local/bin/hyprsimple-hw-intel-laptop.sh"
+[[ -x $CHECK ]] || exit 0
+
+if bash "$CHECK"; then
+  # Intel laptop: make sure it is actually installed and running
+  if ! pacman -Qi thermald &>/dev/null; then
+    sudo pacman -S --needed --noconfirm thermald || exit 1
+  fi
+  systemctl is-enabled thermald &>/dev/null || sudo systemctl enable --now thermald
+else
+  # Not an Intel laptop: stop and disable, but leave the package alone in case
+  # something else pulled it in
+  if systemctl is-enabled thermald &>/dev/null; then
+    echo "  Not an Intel laptop - disabling thermald"
+    sudo systemctl disable --now thermald
+  fi
+fi

--- a/packages.txt
+++ b/packages.txt
@@ -39,7 +39,6 @@ power-profiles-daemon
 qt5-wayland
 qt6-wayland
 kvantum
-thermald
 
 # networking
 dnsmasq


### PR DESCRIPTION
> Stacked on #16, which provides the migration system this uses. Base will retarget to `main` automatically once #16 merges.

## Problem

`thermald` is an Intel-specific thermal policy daemon. It is meaningful from Sandy Bridge (CPU model 42) onwards, and only on machines that run on battery. `install.sh` installed it from `packages.txt` and enabled it unconditionally, so every AMD machine and every desktop running hyprsimple has a daemon running that does nothing for them.

## Change

`hyprsimple-hw-intel-laptop.sh` exits 0 for Intel + CPU model >= 42 + a battery. It follows omarchy's `hw-*` convention: used as a condition, not run for output.

```bash
if hyprsimple-hw-intel-laptop.sh; then ...
```

`install.sh` installs and enables thermald only when that passes, and thermald is dropped from `packages.txt` so it is no longer pulled in unconditionally.

The migration enables it on Intel laptops that lack it and disables it where it should never have been running. It leaves the package installed in case something else depends on it.

## Testing

Detection, against a synthetic `/proc/cpuinfo` and battery path:

| Case | Result |
|---|---|
| AMD + battery | skip |
| Intel model 26 (pre-Sandy Bridge) | skip |
| Intel model 42 + battery | enable |
| Intel model 186 + battery | enable |
| Intel, no battery (desktop) | skip |

Migration, with stubbed `pacman`/`systemctl` recording their calls:

- **Intel laptop, thermald absent** — installs, then enables
- **Non-Intel with thermald enabled** — disables it, leaves the package
- **Intel laptop already installed and enabled** — zero actions, fully idempotent

## Not a fan controller

To be explicit, since this came out of a question about laptop fan control: thermald throttles via P-states and RAPL. It does not drive fans. Real fan curve control needs a vendor EC driver — omarchy only ships that for ASUS ROG (`asusctl`) and MacBook T2 (`t2fand`). Most laptops expose no PWM channel at all, in which case no software can control the fans.