### PR TITLE
hypr conf split

### DIFF
--- a/.config/hypr/hypridle.conf
+++ b/.config/hypr/hypridle.conf
@@ -1,27 +1,13 @@
-general {
-    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
-    before_sleep_cmd = loginctl lock-session    # lock before suspend.
-    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
-}
+source = ~/.config/hypr/hyprsimple/hypridle/10-general.conf
+source = ~/.config/hypr/hyprsimple/hypridle/20-brightness.conf
+source = ~/.config/hypr/hyprsimple/hypridle/30-lock.conf
+source = ~/.config/hypr/hyprsimple/hypridle/40-dpms.conf
+source = ~/.config/hypr/hyprsimple/hypridle/50-suspend.conf
 
-listener {
-    timeout = 600                                # 10min.
-    on-timeout = brightnessctl -s set 5          # set monitor backlight to minimum, avoid 0 on OLED monitor.
-    on-resume = brightnessctl -r                 # monitor backlight restore.
-}
-
-listener {
-    timeout = 1200                                # 20min
-    on-timeout = loginctl lock-session            # lock screen when timeout has passed
-}
-
-listener {
-    timeout = 1800                                # 30min
-    on-timeout = hyprctl dispatch dpms off        # screen off when timeout has passed
-    on-resume = hyprctl dispatch dpms on          # screen on when activity is detected after timeout has fired.
-}
-
-listener {
-    timeout = 2000                                # 33min
-    on-timeout = systemctl suspend                # suspend pc
-}
+# Comment out any line above and write your own version below it.
+# A listener block here ADDS a listener. It cannot replace one.
+#
+#   20-brightness  dims the backlight
+#   30-lock        locks the session
+#   40-dpms        turns the display off
+#   50-suspend     suspends the machine

--- a/.config/hypr/hyprlock.conf
+++ b/.config/hypr/hyprlock.conf
@@ -1,73 +1,11 @@
 source = ~/.config/hypr/theme-hyprlock.conf
+source = ~/.config/hypr/hyprsimple/hyprlock.conf
 
-general {
-    ignore_empty_input = true
-}
-
-animations {
-    enabled = false
-}
-
-background {
-    monitor =
-    path = ~/.cache/current_lockscreen.png
-    blur_passes = 1
-}
-
-input-field {
-    monitor =
-    size = 400,75
-    outline_thickness = 3
-    dots_size = 0.33
-    dots_spacing = 0.15
-    dots_center = true
-    outer_color = $outer_color
-    inner_color = $inner_color
-    font_color = $font_color
-    fade_on_empty = true
-    fade_timeout = 1000
-    placeholder_text = Enter Password
-    hide_input = false
-    rounding = 8
-    check_color = $check_color
-    fail_color = rgb(204, 34, 34)
-    fail_text = $FAIL <b>($ATTEMPTS)</b>
-    capslock_color = rgb(233, 173, 12)
-    numlock_color = -1
-    bothlock_color = -1
-    invert_numlock = false
-    swap_font_color = false
-    position = 0, -20
-    halign = center
-    valign = center
-}
-
-label {
-    monitor =
-    text = cmd[update:1000] echo "$TIME"
-    color = $font_color
-    font_size = 55
-    font_family = Fira Semibold
-    position = -100, 40
-    halign = right
-    valign = bottom
-    shadow_passes = 5
-    shadow_size = 10
-}
-
-label {
-    monitor =
-    text = mening sare
-    color = $font_color
-    font_size = 20
-    position = -100, 160
-    halign = right
-    valign = bottom
-    shadow_passes = 5
-    shadow_size = 10
-}
-
-auth {
-    fingerprint:enabled = false
-}
-
+# Your overrides go below. The default is sourced first, so anything here wins
+# for general{}, animations{} and auth{}.
+#
+# background{}, input-field{} and label{} do not work that way. Declaring one
+# here ADDS another rather than replacing hyprsimple's. To restyle the lock
+# screen, delete the source line above and paste the default in its place:
+#
+#   ~/.config/hypr/hyprsimple/hyprlock.conf

--- a/.config/hypr/xdph.conf
+++ b/.config/hypr/xdph.conf
@@ -1,4 +1,4 @@
-# Screen sharing configuration
-screencopy {
-  allow_token_by_default = true
-}
+source = ~/.config/hypr/hyprsimple/xdph.conf
+
+# Your overrides go below. screencopy{} is a single category, so anything here
+# wins over the default above.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: dunst-split-test
         run: bash test/dunst-split-test.sh
