### PR TITLE
dunst drop-in split

### DIFF
--- a/.config/dunst/dunstrc
+++ b/.config/dunst/dunstrc
@@ -1,58 +1,12 @@
-[global]
-    follow = mouse
-    indicate_hidden = yes
-
-    offset = 10x10
-
-    notification_height = 0
-
-    separator_height = 2
-
-    padding = 8
-    horizontal_padding = 8
-    text_icon_padding = 0
-    frame_width = 2
-
-    frame_color = "#a6adc8"
-    separator_color = frame
-
-    sort = yes
-    idle_threshold = 120
-    font = monospace 10
-    line_height = 0
-    markup = full
-    alignment = left
-    vertical_alignment = center
-    show_age_threshold = 60
-    word_wrap = yes
-    stack_duplicates = true
-    hide_duplicate_count = false
-
-    show_indicators = yes
-
-    min_icon_size = 0
-    max_icon_size = 64
-
-    icon_path = /usr/share/icons/Papirus-Dark/16x16/status/:/usr/share/icons/Papirus-Dark/16x16/devices/:/usr/share/icons/Papirus-Dark/16x16/actions/:/usr/share/icons/Papirus-Dark/16x16/animations/:/usr/share/icons/Papirus-Dark/16x16/apps/:/usr/share/icons/Papirus-Dark/16x16/categories/:/usr/share/icons/Papirus-Dark/16x16/emblems/:/usr/share/icons/Papirus-Dark/16x16/emotes/:/usr/share/icons/Papirus-Dark/16x16/devices/mimetypes:/usr/share/icons/Papirus-Dark/16x16/panel/:/usr/share/icons/Papirus-Dark/16x16/places/
-
-    dmenu = /usr/bin/wofi -p dunst:
-    browser = /usr/bin/brave
-
-    title = Dunst
-    class = Dunst
-
-    corner_radius = 10
-    timeout = 5
-
-[urgency_low]
-    background = "#1e1e2e"
-    foreground = "#CDD6F4"
-
-[urgency_normal]
-    background = "#1e1e2e"
-    foreground = "#CDD6F4"
-
-[urgency_critical]
-    background = "#1e1e2e"
-    foreground = "#CDD6F4"
-    frame_color = "#FAB387"
+# hyprsimple's dunst defaults are not in this file.
+#
+# dunst reads drop-ins from dunstrc.d/ next to this file, and a drop-in always
+# outranks the base config. The last drop-in in lexical order wins, so:
+#
+#   dunstrc.d/10-hyprsimple.conf   hyprsimple's defaults, a symlink into
+#                                  ~/.local/share/hyprsimple, updated for you
+#   dunstrc.d/90-theme.conf        colours, rewritten on every theme switch
+#   dunstrc.d/99-user.conf         yours, and nothing here will ever touch it
+#
+# Put your own settings in 99-user.conf. Anything you add to this file is
+# overridden by all three of the above, which is almost never what you want.

--- a/.config/hypr/themes/templates/dunst-colors.tpl
+++ b/.config/hypr/themes/templates/dunst-colors.tpl
@@ -1,3 +1,6 @@
+[global]
+    frame_color = "{{ color7 }}"
+
 [urgency_low]
     background = "{{ background }}"
     foreground = "{{ foreground }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: theme-refresh-test
         run: bash test/theme-refresh-test.sh
+
+      - name: dunst-split-test
+        run: bash test/dunst-split-test.sh

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -78,23 +78,17 @@ if [[ -f "$GEN/hyprlock.conf" ]]; then
 fi
 
 # 7. Update Dunst colors
+# generated/dunst-colors is already valid dunst config, so it drops straight in
+# as an override. Drop-ins outrank the base dunstrc, and lexical order decides
+# between them, so 90-theme sits above hyprsimple's default and below the user's.
+DUNST_DROPIN="$HOME/.config/dunst/dunstrc.d/90-theme.conf"
+mkdir -p "$(dirname "$DUNST_DROPIN")"
 if [[ -f "$GEN/dunst-colors" ]]; then
-  DUNST_CONFIG="$HOME/.config/dunst/dunstrc"
-  if [[ -f "$DUNST_CONFIG" ]]; then
-    # Extract colors from generated file
-    LOW_BG=$(sed -n '/urgency_low/,/urgency_normal/{/background/s/.*"\(.*\)".*/\1/p}' "$GEN/dunst-colors")
-    LOW_FG=$(sed -n '/urgency_low/,/urgency_normal/{/foreground/s/.*"\(.*\)".*/\1/p}' "$GEN/dunst-colors")
-    LOW_FC=$(sed -n '/urgency_low/,/urgency_normal/{/frame_color/s/.*"\(.*\)".*/\1/p}' "$GEN/dunst-colors")
-    NORM_FC=$(sed -n '/urgency_normal/,/urgency_critical/{/frame_color/s/.*"\(.*\)".*/\1/p}' "$GEN/dunst-colors")
-    CRIT_FC=$(sed -n '/urgency_critical/,${/frame_color/s/.*"\(.*\)".*/\1/p}' "$GEN/dunst-colors")
-
-    # Replace in dunstrc (all urgency levels share bg/fg, differ by frame_color)
-    sed -i "s/frame_color = \"#[a-fA-F0-9]*\"/frame_color = \"$LOW_FC\"/1" "$DUNST_CONFIG"
-    sed -i "/\[urgency_normal\]/,/\[/{s/frame_color = \".*\"/frame_color = \"$NORM_FC\"/}" "$DUNST_CONFIG"
-    sed -i "/\[urgency_critical\]/,/\[/{s/frame_color = \".*\"/frame_color = \"$CRIT_FC\"/}" "$DUNST_CONFIG"
-    sed -i "s/background = \"#[a-fA-F0-9]*\"/background = \"$LOW_BG\"/g" "$DUNST_CONFIG"
-    sed -i "s/foreground = \"#[a-fA-F0-9]*\"/foreground = \"$LOW_FG\"/g" "$DUNST_CONFIG"
-  fi
+  cp "$GEN/dunst-colors" "$DUNST_DROPIN"
+else
+  # This theme has no colors.toml, so there are no colours to apply. Drop the
+  # previous theme's file rather than leaving its colours in force.
+  rm -f "$DUNST_DROPIN"
 fi
 
 # 8. Update btop theme

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Minimal Hyprland dotfiles for Arch Linux. Clean, functional, no bloat.
 
 ## Features
 
-- **17 themes** with one-key switching, all apps update at once (waybar, rofi, ghostty, hyprlock, dunst, btop)
+- **16 themes** with one-key switching, all apps update at once (waybar, rofi, ghostty, hyprlock, dunst, btop)
 - **Per-theme wallpapers** with picker and cycle support
 - **Per-theme backgrounds** for app launcher and power menu
 - **Hardware auto-detection** at install (NVIDIA, Vulkan, Intel iGPU, WiFi, battery)

