### PR TITLE
Remove hardcoded home path from shipped hyprpaper.conf

### DIFF
--- a/.config/hypr/hyprpaper.conf
+++ b/.config/hypr/hyprpaper.conf
@@ -1,6 +1,6 @@
 wallpaper {
     monitor =
-    path = /home/rizki/.config/hypr/themes/everforest/backgrounds
+    path = ~/.config/hypr/themes/deep-sea/backgrounds
     fit_mode = cover
     timeout = 30
 }

--- a/migrations/1787389156.sh
+++ b/migrations/1787389156.sh
@@ -1,0 +1,20 @@
+echo "Repair hyprpaper.conf wallpaper paths pointing at another user's home"
+
+# .config/hypr/hyprpaper.conf shipped with a hardcoded /home/rizki/... path, so a
+# fresh install left every user whose name is not "rizki" with a broken wallpaper
+# path until their first theme switch rewrote the file.
+
+CONF="$HOME/.config/hypr/hyprpaper.conf"
+[[ -f $CONF ]] || exit 0
+
+# Rewrite any /home/<someone-else>/ prefix to this user's home. Anchored to the
+# start of the path so it cannot touch anything else, and a no-op once correct.
+if grep -qE "^\s*path\s*=\s*/home/[^/]+/" "$CONF" &&
+   ! grep -qE "^\s*path\s*=\s*${HOME}/" "$CONF"; then
+  sed -i -E "s#^(\s*path\s*=\s*)/home/[^/]+/#\1${HOME}/#" "$CONF"
+  echo "  Rewrote wallpaper path to $HOME"
+
+  if systemctl --user is-active hyprpaper.service &>/dev/null; then
+    systemctl --user restart hyprpaper.service
+  fi
+fi


### PR DESCRIPTION
## Problem

`.config/hypr/hyprpaper.conf` was committed with an absolute path into a specific developer's home directory:

```
path = /home/rizki/.config/hypr/themes/everforest/backgrounds
```

Two bugs in one line:

1. **Wrong for every user not named `rizki`.** A fresh install copies this file verbatim, so the wallpaper path is broken until something rewrites it.
2. **Wrong theme.** It names `everforest`, while `install.sh` sets `DEFAULT_THEME="deep-sea"`.

In practice `theme-switcher.sh` calls `write_hyprpaper_conf`, which regenerates the file using `$HOME`, so the breakage was usually transient — resolved at the first theme apply during install. But a committed config should never carry another machine's absolute paths, and anything that interrupts the install before the theme step leaves it broken.

## Fix

Use `~`, which the Hypr config parser expands and which the shipped `hyprlock.conf` already depends on (`path = ~/.cache/current_lockscreen.png`), and point at `deep-sea` to match `DEFAULT_THEME`:

```
path = ~/.config/hypr/themes/deep-sea/backgrounds
```

A migration repairs machines already carrying a foreign path. It rewrites only the `/home/<other-user>/` prefix, so the user keeps whichever theme they are actually on, and restarts hyprpaper if it is running.

## Testing

| Case | Result |
|---|---|
| `/home/rizki/...everforest/backgrounds` | rewritten to `$HOME`, theme preserved as everforest |
| re-run twice more | unchanged (idempotent) |
| already `$HOME/...` | untouched |
| `~/...` (the new default) | untouched |
| `$HOME/.cache/current_wallpaper` (live-wallpaper mode) | untouched |
| file missing | clean exit 0 |

A repo-wide grep for `/home/[a-z]` (excluding `.git`, `external`, `assets`) returns nothing after this change.