### PR TITLE
Deliver the dunst template fix to existing installs

### DIFF
--- a/migrations/1788069834.sh
+++ b/migrations/1788069834.sh
@@ -1,0 +1,39 @@
+echo "Refresh the dunst colour template so the global frame colour tracks the theme"
+
+# hyprsimple's dunst template gained a [global] section, but templates live in
+# ~/.config, which updates never overwrite. Without this the change reaches new
+# installs and nobody else.
+#
+# The rendered output under each theme's generated/ is build output, so it is
+# rebuilt rather than migrated. The drop-in for the theme you are on is
+# refreshed too, so the change is visible without switching themes first.
+
+TPL="$HOME/.config/hypr/themes/templates/dunst-colors.tpl"
+SHIPPED_TPL="$HYPRSIMPLE_PATH/.config/hypr/themes/templates/dunst-colors.tpl"
+
+[[ -f $SHIPPED_TPL ]] || exit 0
+
+if [[ ! -f $TPL ]] || ! cmp -s "$TPL" "$SHIPPED_TPL"; then
+  "$HOME/.local/bin/hyprsimple-refresh-config.sh" hypr/themes/templates/dunst-colors.tpl
+fi
+
+# Rebuild the rendered output for the theme currently applied, and refresh its
+# drop-in. current_wallpaper_path is the only record of which theme that is, so
+# this is skipped rather than guessed when it is absent.
+WP_PATH="$HOME/.cache/current_wallpaper_path"
+if [[ -f $WP_PATH ]]; then
+  theme_dir=$(dirname "$(dirname "$(cat "$WP_PATH")")")
+  if [[ -f "$theme_dir/colors.toml" ]]; then
+    "$HOME/.local/bin/theme-apply-templates.sh" "$theme_dir" >/dev/null
+    if [[ -f "$theme_dir/generated/dunst-colors" ]]; then
+      mkdir -p "$HOME/.config/dunst/dunstrc.d"
+      cp "$theme_dir/generated/dunst-colors" "$HOME/.config/dunst/dunstrc.d/90-theme.conf"
+      echo "Refreshed dunstrc.d/90-theme.conf from $(basename "$theme_dir")"
+    fi
+  fi
+fi
+
+if pgrep -x dunst >/dev/null; then
+  pkill dunst
+  uwsm app -- dunst >/dev/null 2>&1 &
+fi

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -397,5 +397,113 @@ else
   fail "the vendored fixture matches a checksum the migration recognises"
 fi
 