--- a/default/dunst/10-hyprsimple.conf
+++ b/default/dunst/10-hyprsimple.conf
@@ -1,0 +1,58 @@
+[global]
+    follow = mouse
+    indicate_hidden = yes
+
+    offset = 10x10
+
+    notification_height = 0
+
+    separator_height = 2
+
+    padding = 8
+    horizontal_padding = 8
+    text_icon_padding = 0
+    frame_width = 2
+
+    frame_color = "#a6adc8"
+    separator_color = frame
+
+    sort = yes
+    idle_threshold = 120
+    font = monospace 10
+    line_height = 0
+    markup = full
+    alignment = left
+    vertical_alignment = center
+    show_age_threshold = 60
+    word_wrap = yes
+    stack_duplicates = true
+    hide_duplicate_count = false
+
+    show_indicators = yes
+
+    min_icon_size = 0
+    max_icon_size = 64
+
+    icon_path = /usr/share/icons/Papirus-Dark/16x16/status/:/usr/share/icons/Papirus-Dark/16x16/devices/:/usr/share/icons/Papirus-Dark/16x16/actions/:/usr/share/icons/Papirus-Dark/16x16/animations/:/usr/share/icons/Papirus-Dark/16x16/apps/:/usr/share/icons/Papirus-Dark/16x16/categories/:/usr/share/icons/Papirus-Dark/16x16/emblems/:/usr/share/icons/Papirus-Dark/16x16/emotes/:/usr/share/icons/Papirus-Dark/16x16/devices/mimetypes:/usr/share/icons/Papirus-Dark/16x16/panel/:/usr/share/icons/Papirus-Dark/16x16/places/
+
+    dmenu = /usr/bin/wofi -p dunst:
+    browser = /usr/bin/brave
+
+    title = Dunst
+    class = Dunst
+
+    corner_radius = 10
+    timeout = 5
+
+[urgency_low]
+    background = "#1e1e2e"
+    foreground = "#CDD6F4"
+
+[urgency_normal]
+    background = "#1e1e2e"
+    foreground = "#CDD6F4"
+
+[urgency_critical]
+    background = "#1e1e2e"
+    foreground = "#CDD6F4"
+    frame_color = "#FAB387"

--- a/install.sh
+++ b/install.sh
@@ -527,6 +527,12 @@ mkdir -p "$CACHE_DIR"
 mkdir -p "$HOME/.config/btop/themes"
 mkdir -p "$HOME/.config/rofi"
 
+# dunst reads drop-ins from dunstrc.d/ beside the base config. Symlinking the
+# default rather than copying it is what lets hyprsimple-update deliver changes
+# without a migration, the same guarantee package.path gives the lua config.
+mkdir -p "$HOME/.config/dunst/dunstrc.d"
+ln -sfn "$HYPRSIMPLE_PATH/default/dunst/10-hyprsimple.conf" "$HOME/.config/dunst/dunstrc.d/10-hyprsimple.conf"
+
 # One-time setup: symlink rofi launcher/powermenu dirs to the default theme
 ln -sfn "$THEME_DIR/rofi/launcher" "$HOME/.config/rofi/launcher"
 ln -sfn "$THEME_DIR/rofi/powermenu" "$HOME/.config/rofi/powermenu"

