### PR TITLE
Shallow installs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: config-realworld-test
         run: bash test/config-realworld-test.sh
+
+      - name: shallow-install-test
+        run: bash test/shallow-install-test.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -115,10 +115,11 @@ copy_source_to_canonical_path() {
 echo -e "\n${YELLOW}Installing hyprsimple to $HYPRSIMPLE_PATH...${NC}"
 copy_source_to_canonical_path
 
-# A shallow clone can't be pulled from later, so give it real history
-if [[ -d "$HYPRSIMPLE_PATH/.git" ]]; then
-  git -C "$HYPRSIMPLE_PATH" fetch --unshallow origin "$REPO_REF" >/dev/null 2>&1 || true
-else
+# The clone above is shallow and stays that way. A shallow clone pulls fine:
+# git fast-forwards it and leaves it shallow, which is all hyprsimple-update
+# needs. Unshallowing here used to pull the repository's full history, which is
+# 192 MB against 27 MB for a shallow clone.
+if [[ ! -d "$HYPRSIMPLE_PATH/.git" ]]; then
   echo -e "${YELLOW}Source was not a git checkout, so hyprsimple-update will not be able to pull.${NC}"
 fi
 echo -e "${GREEN}Done${NC}"

--- a/migrations/1788011545.sh
+++ b/migrations/1788011545.sh
@@ -1,0 +1,80 @@
+echo "Drop the repository history hyprsimple does not need"
+
+# A default clone brings every branch, every remote-tracking ref and every tag,
+# and git keeps an object alive as long as any reference reaches it. That is why
+# an install carries the full history, 192 MB against 27 MB for a shallow one,
+# including every version of the wallpapers removed in the repo slimming.
+#
+# git pull only ever adds objects, so an install never shrinks on its own.
+#
+# This is the only migration that deletes data permanently. There is nothing to
+# restore from afterwards, so it refuses and changes nothing whenever it sees
+# something it does not expect. Losing 165 MB of disk is better than losing a
+# commit somebody meant to keep.
+
+REPO="$HYPRSIMPLE_PATH"
+[[ -d $REPO/.git ]] || exit 0
+
+if [[ -f $REPO/.git/shallow ]]; then
+  echo "  Already shallow, nothing to do"
+  exit 0
+fi
+
+branch=$(git -C "$REPO" symbolic-ref --quiet --short HEAD) || {
+  echo "  HEAD is detached, leaving this install alone"
+  exit 0
+}
+
+if [[ -n $(git -C "$REPO" status --porcelain) ]]; then
+  echo "  $REPO has local changes, leaving it alone"
+  exit 0
+fi
+
+# A branch holding commits the tracked branch cannot reach is somebody's work.
+unmerged=()
+while IFS= read -r b; do
+  [[ $b == "$branch" ]] && continue
+  if [[ -n $(git -C "$REPO" rev-list --count "$branch..$b" 2>/dev/null) ]] &&
+     (($(git -C "$REPO" rev-list --count "$branch..$b") > 0)); then
+    unmerged+=("$b")
+  fi
+done < <(git -C "$REPO" for-each-ref --format='%(refname:short)' refs/heads)
+
+if ((${#unmerged[@]} > 0)); then
+  echo "  These branches have commits not on $branch, so nothing was deleted:"
+  for b in "${unmerged[@]}"; do
+    echo "    $b"
+  done
+  echo "  Merge or delete them and run hyprsimple-update again to reclaim the space."
+  exit 0
+fi
+
+before=$(du -sm "$REPO/.git" | cut -f1)
+
+# 1. Cut the parent chain so history stops being reachable through the branch.
+git -C "$REPO" fetch --quiet --depth 1 origin "$branch" || {
+  echo "  Could not reach origin, leaving this install alone"
+  exit 0
+}
+
+# 2. Drop every other reference. Until these are gone they still reach the old
+#    objects regardless of the shallow fetch.
+while IFS= read -r b; do
+  [[ $b == "$branch" ]] && continue
+  git -C "$REPO" branch -D "$b" >/dev/null 2>&1
+done < <(git -C "$REPO" for-each-ref --format='%(refname:short)' refs/heads)
+
+while IFS= read -r r; do
+  [[ $r == "refs/remotes/origin/$branch" ]] && continue
+  git -C "$REPO" update-ref -d "$r" 2>/dev/null
+done < <(git -C "$REPO" for-each-ref --format='%(refname)' refs/remotes refs/tags)
+
+# 3. The reflog is a hidden reference that would keep everything alive.
+git -C "$REPO" reflog expire --expire=now --all 2>/dev/null
+
+# 4. Rewrite the pack without the unreachable objects. This reclaims the space.
+git -C "$REPO" repack -adq 2>/dev/null
+git -C "$REPO" prune --expire=now 2>/dev/null
+
+after=$(du -sm "$REPO/.git" | cut -f1)
+echo "  Install history: ${before} MB -> ${after} MB"

--- a/test/shallow-install-test.sh
+++ b/test/shallow-install-test.sh
@@ -27,7 +27,11 @@ make_install() {
   local name="$1"
   local origin="$TMP/$name-origin"
   local inst="$TMP/$name"
+  # Name the branch explicitly. `git init` takes it from init.defaultBranch,
+  # which is main on some machines and master on others, and a mismatch leaves
+  # the bare repo's HEAD pointing at a branch this fixture never creates.
   git init -q --bare "$origin"
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
   git clone -q "$origin" "$TMP/$name-work" 2>/dev/null
   git -C "$TMP/$name-work" config user.email test@example.com
   git -C "$TMP/$name-work" config user.name test
@@ -43,7 +47,11 @@ make_install() {
   git -C "$TMP/$name-work" tag -a v1 -m v1
   git -C "$TMP/$name-work" push -q origin v1
   git clone -q "$origin" "$inst"
-  git -C "$inst" checkout -q main 2>/dev/null || true
+  # The install clone commits too, in the unmerged-branch case. A GitHub runner
+  # has no global git identity, so it needs its own.
+  git -C "$inst" config user.email test@example.com
+  git -C "$inst" config user.name test
+  git -C "$inst" checkout -q main
   echo "$inst"
 }
 

--- a/test/shallow-install-test.sh
+++ b/test/shallow-install-test.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Checks the install-shrinking migration against fixtures.
+# Never touches the real install at ~/.local/share/hyprsimple.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$REPO/migrations/1788011545.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# An origin with enough history that dropping it is measurable, and a full
+# clone of it standing in for an install.
+# One `local` per line. On bash 5.3, `local a="$1" b="$a"` does not evaluate
+# left to right: every right-hand side is expanded before any assignment lands,
+# so `b` is built from an empty `a`. Under `set -u` that aborts the function
+# inside its own command substitution and the caller captures an empty string.
+make_install() {
+  local name="$1"
+  local origin="$TMP/$name-origin"
+  local inst="$TMP/$name"
+  git init -q --bare "$origin"
+  git clone -q "$origin" "$TMP/$name-work" 2>/dev/null
+  git -C "$TMP/$name-work" config user.email test@example.com
+  git -C "$TMP/$name-work" config user.name test
+  local i
+  for i in 1 2 3 4 5; do
+    head -c 200000 /dev/urandom >"$TMP/$name-work/blob.bin"
+    printf 'v%s\n' "$i" >"$TMP/$name-work/f.txt"
+    git -C "$TMP/$name-work" add -A
+    git -C "$TMP/$name-work" commit -qm "commit $i"
+  done
+  git -C "$TMP/$name-work" push -q origin HEAD:refs/heads/main
+  git -C "$TMP/$name-work" push -q origin HEAD:refs/heads/other
+  git -C "$TMP/$name-work" tag -a v1 -m v1
+  git -C "$TMP/$name-work" push -q origin v1
+  git clone -q "$origin" "$inst"
+  git -C "$inst" checkout -q main 2>/dev/null || true
+  echo "$inst"
+}
+
+# Kilobytes, not megabytes. A fixture install is around 1200 KB, so measuring
+# in whole megabytes would make "shrank by half" a coin flip.
+size_kb() { du -sk "$1/.git" | cut -f1; }
+
+# Every fixture path goes through this before any git command touches it. An
+# empty path would make `git -C "$path"` operate on the current directory, which
+# is the repository this suite runs from, so a fixture bug would corrupt the
+# working tree rather than fail a check.
+must_be_fixture() {
+  if [[ -z ${1:-} || ! -d $1/.git || $1 != "$TMP"/* ]]; then
+    printf 'fixture: refusing to use path [%s], expected a git repo under %s\n' "${1:-}" "$TMP" >&2
+    exit 2
+  fi
+}
+
+# ---- a fat install shrinks and can still pull ---------------------------
+
+inst=$(make_install fat)
+must_be_fixture "$inst"
+before=$(size_kb "$inst")
+HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >"$TMP/out_fat" 2>&1
+after=$(size_kb "$inst")
+
+if ((after * 2 <= before)); then pass "a fat install shrinks by at least half"
+else fail "a fat install shrinks by at least half (before ${before}KB after ${after}KB)"; fi
+
+check "the shrunk install is shallow" "$([[ -f $inst/.git/shallow ]] && echo yes || echo no)" yes
+check "the working tree survives" "$(cat "$inst/f.txt")" "v5"
+git -C "$inst" pull --ff-only -q origin main >/dev/null 2>&1
+check "the shrunk install can still pull" "$?" "0"
+
+# ---- a second run changes nothing ---------------------------------------
+
+size_before_second=$(size_kb "$inst")
+HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "migration is idempotent" "$(size_kb "$inst")" "$size_before_second"
+
+# ---- an unmerged local branch is refused --------------------------------
+
+inst=$(make_install unmerged)
+must_be_fixture "$inst"
+git -C "$inst" checkout -q -b mywork
+printf 'unpushed work\n' >"$inst/mine.txt"
+git -C "$inst" add -A
+git -C "$inst" commit -qm "work nobody pushed"
+git -C "$inst" checkout -q main
+before=$(size_kb "$inst")
+HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >"$TMP/out_unmerged" 2>&1
+
+check "an unmerged branch survives" \
+  "$(git -C "$inst" rev-parse --verify --quiet mywork >/dev/null && echo yes || echo no)" yes
+check "nothing was reclaimed" "$(size_kb "$inst")" "$before"
+if grep -q "mywork" "$TMP/out_unmerged"; then pass "the branch is named in the output"
+else fail "the branch is named in the output"; fi
+
+# ---- a dirty tree is refused --------------------------------------------
+
+inst=$(make_install dirty)
+must_be_fixture "$inst"
+printf 'edited\n' >>"$inst/f.txt"
+before=$(size_kb "$inst")
+HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "a dirty install is left alone" "$(size_kb "$inst")" "$before"
+
+# ---- a detached HEAD is refused -----------------------------------------
+
+inst=$(make_install detached)
+must_be_fixture "$inst"
+git -C "$inst" checkout -q --detach HEAD
+before=$(size_kb "$inst")
+HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "a detached HEAD is left alone" "$(size_kb "$inst")" "$before"
+
+# ---- a missing install is a no-op ---------------------------------------
+
+HYPRSIMPLE_PATH="$TMP/nothing-here" bash "$MIGRATION" >/dev/null 2>&1
+check "a missing install exits 0" "$?" "0"
+
+if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Every hyprsimple install carries the repository's full history. Measured on a fresh clone of `main`:

```
working tree     28 MB
.git            192 MB
```

PR #20 cut the working tree from 152 MB to 28 MB, but `.git` still holds every version of the 8 MB wallpapers that change removed. And `hyprsimple-update` runs `git pull`, which only ever adds objects, so an existing install stays at 192 MB forever.

## Why the history survives

Git keeps an object alive as long as any reference reaches it, and a default clone brings 19 references: 6 local branches, 7 remote-tracking refs, and 6 tags. `origin/chore/repo-slimming` alone reaches 274 commits.

## Two changes

**`bootstrap.sh` stops undoing its own shallow clone.** Line 68 clones `--depth 1`, which is 27 MB. Line 120 then ran `fetch --unshallow` and pulled all 192 MB back. Its comment claimed a shallow clone cannot be pulled from later. That is false, and was verified against a fixture: a shallow clone fast-forwards a real update, stays shallow, and satisfies every git command `hyprsimple-update` runs.

**A migration shrinks an existing install.** Four steps in order, each necessary:

1. `git fetch --depth 1` cuts the parent chain
2. Delete every other ref, which is what does the real work, since they reach the old objects regardless of step 1
3. `git reflog expire --expire=now --all`, because the reflog is a hidden reference
4. `git repack -ad` then `git prune`, which reclaims the space

Measured on a real clone: 192 MB to 27 MB, repack under one second, and the result still pulls and still passes the suites.

## This migration deletes data permanently

The project's other five migrations install a package, edit a config, or move a file aside recoverably. This one removes git objects and there is nothing to restore from. Every guard exists because of that. It refuses and changes nothing when:

- `HEAD` is detached
- the working tree is dirty
- a local branch holds commits the tracked branch cannot reach, and it names the branch
- the install is already shallow

A user with unpushed work keeps 192 MB and keeps the work. That is the intended trade.

## Tests

`test/shallow-install-test.sh`, 11 checks, all against fixtures in a temporary directory:

```
ok - a fat install shrinks by at least half        1212 KB -> 316 KB
ok - the shrunk install is shallow
ok - the working tree survives
ok - the shrunk install can still pull
ok - migration is idempotent
ok - an unmerged branch survives
ok - nothing was reclaimed
ok - the branch is named in the output
ok - a dirty install is left alone
ok - a detached HEAD is left alone
ok - a missing install exits 0
```

It is wired into `.github/workflows/tests.yml` as the fifth suite, and every suite in `test/` is named there with none missed.

### A note on the fixture guard

The first version of this test had a bash bug: `local a="$1" b="$a"` does not evaluate left to right on bash 5.3, so the fixture builder returned an empty path and every `git -C ""` ran against the working repository instead of a fixture. That created a stray branch and detached HEAD during development, and was recovered fully.

The test now uses one `local` per line and calls `must_be_fixture` after every fixture is built, which exits 2 unless the path is non-empty, contains a `.git`, and lives under the temporary directory. Reintroducing the original bug now exits 2 and touches nothing.

## Not in scope

- **`install.sh` is unchanged.** It copies `.git` from the contributor's checkout at whatever depth that has. Making it shallow would put a network dependency into a path that has none. The migration shrinks such an install on its first update.
- **`hyprsimple-update` is unchanged.** Confirmed absent from the diff.
- **Nothing on the remote is rewritten.** This only changes what a local clone keeps.

## Open items

- **The migration has never run against a real install.** Fixtures have 5 refs. A real install has 19. The guards were exercised, the scale was not.
- **`repack -ad` at 192 MB is untested in the migration.** It was around a second in a standalone probe.
- **A commit reachable only from the reflog would be lost.** No guard checks for that, because a commit reachable from nothing is indistinguishable from garbage.

## Context worth knowing

Omarchy, which this project borrows its migration system from, full-clones and carries about 98 MB, and none of its 315 migrations touches git objects. They faced the same problem and did not do this. The 165 MB is real, and so is the fact that this is the first irreversible migration here.