+# ---- migration 3: refreshes the dunst-colors.tpl [global] section --------
+
+MIGRATION3="$REPO/migrations/1788069834.sh"
+
+tplfix_inst="$TMP/install-tplfix"
+mkdir -p "$tplfix_inst/.config/hypr/themes/templates"
+cp "$REPO/.config/hypr/themes/templates/dunst-colors.tpl" \
+  "$tplfix_inst/.config/hypr/themes/templates/dunst-colors.tpl"
+
+tplfix_home="$TMP/home-tplfix"
+must_be_fixture "$tplfix_home"
+mkdir -p "$tplfix_home/.local/bin" "$tplfix_home/.config/hypr/themes/templates" "$tplfix_home/.cache"
+cp "$REPO/.local/bin/theme-apply-templates.sh" "$tplfix_home/.local/bin/theme-apply-templates.sh"
+cp "$REPO/.local/bin/hyprsimple-refresh-config.sh" "$tplfix_home/.local/bin/hyprsimple-refresh-config.sh"
+
+cat >"$tplfix_home/.config/hypr/themes/templates/dunst-colors.tpl" <<'EOF'
+[urgency_low]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+
+[urgency_normal]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ accent }}"
+
+[urgency_critical]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ color1 }}"
+EOF
+
+tplfix_theme="$tplfix_home/.config/hypr/themes/currenttheme"
+mkdir -p "$tplfix_theme/backgrounds"
+: >"$tplfix_theme/backgrounds/wall.jpg"
+cat >"$tplfix_theme/colors.toml" <<'EOF'
+accent = "#89b4fa"
+background = "#1e1e2e"
+foreground = "#cdd6f4"
+color1 = "#f38ba8"
+color7 = "#bac2de"
+EOF
+echo "$tplfix_theme/backgrounds/wall.jpg" >"$tplfix_home/.cache/current_wallpaper_path"
+
+HOME="$tplfix_home" HYPRSIMPLE_PATH="$tplfix_inst" bash "$MIGRATION3" >"$TMP/mig3_out" 2>&1
+check "migration 3 exits 0" "$?" "0"
+
+if grep -q '^\[global\]' "$tplfix_home/.config/hypr/themes/templates/dunst-colors.tpl" \
+  && cmp -s "$tplfix_home/.config/hypr/themes/templates/dunst-colors.tpl" \
+    "$tplfix_inst/.config/hypr/themes/templates/dunst-colors.tpl"; then
+  pass "a live template lacking [global] has it after the migration, byte-identical to the install's copy"
+else
+  fail "a live template lacking [global] has it after the migration, byte-identical to the install's copy"
+fi
+
+if grep -q '^\[global\]' "$tplfix_home/.config/dunst/dunstrc.d/90-theme.conf" 2>/dev/null; then
+  pass "dunstrc.d/90-theme.conf contains a [global] section after the migration"
+else
+  fail "dunstrc.d/90-theme.conf contains a [global] section after the migration"
+fi
+
+# ---- migration 3 is idempotent -------------------------------------------
+
+tplfix_snap=$(find "$tplfix_home" -type f -exec md5sum {} + | sort)
+HOME="$tplfix_home" HYPRSIMPLE_PATH="$tplfix_inst" bash "$MIGRATION3" >/dev/null 2>&1
+check "migration 3 is idempotent" "$(find "$tplfix_home" -type f -exec md5sum {} + | sort)" "$tplfix_snap"
+
+check "a second run of migration 3 writes no second backup" \
+  "$(find "$tplfix_home/.config/hypr/themes/templates" -maxdepth 1 -name 'dunst-colors.tpl.bak.*' | wc -l)" "1"
+
+# ---- migration 3 with no current_wallpaper_path still refreshes the template
+
+nowp_inst="$TMP/install-tplfix-nowp"
+mkdir -p "$nowp_inst/.config/hypr/themes/templates"
+cp "$REPO/.config/hypr/themes/templates/dunst-colors.tpl" \
+  "$nowp_inst/.config/hypr/themes/templates/dunst-colors.tpl"
+
+nowp_home="$TMP/home-tplfix-nowp"
+must_be_fixture "$nowp_home"
+mkdir -p "$nowp_home/.local/bin" "$nowp_home/.config/hypr/themes/templates"
+cp "$REPO/.local/bin/theme-apply-templates.sh" "$nowp_home/.local/bin/theme-apply-templates.sh"
+cp "$REPO/.local/bin/hyprsimple-refresh-config.sh" "$nowp_home/.local/bin/hyprsimple-refresh-config.sh"
+cat >"$nowp_home/.config/hypr/themes/templates/dunst-colors.tpl" <<'EOF'
+[urgency_low]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+
+[urgency_normal]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ accent }}"
+
+[urgency_critical]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ color1 }}"
+EOF
+
+HOME="$nowp_home" HYPRSIMPLE_PATH="$nowp_inst" bash "$MIGRATION3" >/dev/null 2>&1
+check "migration 3 exits 0 with no current_wallpaper_path" "$?" "0"
+
+if grep -q '^\[global\]' "$nowp_home/.config/hypr/themes/templates/dunst-colors.tpl" \
+  && cmp -s "$nowp_home/.config/hypr/themes/templates/dunst-colors.tpl" \
+    "$nowp_inst/.config/hypr/themes/templates/dunst-colors.tpl"; then
+  pass "the template is still refreshed with no current_wallpaper_path"
+else
+  fail "the template is still refreshed with no current_wallpaper_path"
+fi
+
 if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
 printf '\nall checks passed\n'


### PR DESCRIPTION
Follow-up to #26. One part of it never reached anyone who already had hyprsimple installed.

## The gap

#26 added a `[global]` section to `.config/hypr/themes/templates/dunst-colors.tpl` so the global frame colour tracks `{{ color7 }}` instead of staying at the shipped `#a6adc8`.

That directory lives in `~/.config`, which updates deliberately never overwrite. So the change reaches new installs through `install.sh`, and reaches nobody else. Confirmed on a real machine after updating to #26: the install's template had the section, the live one did not.

This is the same class of problem the split exists to close, a project-owned file sitting in user space with no delivery mechanism. It slipped through because every check in #26 measured the repository or a fixture built from it, never an installed machine's `~/.config/hypr/themes/templates/`.

## The migration

Refreshes the template through `hyprsimple-refresh-config.sh`, so the user gets a backup and a printed diff rather than a silent overwrite. Then re-renders the theme currently applied and refreshes `dunstrc.d/90-theme.conf`, so the change is visible without switching themes first. The rendered output under each theme's `generated/` is build output, so it is rebuilt rather than migrated.

The theme is derived from `~/.cache/current_wallpaper_path`, the only record of which theme is applied. When that file is absent the re-render is skipped rather than guessed, and the template is still refreshed.

## One thing fixed in passing

```bash
uwsm app -- dunst >/dev/null 2>&1 &
```

Every earlier migration and `theme-switcher.sh:185` omit the redirect. The backgrounded daemon inherits stdout, so `hyprsimple-update` never returns when its output is piped: the pipe stays open and the caller waits forever. Interactively it goes unnoticed. This migration does not inherit that. The existing sites are left alone, since editing shipped migrations is not something to do casually, and are recorded as their own item.

## Testing

`test/dunst-split-test.sh` goes from 31 checks to 38. The new ones cover a live template lacking `[global]` gaining it and matching the install byte for byte, the drop-in gaining `[global]`, a second run changing nothing and writing no second backup, and a fixture with no `current_wallpaper_path` still exiting 0 with the template refreshed.

Verified beyond the suite two ways. Deleting the refresh call turns four checks red, so they are not vacuous. And the migration was run against a replica of a real machine's `~/.config`, where it produced `[global] frame_color = "#d3c6aa"`, matching everforest's `color7`, and was idempotent on a second run.