--- a/migrations/1788065734.sh
+++ b/migrations/1788065734.sh
@@ -1,0 +1,78 @@
+echo "Move dunst theme colours out of dunstrc and into a drop-in"
+
+# theme-switcher.sh used to patch background, foreground and frame_color
+# straight into ~/.config/dunst/dunstrc with sed. It now writes the theme's
+# colours to dunstrc.d/90-theme.conf instead, which dunst applies on top of the
+# base file. This migration writes that drop-in for the theme you are on, then
+# puts dunstrc's colours back to the values hyprsimple ships, so the file is
+# once again identical to the default for anyone who never edited it.
+#
+# It cannot tell a colour the old sed wrote from one you chose yourself, so it
+# backs the file up first and prints where it went.
+
+DUNST_DIR="$HOME/.config/dunst"
+DUNSTRC="$DUNST_DIR/dunstrc"
+SHIPPED="$HYPRSIMPLE_PATH/.config/dunst/dunstrc"
+
+[[ -f $DUNSTRC ]] || exit 0
+[[ -f $SHIPPED ]] || exit 0
+
+mkdir -p "$DUNST_DIR/dunstrc.d"
+
+# Carry the colours currently in force over to the drop-in. They are already in
+# dunstrc, put there by the old sed, so nothing else has to be consulted: there
+# is no persisted marker naming the theme you are on. Keep the section headers
+# and the three colour keys, drop everything else.
+#
+# Guarded on the file not existing. A second run would otherwise rebuild the
+# drop-in from a dunstrc this migration has already reset, replacing the theme
+# colours with hyprsimple's defaults.
+if [[ ! -e "$DUNST_DIR/dunstrc.d/90-theme.conf" ]]; then
+  awk '
+  /^[[:space:]]*\[/ { section = $0; printed = 0; next }
+  /^[[:space:]]*(background|foreground|frame_color)[[:space:]]*=/ {
+    if (!printed) { if (seen++) print ""; print section; printed = 1 }
+    print
+  }
+' "$DUNSTRC" >"$DUNST_DIR/dunstrc.d/90-theme.conf"
+  echo "Wrote $DUNST_DIR/dunstrc.d/90-theme.conf from the colours already in dunstrc"
+fi
+
+# Put the three colour keys back to what hyprsimple ships. Only these keys, and
+# only when the shipped file actually defines them at that line.
+restored=$(mktemp)
+awk '
+  NR == FNR { shipped[FNR] = $0; next }
+  {
+    line = $0
+    # Same line number and the same key name on both sides. Matching on the key
+    # rather than just "this is a colour line" means an added or removed line
+    # upstream can only skip a reset, never write a background over a foreground.
+    key = ""
+    if (match($0, /^[[:space:]]*(background|foreground|frame_color)[[:space:]]*=/))
+      key = $1
+    skey = ""
+    if (FNR in shipped && match(shipped[FNR], /^[[:space:]]*(background|foreground|frame_color)[[:space:]]*=/)) {
+      split(shipped[FNR], f, /[[:space:]]+/)
+      skey = (f[1] == "" ? f[2] : f[1])
+    }
+    if (key != "" && key == skey) line = shipped[FNR]
+    print line
+  }
+' "$SHIPPED" "$DUNSTRC" >"$restored"
+
+if cmp -s "$restored" "$DUNSTRC"; then
+  rm -f "$restored"
+else
+  backup="$DUNSTRC.bak.$(date +%s)"
+  cp "$DUNSTRC" "$backup"
+  cp "$restored" "$DUNSTRC"
+  rm -f "$restored"
+  echo "Reset the colours in $DUNSTRC to hyprsimple's defaults."
+  echo "Your previous version is at $backup"
+fi
+
+if pgrep -x dunst >/dev/null; then
+  pkill dunst
+  uwsm app -- dunst &
+fi

--- a/migrations/1788065734.sh
+++ b/migrations/1788065734.sh
@@ -12,10 +12,8 @@ echo "Move dunst theme colours out of dunstrc and into a drop-in"
 
 DUNST_DIR="$HOME/.config/dunst"
 DUNSTRC="$DUNST_DIR/dunstrc"
-SHIPPED="$HYPRSIMPLE_PATH/.config/dunst/dunstrc"
 
 [[ -f $DUNSTRC ]] || exit 0
-[[ -f $SHIPPED ]] || exit 0
 
 mkdir -p "$DUNST_DIR/dunstrc.d"
 
@@ -38,28 +36,44 @@ if [[ ! -e "$DUNST_DIR/dunstrc.d/90-theme.conf" ]]; then
   echo "Wrote $DUNST_DIR/dunstrc.d/90-theme.conf from the colours already in dunstrc"
 fi
 
-# Put the three colour keys back to what hyprsimple ships. Only these keys, and
-# only when the shipped file actually defines them at that line.
+# Put the colour keys back to what hyprsimple shipped, so a dunstrc nobody
+# edited is once again byte-identical to the default and the next migration can
+# recognise it.
 restored=$(mktemp)
 awk '
-  NR == FNR { shipped[FNR] = $0; next }
-  {
-    line = $0
-    # Same line number and the same key name on both sides. Matching on the key
-    # rather than just "this is a colour line" means an added or removed line
-    # upstream can only skip a reset, never write a background over a foreground.
-    key = ""
-    if (match($0, /^[[:space:]]*(background|foreground|frame_color)[[:space:]]*=/))
-      key = $1
-    skey = ""
-    if (FNR in shipped && match(shipped[FNR], /^[[:space:]]*(background|foreground|frame_color)[[:space:]]*=/)) {
-      split(shipped[FNR], f, /[[:space:]]+/)
-      skey = (f[1] == "" ? f[2] : f[1])
-    }
-    if (key != "" && key == skey) line = shipped[FNR]
-    print line
+  BEGIN {
+    # The colours hyprsimple shipped in dunstrc before the drop-in split, keyed
+    # by section and key. Literals, not a file read: a migration is a fixed
+    # point in history, so it must not depend on a path a later commit is free
+    # to repurpose, which is exactly what happened to .config/dunst/dunstrc.
+    d["global",          "frame_color"] = "#a6adc8"
+    d["urgency_low",     "background"]  = "#1e1e2e"
+    d["urgency_low",     "foreground"]  = "#CDD6F4"
+    d["urgency_normal",  "background"]  = "#1e1e2e"
+    d["urgency_normal",  "foreground"]  = "#CDD6F4"
+    d["urgency_critical","background"]  = "#1e1e2e"
+    d["urgency_critical","foreground"]  = "#CDD6F4"
+    d["urgency_critical","frame_color"] = "#FAB387"
   }
-' "$SHIPPED" "$DUNSTRC" >"$restored"
+  /^[[:space:]]*\[/ {
+    section = $0
+    gsub(/^[[:space:]]*\[|\][[:space:]]*$/, "", section)
+    print; next
+  }
+  {
+    # Only a key this table names is reset. A colour key the user added
+    # somewhere hyprsimple never shipped one is theirs, and is left alone.
+    if (match($0, /^([[:space:]]*)(background|foreground|frame_color)[[:space:]]*=/)) {
+      indent = $0; sub(/[^[:space:]].*$/, "", indent)
+      key = $1
+      if ((section SUBSEP key) in d) {
+        printf "%s%s = \"%s\"\n", indent, key, d[section, key]
+        next
+      }
+    }
+    print
+  }
+' "$DUNSTRC" >"$restored"
 
 if cmp -s "$restored" "$DUNSTRC"; then
   rm -f "$restored"

--- a/migrations/1788066582.sh
+++ b/migrations/1788066582.sh
@@ -1,0 +1,70 @@
+echo "Move hyprsimple's dunst default into the install"
+
+# hyprsimple's dunst settings now live in ~/.local/share/hyprsimple, symlinked
+# in as dunstrc.d/10-hyprsimple.conf, so future changes reach you through
+# hyprsimple-update with no migration. Your ~/.config/dunst/dunstrc becomes a
+# short pointer file, and dunstrc.d/99-user.conf is yours to edit.
+#
+# Your dunstrc is only replaced when it is byte-identical to something
+# hyprsimple shipped, which proves it was never edited. Anything else is kept
+# at dunstrc.pre-split.<timestamp>, and the lines that differed are copied into
+# 99-user.conf as comments so you can uncomment what you want back.
+
+DUNST_DIR="$HOME/.config/dunst"
+DUNSTRC="$DUNST_DIR/dunstrc"
+BASE="$HYPRSIMPLE_PATH/.config/dunst/dunstrc"
+DEFAULT="$HYPRSIMPLE_PATH/default/dunst/10-hyprsimple.conf"
+
+[[ -f $BASE && -f $DEFAULT ]] || exit 0
+
+mkdir -p "$DUNST_DIR/dunstrc.d"
+ln -sfn "$DEFAULT" "$DUNST_DIR/dunstrc.d/10-hyprsimple.conf"
+
+# md5 of every dunstrc hyprsimple has shipped
+SHIPPED=(
+  "9074d302ad96206fc1d3e32976b7b53f"
+)
+
+if [[ -f $DUNSTRC ]] && ! cmp -s "$DUNSTRC" "$BASE"; then
+  sum=$(md5sum "$DUNSTRC" | cut -d' ' -f1)
+  matched=""
+  for s in "${SHIPPED[@]}"; do
+    [[ $sum == "$s" ]] && matched=yes
+  done
+
+  if [[ -n $matched ]]; then
+    cp "$BASE" "$DUNSTRC"
+  else
+    kept="$DUNSTRC.pre-split.$(date +%s)"
+    mv "$DUNSTRC" "$kept"
+    cp "$BASE" "$DUNSTRC"
+
+    # The differing lines go in as comments. Inert text cannot land a setting in
+    # the wrong section, which parsing them into live config could.
+    user="$DUNST_DIR/dunstrc.d/99-user.conf"
+    {
+      echo "# hyprsimple moved its dunst defaults to dunstrc.d/10-hyprsimple.conf."
+      echo "# Your previous dunstrc is saved at $kept"
+      echo "#"
+      echo "# These lines differed from the default hyprsimple shipped."
+      echo "# Uncomment any you want to keep:"
+      echo "#"
+      diff "$DEFAULT" "$kept" | sed -n 's/^> /#     /p'
+    } >>"$user"
+
+    echo "Kept your dunstrc at $kept"
+    echo "Its differences are listed, commented out, in $user"
+  fi
+fi
+
+# Create the stub only when there is nothing there. Never overwrite it.
+[[ -e "$DUNST_DIR/dunstrc.d/99-user.conf" ]] || cat >"$DUNST_DIR/dunstrc.d/99-user.conf" <<'STUB'
+# Your dunst settings. This file is the last drop-in in lexical order, so
+# anything here overrides both hyprsimple's defaults and the theme colours.
+# hyprsimple never writes to this file.
+STUB
+
+if pgrep -x dunst >/dev/null; then
+  pkill dunst
+  uwsm app -- dunst &
+fi

--- a/migrations/1788066582.sh
+++ b/migrations/1788066582.sh
@@ -52,6 +52,12 @@ if [[ -f $DUNSTRC ]] && ! cmp -s "$DUNSTRC" "$BASE"; then
       diff "$DEFAULT" "$kept" | sed -n 's/^> /#     /p'
     } >>"$user"
 
+    # The earlier migration already saved this file as it was before anything
+    # touched it, which is a more complete record than the copy just made.
+    # Promote it into this name so the user is left with one file, not two.
+    bak=$(ls -1 "$DUNSTRC".bak.* 2>/dev/null | tail -1)
+    [[ -n $bak ]] && mv -f "$bak" "$kept"
+
     echo "Kept your dunstrc at $kept"
     echo "Its differences are listed, commented out, in $user"
   fi

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -348,6 +348,34 @@ else
   fail "99-user.conf written by an earlier run is not overwritten"
 fi
 
+# ---- migration 1 then migration 2 over an edited dunstrc: one saved copy -
+# A real user runs both migrations over the same home. Migration 1 leaves
+# dunstrc.bak.<timestamp>, the file exactly as the user had it. Migration 2
+# then leaves dunstrc.pre-split.<timestamp>, the same file but with migration
+# 1's colour reset already applied, so it is redundant, and the bak, being
+# the more complete record, should be promoted in its place.
+
+chain_home="$TMP/home-chain"
+must_be_fixture "$chain_home"
+mkdir -p "$chain_home/.config/dunst"
+cat "$PRESPLIT" \
+  | sed 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
+  >"$chain_home/.config/dunst/dunstrc"
+cp "$chain_home/.config/dunst/dunstrc" "$TMP/chain_original"
+
+HOME="$chain_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >/dev/null 2>&1
+HOME="$chain_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >/dev/null 2>&1
+
+check "running both migrations over an edited dunstrc leaves exactly one saved copy" \
+  "$(find "$chain_home/.config/dunst" -maxdepth 1 \( -name 'dunstrc.bak.*' -o -name 'dunstrc.pre-split.*' \) | wc -l)" "1"
+
+survivor="$(find "$chain_home/.config/dunst" -maxdepth 1 \( -name 'dunstrc.bak.*' -o -name 'dunstrc.pre-split.*' \))"
+if [[ -n $survivor ]] && cmp -s "$survivor" "$TMP/chain_original"; then
+  pass "the surviving copy is byte-identical to the original dunstrc"
+else
+  fail "the surviving copy is byte-identical to the original dunstrc"
+fi
+
 # ---- a missing dunstrc is a no-op ----------------------------------------
 
 HOME="$TMP/nothing" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -12,6 +12,18 @@ TEMPLATER="$REPO/.local/bin/theme-apply-templates.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# The migrations and theme-switcher.sh end by restarting dunst, and pgrep and
+# pkill do not consult HOME. Without these stubs the suite kills the real
+# notification daemon on any machine running one, once per migration invocation.
+# pgrep exits 1, so the restart block is skipped rather than half executed.
+STUB_BIN="$TMP/stub-bin"
+mkdir -p "$STUB_BIN"
+for stub in pgrep pkill uwsm; do
+  printf '#!/bin/sh\nexit 1\n' >"$STUB_BIN/$stub"
+  chmod +x "$STUB_BIN/$stub"
+done
+export PATH="$STUB_BIN:$PATH"
+
 failures=0
 pass() { printf 'ok - %s\n' "$1"; }
 fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -6,6 +6,7 @@ set -uo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MIGRATION="$REPO/migrations/1788065734.sh"
+MIGRATION2="$REPO/migrations/1788066582.sh"
 SWITCHER="$REPO/.local/bin/theme-switcher.sh"
 TEMPLATER="$REPO/.local/bin/theme-apply-templates.sh"
 TMP="$(mktemp -d)"
@@ -256,6 +257,82 @@ if grep -q 'frame_color = "#89b4fa"' "$extra_home/.config/dunst/dunstrc"; then
   pass "a colour key in a section hyprsimple shipped none for survives the migration"
 else
   fail "a colour key in a section hyprsimple shipped none for survives the migration"
+fi
+
+# ---- migration 2: an unedited dunstrc is replaced by the base -----------
+# HYPRSIMPLE_PATH points at the repo itself: the migration only reads from it,
+# and this is what proves the checks hold against what hyprsimple actually
+# ships, not a stand-in.
+
+unedited_home="$TMP/home-move-unedited"
+must_be_fixture "$unedited_home"
+mkdir -p "$unedited_home/.config/dunst"
+git -C "$REPO" show 12d5e47:.config/dunst/dunstrc >"$unedited_home/.config/dunst/dunstrc"
+
+HOME="$unedited_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >"$TMP/mig2_out" 2>&1
+check "migration 2 exits 0 for an unedited dunstrc" "$?" "0"
+
+if cmp -s "$unedited_home/.config/dunst/dunstrc" "$REPO/.config/dunst/dunstrc"; then
+  pass "an unedited dunstrc is replaced by the base"
+else
+  fail "an unedited dunstrc is replaced by the base"
+fi
+
+check "no .pre-split file exists for an unedited dunstrc" \
+  "$(find "$unedited_home/.config/dunst" -maxdepth 1 -name 'dunstrc.pre-split.*' | wc -l)" "0"
+
+hyprsimple_link="$unedited_home/.config/dunst/dunstrc.d/10-hyprsimple.conf"
+readlink -e "$hyprsimple_link" >"$TMP/link_target"
+check "readlink -e on dunstrc.d/10-hyprsimple.conf exits 0" "$?" "0"
+check "dunstrc.d/10-hyprsimple.conf names the file under the install fixture" \
+  "$(cat "$TMP/link_target")" "$REPO/default/dunst/10-hyprsimple.conf"
+
+check "99-user.conf exists after the run" \
+  "$([[ -f $unedited_home/.config/dunst/dunstrc.d/99-user.conf ]] && echo yes || echo no)" "yes"
+
+# ---- migration 2: an edited dunstrc is kept, its differences copied out --
+
+edited_home="$TMP/home-move-edited"
+must_be_fixture "$edited_home"
+mkdir -p "$edited_home/.config/dunst"
+git -C "$REPO" show 12d5e47:.config/dunst/dunstrc \
+  | sed 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
+  >"$edited_home/.config/dunst/dunstrc"
+cp "$edited_home/.config/dunst/dunstrc" "$TMP/edited_original"
+
+HOME="$edited_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >/dev/null 2>&1
+check "migration 2 exits 0 for an edited dunstrc" "$?" "0"
+
+kept="$(find "$edited_home/.config/dunst" -maxdepth 1 -name 'dunstrc.pre-split.*')"
+if [[ -n $kept ]] && cmp -s "$kept" "$TMP/edited_original"; then
+  pass "an edited dunstrc produces a .pre-split file byte-identical to the original"
+else
+  fail "an edited dunstrc produces a .pre-split file byte-identical to the original"
+fi
+
+if grep -q 'frame_color = "#ffcc00"' "$edited_home/.config/dunst/dunstrc.d/99-user.conf"; then
+  pass "99-user.conf contains the edited key"
+else
+  fail "99-user.conf contains the edited key"
+fi
+
+HOME="$edited_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >/dev/null 2>&1
+check "a second run creates no additional .pre-split file" \
+  "$(find "$edited_home/.config/dunst" -maxdepth 1 -name 'dunstrc.pre-split.*' | wc -l)" "1"
+
+# ---- migration 2: 99-user.conf written by an earlier run is untouched ---
+
+preserve_home="$TMP/home-move-preserve"
+must_be_fixture "$preserve_home"
+mkdir -p "$preserve_home/.config/dunst/dunstrc.d"
+git -C "$REPO" show 12d5e47:.config/dunst/dunstrc >"$preserve_home/.config/dunst/dunstrc"
+echo "# MARKER-DO-NOT-OVERWRITE" >"$preserve_home/.config/dunst/dunstrc.d/99-user.conf"
+
+HOME="$preserve_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >/dev/null 2>&1
+if grep -q 'MARKER-DO-NOT-OVERWRITE' "$preserve_home/.config/dunst/dunstrc.d/99-user.conf"; then
+  pass "99-user.conf written by an earlier run is not overwritten"
+else
+  fail "99-user.conf written by an earlier run is not overwritten"
 fi
 
 # ---- a missing dunstrc is a no-op ----------------------------------------

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Checks the dunst drop-in migration and theme-switcher.sh against fixtures.
+# Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$REPO/migrations/1788065734.sh"
+SWITCHER="$REPO/.local/bin/theme-switcher.sh"
+TEMPLATER="$REPO/.local/bin/theme-apply-templates.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# Every fixture home goes through this before a migration or theme-switcher
+# run touches it. An empty path would make later rm/cp calls operate against
+# the real $HOME, which is the environment this suite runs in.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'fixture: refusing to use path [%s], expected a path under %s\n' "${1:-}" "$TMP" >&2
+    exit 2
+  fi
+}
+
+# Builds a dunstrc with the given colour values in each section, plus one
+# fixed, non-colour line ("timeout = $5") so a caller can check that edit
+# survives the migration untouched.
+build_dunstrc() {
+  local path="$1"
+  local frame="$2"
+  local bg="$3"
+  local fg="$4"
+  local timeout="$5"
+  cat >"$path" <<EOF
+[global]
+    follow = mouse
+    frame_color = "$frame"
+    timeout = $timeout
+
+[urgency_low]
+    background = "$bg"
+    foreground = "$fg"
+
+[urgency_normal]
+    background = "$bg"
+    foreground = "$fg"
+
+[urgency_critical]
+    background = "$bg"
+    foreground = "$fg"
+    frame_color = "$frame"
+EOF
+}
+
+SHIPPED_FRAME='#a6adc8'
+SHIPPED_BG='#1e1e2e'
+SHIPPED_FG='#cdd6f4'
+SHIPPED_TIMEOUT=5
+
+# ---- theme-switcher.sh contains no sed against DUNST_CONFIG --------------
+
+if grep -q 'sed -i.*DUNST_CONFIG' "$SWITCHER"; then
+  fail "theme-switcher.sh no longer sed-patches DUNST_CONFIG"
+else
+  pass "theme-switcher.sh no longer sed-patches DUNST_CONFIG"
+fi
+
+# ---- theme-switcher.sh drops in a theme's generated/dunst-colors --------
+
+switch_home="$TMP/switch-home"
+must_be_fixture "$switch_home"
+mkdir -p "$switch_home/.local/bin" "$switch_home/.config/hypr"
+cp "$REPO/.local/bin/hypr-helpers.sh" "$switch_home/.local/bin/hypr-helpers.sh"
+
+withcolors="$switch_home/.config/hypr/themes/withcolors"
+mkdir -p "$withcolors/generated"
+cat >"$withcolors/generated/dunst-colors" <<'EOF'
+[global]
+    frame_color = "#bac2de"
+
+[urgency_low]
+    background = "#1e1e2e"
+    foreground = "#cdd6f4"
+    frame_color = "#bac2de"
+
+[urgency_normal]
+    background = "#1e1e2e"
+    foreground = "#cdd6f4"
+    frame_color = "#89b4fa"
+
+[urgency_critical]
+    background = "#1e1e2e"
+    foreground = "#cdd6f4"
+    frame_color = "#f38ba8"
+EOF
+
+THEME_SWITCHER_NO_RELOAD=1 HOME="$switch_home" bash "$SWITCHER" withcolors \
+  >"$TMP/switch_out" 2>&1
+check "theme-switcher exits 0 for a theme with generated/dunst-colors" "$?" "0"
+
+DROPIN="$switch_home/.config/dunst/dunstrc.d/90-theme.conf"
+if cmp -s "$DROPIN" "$withcolors/generated/dunst-colors"; then
+  pass "the drop-in is byte-identical to generated/dunst-colors"
+else
+  fail "the drop-in is byte-identical to generated/dunst-colors"
+fi
+
+# ---- switching to a theme with no colours removes the drop-in -----------
+
+nocolors="$switch_home/.config/hypr/themes/nocolors"
+mkdir -p "$nocolors"
+
+THEME_SWITCHER_NO_RELOAD=1 HOME="$switch_home" bash "$SWITCHER" nocolors \
+  >"$TMP/switch_out2" 2>&1
+check "theme-switcher exits 0 for a theme with no colours" "$?" "0"
+
+check "switching to a colourless theme removes the drop-in" \
+  "$([[ -e $DROPIN ]] && echo present || echo gone)" gone
+
+# ---- theme-apply-templates.sh renders a [global] frame_color ------------
+
+tpl_home="$TMP/template-home"
+must_be_fixture "$tpl_home"
+mkdir -p "$tpl_home/.config/hypr/themes/templates"
+cp "$REPO/.config/hypr/themes/templates/dunst-colors.tpl" \
+  "$tpl_home/.config/hypr/themes/templates/"
+
+tpl_theme="$TMP/template-theme"
+mkdir -p "$tpl_theme"
+cat >"$tpl_theme/colors.toml" <<'EOF'
+accent = "#89b4fa"
+background = "#1e1e2e"
+foreground = "#cdd6f4"
+color1 = "#f38ba8"
+color7 = "#bac2de"
+EOF
+
+HOME="$tpl_home" bash "$TEMPLATER" "$tpl_theme" >"$TMP/tpl_out" 2>&1
+check "theme-apply-templates.sh exits 0" "$?" "0"
+
+rendered="$tpl_theme/generated/dunst-colors"
+if grep -q '^\[global\]' "$rendered" && grep -A1 '^\[global\]' "$rendered" | grep -q 'frame_color'; then
+  pass "the rendered template has a [global] section with frame_color"
+else
+  fail "the rendered template has a [global] section with frame_color"
+fi
+
+# ---- migration: plain colour drift resets to the shipped default --------
+
+inst="$TMP/install-plain"
+mig_home="$TMP/home-plain"
+must_be_fixture "$mig_home"
+mkdir -p "$inst/.config/dunst" "$mig_home/.config/dunst"
+build_dunstrc "$inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT"
+build_dunstrc "$mig_home/.config/dunst/dunstrc" '#ffcc00' '#111111' '#eeeeee' "$SHIPPED_TIMEOUT"
+
+HOME="$mig_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >"$TMP/mig_out" 2>&1
+check "migration exits 0" "$?" "0"
+
+if cmp -s "$mig_home/.config/dunst/dunstrc" "$inst/.config/dunst/dunstrc"; then
+  pass "dunstrc is reset to the shipped default"
+else
+  fail "dunstrc is reset to the shipped default"
+fi
+
+check "the drop-in carries the pre-migration colours" \
+  "$(grep -c 'frame_color = "#ffcc00"' "$mig_home/.config/dunst/dunstrc.d/90-theme.conf" 2>/dev/null)" "2"
+
+# ---- a second run changes nothing, and writes no second backup ----------
+
+snap=$(find "$mig_home" -type f -exec md5sum {} + | sort)
+HOME="$mig_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "migration is idempotent" "$(find "$mig_home" -type f -exec md5sum {} + | sort)" "$snap"
+
+check "a second run writes no second backup" \
+  "$(find "$mig_home/.config/dunst" -maxdepth 1 -name 'dunstrc.bak.*' | wc -l)" "1"
+
+# ---- a non-colour edit survives the migration ----------------------------
+
+edit_inst="$TMP/install-edit"
+edit_home="$TMP/home-edit"
+must_be_fixture "$edit_home"
+mkdir -p "$edit_inst/.config/dunst" "$edit_home/.config/dunst"
+build_dunstrc "$edit_inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT"
+build_dunstrc "$edit_home/.config/dunst/dunstrc" '#ffcc00' '#111111' '#eeeeee' 45
+
+HOME="$edit_home" HYPRSIMPLE_PATH="$edit_inst" bash "$MIGRATION" >/dev/null 2>&1
+if grep -q 'timeout = 45' "$edit_home/.config/dunst/dunstrc"; then
+  pass "a non-colour edit survives the migration"
+else
+  fail "a non-colour edit survives the migration"
+fi
+
+# ---- a missing dunstrc is a no-op ----------------------------------------
+
+HOME="$TMP/nothing" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "a missing dunstrc exits 0" "$?" "0"
+
+if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
+printf '\nall checks passed\n'

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -7,6 +7,7 @@ set -uo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MIGRATION="$REPO/migrations/1788065734.sh"
 MIGRATION2="$REPO/migrations/1788066582.sh"
+PRESPLIT="$REPO/test/fixtures/dunst/dunstrc.presplit"
 SWITCHER="$REPO/.local/bin/theme-switcher.sh"
 TEMPLATER="$REPO/.local/bin/theme-apply-templates.sh"
 TMP="$(mktemp -d)"
@@ -279,7 +280,7 @@ fi
 unedited_home="$TMP/home-move-unedited"
 must_be_fixture "$unedited_home"
 mkdir -p "$unedited_home/.config/dunst"
-git -C "$REPO" show 12d5e47:.config/dunst/dunstrc >"$unedited_home/.config/dunst/dunstrc"
+cat "$PRESPLIT" >"$unedited_home/.config/dunst/dunstrc"
 
 HOME="$unedited_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >"$TMP/mig2_out" 2>&1
 check "migration 2 exits 0 for an unedited dunstrc" "$?" "0"
@@ -307,7 +308,7 @@ check "99-user.conf exists after the run" \
 edited_home="$TMP/home-move-edited"
 must_be_fixture "$edited_home"
 mkdir -p "$edited_home/.config/dunst"
-git -C "$REPO" show 12d5e47:.config/dunst/dunstrc \
+cat "$PRESPLIT" \
   | sed 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
   >"$edited_home/.config/dunst/dunstrc"
 cp "$edited_home/.config/dunst/dunstrc" "$TMP/edited_original"
@@ -337,7 +338,7 @@ check "a second run creates no additional .pre-split file" \
 preserve_home="$TMP/home-move-preserve"
 must_be_fixture "$preserve_home"
 mkdir -p "$preserve_home/.config/dunst/dunstrc.d"
-git -C "$REPO" show 12d5e47:.config/dunst/dunstrc >"$preserve_home/.config/dunst/dunstrc"
+cat "$PRESPLIT" >"$preserve_home/.config/dunst/dunstrc"
 echo "# MARKER-DO-NOT-OVERWRITE" >"$preserve_home/.config/dunst/dunstrc.d/99-user.conf"
 
 HOME="$preserve_home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION2" >/dev/null 2>&1
@@ -351,6 +352,15 @@ fi
 
 HOME="$TMP/nothing" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
 check "a missing dunstrc exits 0" "$?" "0"
+
+# ---- the vendored fixture matches the migration's checksum --------------
+
+fixture_sum=$(md5sum "$PRESPLIT" | cut -d' ' -f1)
+if grep -q "$fixture_sum" "$MIGRATION2"; then
+  pass "the vendored fixture matches a checksum the migration recognises"
+else
+  fail "the vendored fixture matches a checksum the migration recognises"
+fi
 
 if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
 printf '\nall checks passed\n'

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -31,13 +31,16 @@ must_be_fixture() {
 
 # Builds a dunstrc with the given colour values in each section, plus one
 # fixed, non-colour line ("timeout = $5") so a caller can check that edit
-# survives the migration untouched.
+# survives the migration untouched. $6 is the urgency_critical frame_color,
+# which hyprsimple ships distinct from the [global] one; it defaults to $2 so
+# fixtures that only care about drift can keep passing five args.
 build_dunstrc() {
   local path="$1"
   local frame="$2"
   local bg="$3"
   local fg="$4"
   local timeout="$5"
+  local critframe="${6:-$frame}"
   cat >"$path" <<EOF
 [global]
     follow = mouse
@@ -55,13 +58,14 @@ build_dunstrc() {
 [urgency_critical]
     background = "$bg"
     foreground = "$fg"
-    frame_color = "$frame"
+    frame_color = "$critframe"
 EOF
 }
 
 SHIPPED_FRAME='#a6adc8'
 SHIPPED_BG='#1e1e2e'
-SHIPPED_FG='#cdd6f4'
+SHIPPED_FG='#CDD6F4'
+SHIPPED_CRIT_FRAME='#FAB387'
 SHIPPED_TIMEOUT=5
 
 # ---- theme-switcher.sh contains no sed against DUNST_CONFIG --------------
@@ -158,7 +162,7 @@ inst="$TMP/install-plain"
 mig_home="$TMP/home-plain"
 must_be_fixture "$mig_home"
 mkdir -p "$inst/.config/dunst" "$mig_home/.config/dunst"
-build_dunstrc "$inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT"
+build_dunstrc "$inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT" "$SHIPPED_CRIT_FRAME"
 build_dunstrc "$mig_home/.config/dunst/dunstrc" '#ffcc00' '#111111' '#eeeeee' "$SHIPPED_TIMEOUT"
 
 HOME="$mig_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >"$TMP/mig_out" 2>&1
@@ -188,7 +192,7 @@ edit_inst="$TMP/install-edit"
 edit_home="$TMP/home-edit"
 must_be_fixture "$edit_home"
 mkdir -p "$edit_inst/.config/dunst" "$edit_home/.config/dunst"
-build_dunstrc "$edit_inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT"
+build_dunstrc "$edit_inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT" "$SHIPPED_CRIT_FRAME"
 build_dunstrc "$edit_home/.config/dunst/dunstrc" '#ffcc00' '#111111' '#eeeeee' 45
 
 HOME="$edit_home" HYPRSIMPLE_PATH="$edit_inst" bash "$MIGRATION" >/dev/null 2>&1
@@ -196,6 +200,62 @@ if grep -q 'timeout = 45' "$edit_home/.config/dunst/dunstrc"; then
   pass "a non-colour edit survives the migration"
 else
   fail "a non-colour edit survives the migration"
+fi
+
+# ---- colours reset even when the shipped install's dunstrc is comment-only,
+# the state Task 3 ships. A migration is a fixed point in history and must not
+# depend on a path a later commit is free to repurpose. --------------------
+
+comment_inst="$TMP/install-comment"
+comment_home="$TMP/home-comment"
+must_be_fixture "$comment_home"
+mkdir -p "$comment_inst/.config/dunst" "$comment_home/.config/dunst"
+cat >"$comment_inst/.config/dunst/dunstrc" <<'EOF'
+# See dunstrc.d/ for hyprsimple's dunst colours.
+EOF
+build_dunstrc "$comment_home/.config/dunst/dunstrc" '#ffcc00' '#111111' '#eeeeee' "$SHIPPED_TIMEOUT" '#ffcc00'
+
+HOME="$comment_home" HYPRSIMPLE_PATH="$comment_inst" bash "$MIGRATION" >/dev/null 2>&1
+if grep -q "frame_color = \"$SHIPPED_FRAME\"" "$comment_home/.config/dunst/dunstrc" \
+  && grep -q "foreground = \"$SHIPPED_FG\"" "$comment_home/.config/dunst/dunstrc"; then
+  pass "colours reset even when the shipped install's dunstrc is comment-only"
+else
+  fail "colours reset even when the shipped install's dunstrc is comment-only"
+fi
+
+# ---- a colour key in a section hyprsimple shipped none for is left alone --
+
+extra_inst="$TMP/install-extra"
+extra_home="$TMP/home-extra"
+must_be_fixture "$extra_home"
+mkdir -p "$extra_inst/.config/dunst" "$extra_home/.config/dunst"
+build_dunstrc "$extra_inst/.config/dunst/dunstrc" "$SHIPPED_FRAME" "$SHIPPED_BG" "$SHIPPED_FG" "$SHIPPED_TIMEOUT" "$SHIPPED_CRIT_FRAME"
+cat >"$extra_home/.config/dunst/dunstrc" <<EOF
+[global]
+    follow = mouse
+    frame_color = "#ffcc00"
+    timeout = $SHIPPED_TIMEOUT
+
+[urgency_low]
+    background = "#111111"
+    foreground = "#eeeeee"
+    frame_color = "#89b4fa"
+
+[urgency_normal]
+    background = "#111111"
+    foreground = "#eeeeee"
+
+[urgency_critical]
+    background = "#111111"
+    foreground = "#eeeeee"
+    frame_color = "#ffcc00"
+EOF
+
+HOME="$extra_home" HYPRSIMPLE_PATH="$extra_inst" bash "$MIGRATION" >/dev/null 2>&1
+if grep -q 'frame_color = "#89b4fa"' "$extra_home/.config/dunst/dunstrc"; then
+  pass "a colour key in a section hyprsimple shipped none for survives the migration"
+else
+  fail "a colour key in a section hyprsimple shipped none for survives the migration"
 fi
 
 # ---- a missing dunstrc is a no-op ----------------------------------------

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -359,7 +359,8 @@ chain_home="$TMP/home-chain"
 must_be_fixture "$chain_home"
 mkdir -p "$chain_home/.config/dunst"
 cat "$PRESPLIT" \
-  | sed 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
+  | sed -e 's|browser = /usr/bin/brave|browser = /usr/bin/firefox|' \
+        -e 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
   >"$chain_home/.config/dunst/dunstrc"
 cp "$chain_home/.config/dunst/dunstrc" "$TMP/chain_original"
 
@@ -374,6 +375,12 @@ if [[ -n $survivor ]] && cmp -s "$survivor" "$TMP/chain_original"; then
   pass "the surviving copy is byte-identical to the original dunstrc"
 else
   fail "the surviving copy is byte-identical to the original dunstrc"
+fi
+
+if [[ $survivor == *"/dunstrc.pre-split."* ]]; then
+  pass "the surviving copy is the promoted .pre-split, not the plain .bak"
+else
+  fail "the surviving copy is the promoted .pre-split, not the plain .bak"
 fi
 
 # ---- a missing dunstrc is a no-op ----------------------------------------

--- a/test/fixtures/dunst/dunstrc.presplit
+++ b/test/fixtures/dunst/dunstrc.presplit
@@ -1,0 +1,58 @@
+[global]
+    follow = mouse
+    indicate_hidden = yes
+
+    offset = 10x10
+
+    notification_height = 0
+
+    separator_height = 2
+
+    padding = 8
+    horizontal_padding = 8
+    text_icon_padding = 0
+    frame_width = 2
+
+    frame_color = "#a6adc8"
+    separator_color = frame
+
+    sort = yes
+    idle_threshold = 120
+    font = monospace 10
+    line_height = 0
+    markup = full
+    alignment = left
+    vertical_alignment = center
+    show_age_threshold = 60
+    word_wrap = yes
+    stack_duplicates = true
+    hide_duplicate_count = false
+
+    show_indicators = yes
+
+    min_icon_size = 0
+    max_icon_size = 64
+
+    icon_path = /usr/share/icons/Papirus-Dark/16x16/status/:/usr/share/icons/Papirus-Dark/16x16/devices/:/usr/share/icons/Papirus-Dark/16x16/actions/:/usr/share/icons/Papirus-Dark/16x16/animations/:/usr/share/icons/Papirus-Dark/16x16/apps/:/usr/share/icons/Papirus-Dark/16x16/categories/:/usr/share/icons/Papirus-Dark/16x16/emblems/:/usr/share/icons/Papirus-Dark/16x16/emotes/:/usr/share/icons/Papirus-Dark/16x16/devices/mimetypes:/usr/share/icons/Papirus-Dark/16x16/panel/:/usr/share/icons/Papirus-Dark/16x16/places/
+
+    dmenu = /usr/bin/wofi -p dunst:
+    browser = /usr/bin/brave
+
+    title = Dunst
+    class = Dunst
+
+    corner_radius = 10
+    timeout = 5
+
+[urgency_low]
+    background = "#1e1e2e"
+    foreground = "#CDD6F4"
+
+[urgency_normal]
+    background = "#1e1e2e"
+    foreground = "#CDD6F4"
+
+[urgency_critical]
+    background = "#1e1e2e"
+    foreground = "#CDD6F4"
+    frame_color = "#FAB387"


### PR DESCRIPTION
Retires the `sed` patching of `~/.config/dunst/dunstrc` and moves hyprsimple's dunst default into the install, so updates reach it without a migration each time.

## Why

Two defects shared one root cause: hyprsimple treated the user's `dunstrc` as a file it may rewrite in place.

`theme-switcher.sh` already rendered `themes/templates/dunst-colors.tpl` into `<theme>/generated/dunst-colors`, which is **already valid dunst config**. Nineteen lines then parsed the colours back out of it with five `sed -n` extractions and wrote them into the live `dunstrc` with five `sed -i` regexes, no backup and no guard. That is now one `cp` into a drop-in.

Separately, `dunstrc` was user space by location and project-owned by intent, with no mechanism carrying a repository change to an installed machine. This is what PR #22 closed for the Lua config.

## Layout

```
~/.config/dunst/
  dunstrc                       comment-only, exists so dunstrc.d/ is searched
  dunstrc.d/
    10-hyprsimple.conf          symlink into ~/.local/share/hyprsimple
    90-theme.conf               rewritten on every theme switch
    99-user.conf                yours, never overwritten
```

Precedence reads left to right in the filenames. Unlike hyprlang's `source`, drop-ins are genuine key-level override rather than accumulation, so the additive-duplication trap found in #22 cannot occur here.

The symlink is what delivers updates with no migration, the same guarantee `package.path` gives the Lua config. Precedent at `install.sh:531-532`, which already symlinks the rofi directories.

## Two behaviour fixes ride along

- **`[global] frame_color`.** The first `sed -i` used the `/1` flag, so it also rewrote line 16. The template gains a `[global]` section using `{{ color7 }}`, which is the value that `sed` was propagating, so the global frame colour is unchanged.
- **Stale colours.** A theme with no `colors.toml` used to leave the previous theme's colours patched in. The drop-in is removed instead, so it falls back to the shipped default rather than lying.

## Behaviour change worth knowing

`[urgency_normal]` now takes `{{ accent }}` where it previously inherited `{{ color7 }}` from the global block, because the template defines all three urgencies and the old `sed` only ever wrote two. Those differ in 15 of the 16 themes, so normal-priority notification frames change colour on most of them. This is the template's intent finally taking effect, not a regression.

## Migrations

`1788065734` writes the drop-in from the colours already in `dunstrc`, then resets those colours to the values hyprsimple shipped, carried as literals rather than read from a file. It cannot tell a colour the old `sed` wrote from one the user chose, so it takes a backup first.

`1788066582` replaces `dunstrc` with the pointer file when it matches a shipped checksum. Otherwise it keeps the original, promotes the first migration's backup into `dunstrc.pre-split.<timestamp>` so one copy remains rather than two, and lists the differing lines in `99-user.conf` **as comments**. Inert text cannot land a setting in a section dunst ignores, which parsing them into live config could.

## Testing

New `test/dunst-split-test.sh`, 31 checks, wired into CI beside the existing six suites. All seven suites and the image policy pass.

The fixture is vendored at `test/fixtures/dunst/dunstrc.presplit` rather than read from a commit, so it survives the squash merge, and one check ties its checksum to the one the migration lists. The suite stubs `pgrep`, `pkill` and `uwsm` on `PATH`: without that it killed the developer's real notification daemon nine times per run, invisibly, because CI has no dunst.

Verified beyond the suite: both migrations run in sequence against a real theme-mangled `dunstrc` leave one saved copy byte-identical to the original, and the suite passes from a tree with no `.git` at all.

## Not covered

- **dunst's own precedence resolution.** Documented in `man 1 dunst`, needs a running daemon and a display. Deliberately not asserted in CI.
- **`install.sh` end to end.** The added fragment parses, but no test runs a full install.
- If the install directory is moved later the symlink dangles, and dunst skips an unreadable drop-in silently.