+
+      - name: hypr-conf-split-test
+        run: bash test/hypr-conf-split-test.sh

--- a/default/hypr/hypridle/10-general.conf
+++ b/default/hypr/hypridle/10-general.conf
@@ -1,0 +1,6 @@
+general {
+    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
+    before_sleep_cmd = loginctl lock-session    # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+}
+

--- a/default/hypr/hypridle/20-brightness.conf
+++ b/default/hypr/hypridle/20-brightness.conf
@@ -1,0 +1,6 @@
+listener {
+    timeout = 600                                # 10min.
+    on-timeout = brightnessctl -s set 5          # set monitor backlight to minimum, avoid 0 on OLED monitor.
+    on-resume = brightnessctl -r                 # monitor backlight restore.
+}
+

--- a/default/hypr/hypridle/30-lock.conf
+++ b/default/hypr/hypridle/30-lock.conf
@@ -1,0 +1,5 @@
+listener {
+    timeout = 1200                                # 20min
+    on-timeout = loginctl lock-session            # lock screen when timeout has passed
+}
+

--- a/default/hypr/hypridle/40-dpms.conf
+++ b/default/hypr/hypridle/40-dpms.conf
@@ -1,0 +1,6 @@
+listener {
+    timeout = 1800                                # 30min
+    on-timeout = hyprctl dispatch dpms off        # screen off when timeout has passed
+    on-resume = hyprctl dispatch dpms on          # screen on when activity is detected after timeout has fired.
+}
+

--- a/default/hypr/hypridle/50-suspend.conf
+++ b/default/hypr/hypridle/50-suspend.conf
@@ -1,0 +1,4 @@
+listener {
+    timeout = 2000                                # 33min
+    on-timeout = systemctl suspend                # suspend pc
+}

--- a/default/hypr/hyprlock.conf
+++ b/default/hypr/hyprlock.conf
@@ -1,0 +1,73 @@
+source = ~/.config/hypr/theme-hyprlock.conf
+
+general {
+    ignore_empty_input = true
+}
+
+animations {
+    enabled = false
+}
+
+background {
+    monitor =
+    path = ~/.cache/current_lockscreen.png
+    blur_passes = 1
+}
+
+input-field {
+    monitor =
+    size = 400,75
+    outline_thickness = 3
+    dots_size = 0.33
+    dots_spacing = 0.15
+    dots_center = true
+    outer_color = $outer_color
+    inner_color = $inner_color
+    font_color = $font_color
+    fade_on_empty = true
+    fade_timeout = 1000
+    placeholder_text = Enter Password
+    hide_input = false
+    rounding = 8
+    check_color = $check_color
+    fail_color = rgb(204, 34, 34)
+    fail_text = $FAIL <b>($ATTEMPTS)</b>
+    capslock_color = rgb(233, 173, 12)
+    numlock_color = -1
+    bothlock_color = -1
+    invert_numlock = false
+    swap_font_color = false
+    position = 0, -20
+    halign = center
+    valign = center
+}
+
+label {
+    monitor =
+    text = cmd[update:1000] echo "$TIME"
+    color = $font_color
+    font_size = 55
+    font_family = Fira Semibold
+    position = -100, 40
+    halign = right
+    valign = bottom
+    shadow_passes = 5
+    shadow_size = 10
+}
+
+label {
+    monitor =
+    text = mening sare
+    color = $font_color
+    font_size = 20
+    position = -100, 160
+    halign = right
+    valign = bottom
+    shadow_passes = 5
+    shadow_size = 10
+}
+
+auth {
+    fingerprint:enabled = false
+}
+

--- a/default/hypr/xdph.conf
+++ b/default/hypr/xdph.conf
@@ -1,0 +1,4 @@
+# Screen sharing configuration
+screencopy {
+  allow_token_by_default = true
+}

--- a/install.sh
+++ b/install.sh
@@ -533,6 +533,10 @@ mkdir -p "$HOME/.config/rofi"
 mkdir -p "$HOME/.config/dunst/dunstrc.d"
 ln -sfn "$HYPRSIMPLE_PATH/default/dunst/10-hyprsimple.conf" "$HOME/.config/dunst/dunstrc.d/10-hyprsimple.conf"
 
+# hyprlock, hypridle and xdph source their defaults through this link, so no
+# config file has to hardcode an install path that HYPRSIMPLE_PATH can change.
+ln -sfn "$HYPRSIMPLE_PATH/default/hypr" "$HOME/.config/hypr/hyprsimple"
+
 # One-time setup: symlink rofi launcher/powermenu dirs to the default theme
 ln -sfn "$THEME_DIR/rofi/launcher" "$HOME/.config/rofi/launcher"
 ln -sfn "$THEME_DIR/rofi/powermenu" "$HOME/.config/rofi/powermenu"

--- a/migrations/1788076006.sh
+++ b/migrations/1788076006.sh
@@ -71,13 +71,16 @@ for name in hyprlock.conf hypridle.conf xdph.conf; do
 
     # Differences go in as comments. Inert text cannot land a setting in a
     # category that ignores it, which pasting them in as config could.
+    diffs=$(diff "$DEFAULTS/$name" "$kept" 2>/dev/null | sed -n 's/^> /#     /p')
     {
       echo ""
       echo "# Your previous $name is saved at $kept"
-      echo "# These lines differed from the default hyprsimple shipped."
-      echo "# Uncomment any you want to keep:"
-      echo "#"
-      diff "$DEFAULTS/$name" "$kept" 2>/dev/null | sed -n 's/^> /#     /p'
+      if [[ -n $diffs ]]; then
+        echo "# These lines differed from the default hyprsimple shipped."
+        echo "# Uncomment any you want to keep:"
+        echo "#"
+        printf '%s\n' "$diffs"
+      fi
     } >>"$user"
 
     echo "Kept your $name at $kept"

--- a/migrations/1788076006.sh
+++ b/migrations/1788076006.sh
@@ -1,0 +1,85 @@
+echo "Move hyprsimple's hyprlock, hypridle and xdph defaults into the install"
+
+# These three configs now live in ~/.local/share/hyprsimple and are reached
+# through ~/.config/hypr/hyprsimple, a symlink this migration creates. Your own
+# files become short lists of source lines with room for your overrides, so
+# future changes reach you through hyprsimple-update with no migration.
+#
+# A file is only replaced when it is byte-identical to something hyprsimple
+# shipped, which proves it was never edited. Anything else is kept at
+# <name>.pre-split.<timestamp> and its differences are listed, commented out,
+# in the file that replaces it.
+
+CONF="$HOME/.config/hypr"
+DEFAULTS="$HYPRSIMPLE_PATH/default/hypr"
+LINK="$CONF/hyprsimple"
+
+[[ -d $CONF && -d $DEFAULTS ]] || exit 0
+
+ln -sfn "$DEFAULTS" "$LINK"
+
+# A missing source is not fatal in hyprlang: hypridle would start with no rules
+# at all, so the machine would never lock, blank or suspend, and the only sign
+# would be a line in a log. Nothing below runs unless the link resolves.
+if [[ ! -e "$LINK/hypridle/10-general.conf" ]]; then
+  echo "$LINK does not resolve to the hyprsimple defaults. Nothing was changed." >&2
+  exit 1
+fi
+
+# name:md5 of every version hyprsimple has shipped for these files
+SHIPPED=(
+  "hypridle.conf:9baa82fba2dfa10704a985125ac9cbfe"
+  "xdph.conf:78b554b8f101109f7105cd4a40b02de2"
+  "hyprlock.conf:d924867c1f268c9520c2dca3b28fd639"
+)
+
+for name in hyprlock.conf hypridle.conf xdph.conf; do
+  user="$CONF/$name"
+  new="$HYPRSIMPLE_PATH/.config/hypr/$name"
+
+  [[ -f $new ]] || continue
+
+  # Already converted by an earlier run. Two shapes count as converted: the
+  # file is byte-identical to what ships, or it is that file plus the comment
+  # block the customized branch below appends. Testing only the first would
+  # make a second run take the customized branch again and write a second
+  # .pre-split.
+  if [[ -f $user ]]; then
+    if cmp -s "$user" "$new" || grep -q "^# Your previous $name is saved at " "$user"; then
+      continue
+    fi
+  fi
+
+  if [[ ! -f $user ]]; then
+    cp "$new" "$user"
+    continue
+  fi
+
+  sum=$(md5sum "$user" | cut -d' ' -f1)
+  matched=""
+  for entry in "${SHIPPED[@]}"; do
+    [[ ${entry%%:*} == "$name" && ${entry##*:} == "$sum" ]] && matched=yes
+  done
+
+  if [[ -n $matched ]]; then
+    cp "$new" "$user"
+    echo "Converted $user"
+  else
+    kept="$user.pre-split.$(date +%s)"
+    mv "$user" "$kept"
+    cp "$new" "$user"
+
+    # Differences go in as comments. Inert text cannot land a setting in a
+    # category that ignores it, which pasting them in as config could.
+    {
+      echo ""
+      echo "# Your previous $name is saved at $kept"
+      echo "# These lines differed from the default hyprsimple shipped."
+      echo "# Uncomment any you want to keep:"
+      echo "#"
+      diff "$DEFAULTS/$name" "$kept" 2>/dev/null | sed -n 's/^> /#     /p'
+    } >>"$user"
+
+    echo "Kept your $name at $kept"
+  fi
+done

--- a/test/fixtures/hypr/hypridle.presplit.conf
+++ b/test/fixtures/hypr/hypridle.presplit.conf
@@ -1,0 +1,27 @@
+general {
+    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
+    before_sleep_cmd = loginctl lock-session    # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+}
+
+listener {
+    timeout = 600                                # 10min.
+    on-timeout = brightnessctl -s set 5          # set monitor backlight to minimum, avoid 0 on OLED monitor.
+    on-resume = brightnessctl -r                 # monitor backlight restore.
+}
+
+listener {
+    timeout = 1200                                # 20min
+    on-timeout = loginctl lock-session            # lock screen when timeout has passed
+}
+
+listener {
+    timeout = 1800                                # 30min
+    on-timeout = hyprctl dispatch dpms off        # screen off when timeout has passed
+    on-resume = hyprctl dispatch dpms on          # screen on when activity is detected after timeout has fired.
+}
+
+listener {
+    timeout = 2000                                # 33min
+    on-timeout = systemctl suspend                # suspend pc
+}

--- a/test/fixtures/hypr/hyprlock.presplit.conf
+++ b/test/fixtures/hypr/hyprlock.presplit.conf
@@ -1,0 +1,73 @@
+source = ~/.config/hypr/theme-hyprlock.conf
+
+general {
+    ignore_empty_input = true
+}
+
+animations {
+    enabled = false
+}
+
+background {
+    monitor =
+    path = ~/.cache/current_lockscreen.png
+    blur_passes = 1
+}
+
+input-field {
+    monitor =
+    size = 400,75
+    outline_thickness = 3
+    dots_size = 0.33
+    dots_spacing = 0.15
+    dots_center = true
+    outer_color = $outer_color
+    inner_color = $inner_color
+    font_color = $font_color
+    fade_on_empty = true
+    fade_timeout = 1000
+    placeholder_text = Enter Password
+    hide_input = false
+    rounding = 8
+    check_color = $check_color
+    fail_color = rgb(204, 34, 34)
+    fail_text = $FAIL <b>($ATTEMPTS)</b>
+    capslock_color = rgb(233, 173, 12)
+    numlock_color = -1
+    bothlock_color = -1
+    invert_numlock = false
+    swap_font_color = false
+    position = 0, -20
+    halign = center
+    valign = center
+}
+
+label {
+    monitor =
+    text = cmd[update:1000] echo "$TIME"
+    color = $font_color
+    font_size = 55
+    font_family = Fira Semibold
+    position = -100, 40
+    halign = right
+    valign = bottom
+    shadow_passes = 5
+    shadow_size = 10
+}
+
+label {
+    monitor =
+    text = mening sare
+    color = $font_color
+    font_size = 20
+    position = -100, 160
+    halign = right
+    valign = bottom
+    shadow_passes = 5
+    shadow_size = 10
+}
+
+auth {
+    fingerprint:enabled = false
+}
+

--- a/test/fixtures/hypr/xdph.presplit.conf
+++ b/test/fixtures/hypr/xdph.presplit.conf
@@ -1,0 +1,4 @@
+# Screen sharing configuration
+screencopy {
+  allow_token_by_default = true
+}

--- a/test/hypr-conf-split-test.sh
+++ b/test/hypr-conf-split-test.sh
@@ -150,6 +150,44 @@ check "a second run is idempotent" "$(find "$edited_home" -type f -exec md5sum {
 check "a second run writes no second .pre-split for hyprlock.conf" \
   "$(find "$edited_home/.config/hypr" -maxdepth 1 -name 'hyprlock.conf.pre-split.*' | wc -l)" "1"
 
+# ---- migration: a strict-subset hyprlock.conf prints no empty header ----
+# This is the maintainer's real case: their hyprlock.conf is missing settings
+# the default carries, so diff produces no "> " lines and, unpatched, the
+# invitation to uncomment lines that are not there stands alone.
+
+subset_home="$TMP/home-subset"
+must_be_fixture "$subset_home"
+mkdir -p "$subset_home/.config/hypr"
+sed '4d' "$REPO/default/hypr/hyprlock.conf" >"$subset_home/.config/hypr/hyprlock.conf"
+
+HOME="$subset_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+subset_result="$subset_home/.config/hypr/hyprlock.conf"
+subset_has_saved=$(grep -q '^# Your previous hyprlock.conf is saved at ' "$subset_result" && echo yes || echo no)
+subset_has_header=$(grep -q 'Uncomment any you want to keep' "$subset_result" && echo yes || echo no)
+
+check "a strict-subset hyprlock.conf gets the saved-at line but no empty uncomment header" \
+  "$subset_has_saved:$subset_has_header" "yes:no"
+
+# ---- migration: a hyprlock.conf with an extra line gets the full header -
+# The counterpart to the subset check above: with an actual difference to
+# report, both lines must appear, and the extra line among the comments.
+
+extra_home="$TMP/home-extra"
+must_be_fixture "$extra_home"
+mkdir -p "$extra_home/.config/hypr"
+EXTRA_LINE="# a line the shipped default does not contain"
+cp "$REPO/default/hypr/hyprlock.conf" "$extra_home/.config/hypr/hyprlock.conf"
+echo "$EXTRA_LINE" >>"$extra_home/.config/hypr/hyprlock.conf"
+
+HOME="$extra_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+extra_result="$extra_home/.config/hypr/hyprlock.conf"
+extra_has_saved=$(grep -q '^# Your previous hyprlock.conf is saved at ' "$extra_result" && echo yes || echo no)
+extra_has_header=$(grep -q 'Uncomment any you want to keep' "$extra_result" && echo yes || echo no)
+extra_has_line=$(grep -qF "#     $EXTRA_LINE" "$extra_result" && echo yes || echo no)
+
+check "a hyprlock.conf with an extra line gets both header lines and the extra line as a comment" \
+  "$extra_has_saved:$extra_has_header:$extra_has_line" "yes:yes:yes"
+
 # ---- $DEFAULTS that does not resolve to real defaults: exits non-zero,
 # nothing changes. $DEFAULTS itself is present (an install always ships
 # default/hypr) but empty, the shape a broken or partial install takes; the

--- a/test/hypr-conf-split-test.sh
+++ b/test/hypr-conf-split-test.sh
@@ -38,14 +38,24 @@ must_be_fixture() {
   fi
 }
 
-# The three files as they stood at the commit before this branch. a48c596 is
-# on main and survives a squash merge; a branch commit would not.
-PRESPLIT_HYPRIDLE="$TMP/presplit-hypridle.conf"
-PRESPLIT_HYPRLOCK="$TMP/presplit-hyprlock.conf"
-PRESPLIT_XDPH="$TMP/presplit-xdph.conf"
-git -C "$REPO" show a48c596:.config/hypr/hypridle.conf >"$PRESPLIT_HYPRIDLE"
-git -C "$REPO" show a48c596:.config/hypr/hyprlock.conf >"$PRESPLIT_HYPRLOCK"
-git -C "$REPO" show a48c596:.config/hypr/xdph.conf >"$PRESPLIT_XDPH"
+# The three files as they stood at the commit before this branch, vendored
+# under test/fixtures/hypr so the suite never reads git history.
+PRESPLIT_HYPRIDLE="$REPO/test/fixtures/hypr/hypridle.presplit.conf"
+PRESPLIT_HYPRLOCK="$REPO/test/fixtures/hypr/hyprlock.presplit.conf"
+PRESPLIT_XDPH="$REPO/test/fixtures/hypr/xdph.presplit.conf"
+
+# ---- vendored fixtures match the checksums the migration recognises -----
+
+for pair in "hypridle.conf:hypridle" "xdph.conf:xdph" "hyprlock.conf:hyprlock"; do
+  name=${pair%%:*}
+  stem=${pair##*:}
+  sum=$(md5sum "$REPO/test/fixtures/hypr/$stem.presplit.conf" | cut -d' ' -f1)
+  if grep -q "$name:$sum" "$MIGRATION"; then
+    pass "the vendored $name fixture matches the checksum the migration recognises"
+  else
+    fail "the vendored $name fixture matches the checksum the migration recognises"
+  fi
+done
 
 # ---- the hypridle fragments concatenate back to the pre-split file ------
 

--- a/test/hypr-conf-split-test.sh
+++ b/test/hypr-conf-split-test.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Checks the hyprlock/hypridle/xdph split and its migration against fixtures.
+# Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$REPO/migrations/1788076006.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The migration ends by nothing that touches a daemon directly, but model the
+# stub block on dunst-split-test.sh anyway: pgrep, pkill and uwsm do not
+# consult HOME, and a future edit to this migration may grow a restart call.
+STUB_BIN="$TMP/stub-bin"
+mkdir -p "$STUB_BIN"
+for stub in pgrep pkill uwsm; do
+  printf '#!/bin/sh\nexit 1\n' >"$STUB_BIN/$stub"
+  chmod +x "$STUB_BIN/$stub"
+done
+export PATH="$STUB_BIN:$PATH"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# Every fixture home goes through this before a migration run touches it. An
+# empty path would make later rm/cp calls operate against the real $HOME,
+# which is the environment this suite runs in.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'fixture: refusing to use path [%s], expected a path under %s\n' "${1:-}" "$TMP" >&2
+    exit 2
+  fi
+}
+
+# The three files as they stood at the commit before this branch. a48c596 is
+# on main and survives a squash merge; a branch commit would not.
+PRESPLIT_HYPRIDLE="$TMP/presplit-hypridle.conf"
+PRESPLIT_HYPRLOCK="$TMP/presplit-hyprlock.conf"
+PRESPLIT_XDPH="$TMP/presplit-xdph.conf"
+git -C "$REPO" show a48c596:.config/hypr/hypridle.conf >"$PRESPLIT_HYPRIDLE"
+git -C "$REPO" show a48c596:.config/hypr/hyprlock.conf >"$PRESPLIT_HYPRLOCK"
+git -C "$REPO" show a48c596:.config/hypr/xdph.conf >"$PRESPLIT_XDPH"
+
+# ---- the hypridle fragments concatenate back to the pre-split file ------
+
+concat="$TMP/concat-hypridle.conf"
+cat "$REPO/default/hypr/hypridle/10-general.conf" \
+  "$REPO/default/hypr/hypridle/20-brightness.conf" \
+  "$REPO/default/hypr/hypridle/30-lock.conf" \
+  "$REPO/default/hypr/hypridle/40-dpms.conf" \
+  "$REPO/default/hypr/hypridle/50-suspend.conf" \
+  >"$concat"
+
+if cmp -s "$concat" "$PRESPLIT_HYPRIDLE"; then
+  pass "the hypridle fragments concatenate to the pre-split hypridle.conf"
+else
+  fail "the hypridle fragments concatenate to the pre-split hypridle.conf"
+fi
+
+# ---- hyprlock.conf and xdph.conf are unchanged by the split --------------
+
+if cmp -s "$REPO/default/hypr/hyprlock.conf" "$PRESPLIT_HYPRLOCK"; then
+  pass "default/hypr/hyprlock.conf is byte-identical to the pre-split version"
+else
+  fail "default/hypr/hyprlock.conf is byte-identical to the pre-split version"
+fi
+
+if cmp -s "$REPO/default/hypr/xdph.conf" "$PRESPLIT_XDPH"; then
+  pass "default/hypr/xdph.conf is byte-identical to the pre-split version"
+else
+  fail "default/hypr/xdph.conf is byte-identical to the pre-split version"
+fi
+
+# ---- declining 30-lock.conf removes exactly its own lock listener --------
+# general{}'s before_sleep_cmd also calls loginctl lock-session, so the count
+# after dropping 30-lock.conf should be 1, not 0.
+
+nolock="$TMP/concat-nolock.conf"
+cat "$REPO/default/hypr/hypridle/10-general.conf" \
+  "$REPO/default/hypr/hypridle/20-brightness.conf" \
+  "$REPO/default/hypr/hypridle/40-dpms.conf" \
+  "$REPO/default/hypr/hypridle/50-suspend.conf" \
+  >"$nolock"
+
+check "declining 30-lock.conf leaves exactly the general{} lock-session" \
+  "$(grep -c 'loginctl lock-session' "$nolock")" "1"
+
+# ---- migration: an unedited install is converted, symlink resolves ------
+
+inst="$REPO"
+unedited_home="$TMP/home-unedited"
+must_be_fixture "$unedited_home"
+mkdir -p "$unedited_home/.config/hypr"
+cp "$PRESPLIT_HYPRIDLE" "$unedited_home/.config/hypr/hypridle.conf"
+cp "$PRESPLIT_HYPRLOCK" "$unedited_home/.config/hypr/hyprlock.conf"
+cp "$PRESPLIT_XDPH" "$unedited_home/.config/hypr/xdph.conf"
+
+HOME="$unedited_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >"$TMP/mig_out" 2>&1
+check "migration exits 0 for an unedited install" "$?" "0"
+
+readlink -e "$unedited_home/.config/hypr/hyprsimple" >"$TMP/link_target"
+check "readlink -e on .config/hypr/hyprsimple exits 0" "$?" "0"
+check ".config/hypr/hyprsimple names the install fixture's default/hypr" \
+  "$(cat "$TMP/link_target")" "$inst/default/hypr"
+
+check "a hypridle.conf matching the shipped checksum is replaced" \
+  "$(cmp -s "$unedited_home/.config/hypr/hypridle.conf" "$inst/.config/hypr/hypridle.conf" && echo same || echo diff)" "same"
+
+check "no .pre-split file exists for the unedited hypridle.conf" \
+  "$(find "$unedited_home/.config/hypr" -maxdepth 1 -name 'hypridle.conf.pre-split.*' | wc -l)" "0"
+
+# ---- migration: an edited hyprlock.conf is preserved at .pre-split -------
+
+edited_home="$TMP/home-edited"
+must_be_fixture "$edited_home"
+mkdir -p "$edited_home/.config/hypr"
+cp "$PRESPLIT_HYPRIDLE" "$edited_home/.config/hypr/hypridle.conf"
+sed 's/general {/general { # customized/' "$PRESPLIT_HYPRLOCK" >"$edited_home/.config/hypr/hyprlock.conf"
+cp "$PRESPLIT_XDPH" "$edited_home/.config/hypr/xdph.conf"
+cp "$edited_home/.config/hypr/hyprlock.conf" "$TMP/edited_hyprlock_original"
+
+HOME="$edited_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "migration exits 0 for an edited hyprlock.conf" "$?" "0"
+
+kept="$(find "$edited_home/.config/hypr" -maxdepth 1 -name 'hyprlock.conf.pre-split.*')"
+if [[ -n $kept ]] && cmp -s "$kept" "$TMP/edited_hyprlock_original"; then
+  pass "the edited hyprlock.conf is preserved byte-identical at .pre-split"
+else
+  fail "the edited hyprlock.conf is preserved byte-identical at .pre-split"
+fi
+
+if grep -q "^# Your previous hyprlock.conf is saved at $kept\$" "$edited_home/.config/hypr/hyprlock.conf"; then
+  pass "the installed hyprlock.conf names its .pre-split path"
+else
+  fail "the installed hyprlock.conf names its .pre-split path"
+fi
+
+# ---- a second run changes nothing and writes no second .pre-split -------
+
+snap=$(find "$edited_home" -type f -exec md5sum {} + | sort)
+HOME="$edited_home" HYPRSIMPLE_PATH="$inst" bash "$MIGRATION" >/dev/null 2>&1
+check "a second run is idempotent" "$(find "$edited_home" -type f -exec md5sum {} + | sort)" "$snap"
+
+check "a second run writes no second .pre-split for hyprlock.conf" \
+  "$(find "$edited_home/.config/hypr" -maxdepth 1 -name 'hyprlock.conf.pre-split.*' | wc -l)" "1"
+
+# ---- $DEFAULTS that does not resolve to real defaults: exits non-zero,
+# nothing changes. $DEFAULTS itself is present (an install always ships
+# default/hypr) but empty, the shape a broken or partial install takes; the
+# guard that fires is the one after the symlink is created, not the leading
+# "nothing to do" early exit, which is itself a silent, deliberate exit 0 for
+# hosts with no hypr config at all and is not what this check is after.
+
+nodef_inst="$TMP/install-nodefaults"
+mkdir -p "$nodef_inst/default/hypr" "$nodef_inst/.config/hypr"
+cp "$REPO/.config/hypr/hypridle.conf" "$nodef_inst/.config/hypr/hypridle.conf"
+cp "$REPO/.config/hypr/hyprlock.conf" "$nodef_inst/.config/hypr/hyprlock.conf"
+cp "$REPO/.config/hypr/xdph.conf" "$nodef_inst/.config/hypr/xdph.conf"
+# $nodef_inst/default/hypr deliberately stays empty: no hypridle/10-general.conf.
+
+nodef_home="$TMP/home-nodefaults"
+must_be_fixture "$nodef_home"
+mkdir -p "$nodef_home/.config/hypr"
+cp "$PRESPLIT_HYPRIDLE" "$nodef_home/.config/hypr/hypridle.conf"
+cp "$PRESPLIT_HYPRLOCK" "$nodef_home/.config/hypr/hyprlock.conf"
+cp "$PRESPLIT_XDPH" "$nodef_home/.config/hypr/xdph.conf"
+nodef_snap=$(find "$nodef_home" -type f -exec md5sum {} + | sort)
+
+HOME="$nodef_home" HYPRSIMPLE_PATH="$nodef_inst" bash "$MIGRATION" >/dev/null 2>&1
+status=$?
+if ((status != 0)); then
+  pass "with \$DEFAULTS not resolving, the migration exits non-zero"
+else
+  fail "with \$DEFAULTS not resolving, the migration exits non-zero"
+fi
+
+check "with \$DEFAULTS not resolving, no user file differs from before the run" \
+  "$(find "$nodef_home" -type f -exec md5sum {} + | sort)" "$nodef_snap"
+
+if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Group A of the non-Lua config split. `hyprlock.conf`, `hypridle.conf` and `xdph.conf` move into the install so updates reach them, following #22 for lua and #26 for dunst.

## Why these three, and not five

The roadmap listed five files. Two do not belong:

- **`hyprsunset.conf` is TOML**, not hyprlang, on hyprsunset v0.4.0. It has `[[profile]]` tables and no include directive, so it moves to group F beside `starship.toml` and `yazi.toml`.
- `hyprpaper.conf` and `theme-hyprlock.conf` were already ruled out in #26 as machine-written state.

Group A is three files, 104 lines.

## The constraint that shapes the design

hyprlang has two kinds of category and the difference decides everything. **Singleton** categories (`general`, `animations`, `auth`, `screencopy`) are overridden by re-declaring them. **Repeating** categories (`background`, `input-field`, `label`, `listener`) instantiate once per declaration, so a second `listener` block adds a fifth listener rather than replacing the third.

`source` therefore cannot express an override for the parts of these files a user most plausibly wants to change. What cannot be overridden can still be **declined**, so granularity is the substitute, applied where a user makes a real choice:

- `hypridle.conf` becomes five source lines, one per listener, each independently commentable. Changing the idle timeout means commenting one line and writing your own, while still receiving updates to the other three.
- `hyprlock.conf` and `xdph.conf` get a single default each. Their repeating categories form one visual design rather than four independent decisions, so fragments would add files without adding a choice anyone makes.

## Layout

```
~/.config/hypr/hyprsimple  ->  $HYPRSIMPLE_PATH/default/hypr
```

Every `source` line is written relative to that link, so no config file hardcodes an install path that `HYPRSIMPLE_PATH` can change. Groups B, C and E can reuse it.

The installed `hypridle.conf` states the mechanism, because it is genuinely surprising:

```
# Comment out any line above and write your own version below it.
# A listener block here ADDS a listener. It cannot replace one.
```

## A missing source is not fatal, which is why the migration guards

Measured rather than assumed. hyprlang reports `source= globbing error: found no match`, prints `Proceeding ignoring faulty entries`, and the daemon exits 0. For `hypridle` that means starting with **no rules at all**: the machine would never lock, blank or suspend, with the only evidence in a log nobody reads.

So the migration creates the symlink, verifies it resolves to real defaults, and refuses to rewrite anything otherwise.

## Migration

Checksum-gated the way `1788066582` is. A file byte-identical to something hyprsimple shipped is converted. Anything else is kept at `<name>.pre-split.<timestamp>`, with its differing lines appended to the replacement as inert comments. Inert because a mis-read line can then only produce an odd comment, never a setting landing in a category that ignores it.

The invitation to uncomment is printed only when there are lines to uncomment. A file that is a strict subset of the default has nothing to offer back, and a lone header inviting you to uncomment nothing is worse than silence.

## Testing

New `test/hypr-conf-split-test.sh`, 18 checks, wired into CI. Eight suites now, 135 checks, all passing.

The load-bearing check is byte-level: the five `hypridle` fragments concatenated in filename order must equal what the repository shipped before the split. Line ranges alone would let a dropped blank separator through. Fragment declining is measured too: dropping `30-lock.conf` leaves exactly one `loginctl lock-session`, the one in `general{}`.

Fixtures read the pre-split files from `a48c596`, which is on `main` and survives a squash merge.

Verified beyond the suite. The migration was run against a replica of a real machine's `~/.config/hypr`, where `hypridle.conf` and `xdph.conf` matched shipped checksums and converted, and `hyprlock.conf` matched none of the ten ever shipped and was preserved byte-identical. Three separate mutations of the header logic, including reverting it to the original bug, each turn the suite red.

## Not covered

The daemons actually parsing the result needs a running compositor and, for hyprlock, a lock screen. Manual after merge: `hypridle` runs, the lock key still locks, and the lock screen still takes its colours from `theme-hyprlock.conf`.
