### PR TITLE
waybar screen recording indicator

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -7,7 +7,7 @@
     // Choose the order of the modules
     "modules-left": ["hyprland/workspaces", "custom/muslimtify"],
     "modules-center": ["hyprland/window"],
-    "modules-right": ["cpu", "memory", "network", "bluetooth", "pulseaudio","pulseaudio#microphone", "backlight", "battery", "clock", "tray", "custom/lock", "custom/power"],
+    "modules-right": ["cpu", "memory", "network", "bluetooth", "pulseaudio","pulseaudio#microphone", "backlight", "battery", "custom/screenrecording", "clock", "tray", "custom/lock", "custom/power"],
     "hyprland/workspaces": {
          "disable-scroll": true,
          "sort-by-name": true,
@@ -118,6 +118,12 @@
         "tooltip": false,
         "on-click": "hyprlock",
         "format": "",
+    },
+    "custom/screenrecording": {
+        "exec": "~/.local/bin/waybar-screenrecording.sh",
+        "return-type": "json",
+        "signal": 8,
+        "on-click": "~/.local/bin/screen-record.sh"
     },
     "custom/muslimtify": {
         "exec": "~/.local/bin/waybar-muslimtify.sh",

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -175,3 +175,14 @@ tooltip label {
     text-shadow: 0 0 10px alpha(@warning, 0.6);
     box-shadow: inset 0 1px 0 alpha(@warning, 0.15), 0 2px 8px alpha(@warning, 0.2);
 }
+
+#custom-screenrecording {
+    min-width: 12px;
+    margin: 0 7.5px;
+    padding: 0;
+}
+
+#custom-screenrecording.active {
+    color: @danger;
+    text-shadow: 0 0 8px alpha(@danger, 0.5);
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: hypr-conf-split-test
         run: bash test/hypr-conf-split-test.sh
+
+      - name: waybar-refresh-test
+        run: bash test/waybar-refresh-test.sh

--- a/.local/bin/hyprsimple-muslimtify.sh
+++ b/.local/bin/hyprsimple-muslimtify.sh
@@ -36,12 +36,8 @@ pick_aur_helper() {
 }
 
 reload_waybar() {
-  if pgrep -x waybar >/dev/null; then
-    pkill waybar
-    sleep 0.2
-    uwsm app -- waybar >/dev/null 2>&1 &
-    ok "waybar reloaded"
-  fi
+  "$HOME/.local/bin/hyprsimple-restart-waybar.sh"
+  ok "waybar reloaded"
 }
 
 backup() {

--- a/.local/bin/hyprsimple-muslimtify.sh
+++ b/.local/bin/hyprsimple-muslimtify.sh
@@ -36,7 +36,7 @@ pick_aur_helper() {
 }
 
 reload_waybar() {
-  "$HOME/.local/bin/hyprsimple-restart-waybar.sh"
+  "$HOME/.local/bin/hyprsimple-restart-waybar.sh" --if-running
   ok "waybar reloaded"
 }
 

--- a/.local/bin/hyprsimple-refresh-waybar.sh
+++ b/.local/bin/hyprsimple-refresh-waybar.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Reset waybar's config to hyprsimple's defaults, keeping the one setting people
+# actually change. hyprsimple-refresh-config.sh keeps a backup and prints a diff,
+# so everything else replaced here is recoverable.
+
+WAYBAR_CONFIG="$HOME/.config/waybar/config.jsonc"
+
+position=$(sed -nE 's/.*"position"[[:space:]]*:[[:space:]]*"(top|bottom|left|right)".*/\1/p' "$WAYBAR_CONFIG" 2>/dev/null | head -n 1)
+
+"$HOME/.local/bin/hyprsimple-refresh-config.sh" waybar/config.jsonc
+"$HOME/.local/bin/hyprsimple-refresh-config.sh" waybar/style.css
+
+[[ -n $position ]] && sed -i -E "s/(\"position\"[[:space:]]*:[[:space:]]*\")[a-z]+(\")/\1${position}\2/" "$WAYBAR_CONFIG"
+
+"$HOME/.local/bin/hyprsimple-restart-waybar.sh"

--- a/.local/bin/hyprsimple-restart-waybar.sh
+++ b/.local/bin/hyprsimple-restart-waybar.sh
@@ -3,6 +3,14 @@
 # Restart waybar. setsid plus the redirect detach it from the caller, so a
 # piped or non-interactive caller returns instead of waiting on the daemon's
 # inherited stdout.
+#
+# --if-running reloads a bar that is already up and does nothing otherwise.
+# Without it, waybar is started whether or not one was running, which is what
+# install.sh needs.
+
+if [[ $1 == --if-running ]] && ! pgrep -x waybar >/dev/null; then
+  exit 0
+fi
 
 pkill -x waybar
 setsid uwsm app -- waybar >/dev/null 2>&1 &

--- a/.local/bin/hyprsimple-restart-waybar.sh
+++ b/.local/bin/hyprsimple-restart-waybar.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Restart waybar. setsid plus the redirect detach it from the caller, so a
+# piped or non-interactive caller returns instead of waiting on the daemon's
+# inherited stdout.
+
+pkill -x waybar
+setsid uwsm app -- waybar >/dev/null 2>&1 &

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -177,9 +177,7 @@ if [[ -z "$THEME_SWITCHER_NO_RELOAD" ]]; then
 
   systemctl --user restart hyprpaper.service
 
-  if pgrep -x waybar > /dev/null; then
-    pkill waybar; sleep 0.1; uwsm app -- waybar &
-  fi
+  "$HOME/.local/bin/hyprsimple-restart-waybar.sh"
 
   if pgrep -x dunst > /dev/null; then
     pkill dunst; uwsm app -- dunst &

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -177,7 +177,7 @@ if [[ -z "$THEME_SWITCHER_NO_RELOAD" ]]; then
 
   systemctl --user restart hyprpaper.service
 
-  "$HOME/.local/bin/hyprsimple-restart-waybar.sh"
+  "$HOME/.local/bin/hyprsimple-restart-waybar.sh" --if-running
 
   if pgrep -x dunst > /dev/null; then
     pkill dunst; uwsm app -- dunst &

--- a/.local/bin/waybar-screenrecording.sh
+++ b/.local/bin/waybar-screenrecording.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Mirrors screenrecording_active() in screen-record.sh. waybar re-runs this on
+# RTMIN+8, which screen-record.sh already sends on both start and stop.
+
+if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
+  echo '{"text": "󰻂", "tooltip": "Recording. Click to stop", "class": "active"}'
+else
+  echo '{"text": ""}'
+fi

--- a/install.sh
+++ b/install.sh
@@ -562,12 +562,7 @@ echo -e "${YELLOW}Configuring shell integration...${NC}"
 bash "$HOME/.local/bin/terminal.sh" || true
 
 hyprctl reload || true
-if pgrep -x waybar > /dev/null; then
-  pkill waybar
-  sleep 1
-fi
-nohup waybar > /dev/null 2>&1 &
-disown
+bash "$HOME/.local/bin/hyprsimple-restart-waybar.sh"
 echo -e "${YELLOW}Starting waybar...${NC}"
 sleep 3
 

--- a/migrations/1788087069.sh
+++ b/migrations/1788087069.sh
@@ -1,0 +1,81 @@
+echo "Add the screen recording indicator to waybar"
+
+# waybar's config is not split: its module lists are arrays, so an include
+# cannot add one module without restating the whole list. Updates arrive by
+# explicit reset instead, through hyprsimple-refresh-waybar.
+#
+# A file is refreshed here only when it is byte-identical to something
+# hyprsimple shipped, which proves it was never edited. Anything else is left
+# exactly as it is, and the command to refresh it is printed instead.
+
+WAYBAR="$HOME/.config/waybar"
+[[ -d $WAYBAR ]] || exit 0
+
+CONFIG_SUMS=(
+  07ee330f737f1655ba9fe62632e4f6a8
+  09d5a55da106542ebb2621515c76b291
+  1dcda3be15ccee1c88d4feb3be6bda5d
+  2a2740850b891235ff76d95ba25df500
+  2d03648c3972814b9657ccab576f26ea
+  4e06ee464f5350f635c07a6e9d485d04
+  50e9f99b6a1cc5a65f49615b0a3b7151
+  55a3c955b0498cee29032ffb2354b10c
+  7095e813fbc4e43ba663d0af51fcb9f4
+  71cacc1842185b972e60fe9e21fd9a6f
+  8291a8c1038b7875b22ce17ccaa7545b
+  84d2e2105e25b6aeddf75dc999721050
+  9bac31018660d404a4a51d3529616dbc
+  a54ec3dd7c9efd3cc3756b1c90d3c803
+  adb781665e3c36084bf365009ff757df
+  c751c395316fc0750c2f2b09770a2e91
+  f53cdf586c0b2bee96cbccbd74f20b06
+)
+STYLE_SUMS=(
+  0041768b8c6626ebfb25b5799e453cf9
+  4058a2d6734eadb406fb498fc58b5efc
+  4da8f6885f7708545081bbcbe66807d0
+  696b0ea77ae5d87a4bd948fa419abc6e
+  70f6efb9868fedc57291fc5da85ec7b5
+  8382bad43079231d00dbe54c0d78ac37
+  839b61b5921029dac5dbe4097123d7e7
+  dcce85712d7d9590191c1c2987c31df0
+  ddacad72b961e74605d874589c30c12f
+  e1df5208a1b35c6a3d0cd69cc2abc24a
+  e2198939a76eb765ce6d7bf12725b732
+)
+
+refresh_if_pristine() {
+  local name="$1"
+  shift
+  local user="$WAYBAR/$name"
+  local shipped="$HYPRSIMPLE_PATH/.config/waybar/$name"
+
+  [[ -f $user && -f $shipped ]] || return 0
+  cmp -s "$user" "$shipped" && return 0
+
+  local sum
+  sum=$(md5sum "$user" | cut -d' ' -f1)
+  local s
+  for s in "$@"; do
+    if [[ $sum == "$s" ]]; then
+      cp "$shipped" "$user"
+      echo "Updated $user"
+      return 0
+    fi
+  done
+
+  echo ""
+  echo "$user has your own edits, so it was left alone."
+  echo "It does not yet have the screen recording indicator. To take hyprsimple's"
+  echo "current version, keeping your bar position and a backup of your file:"
+  echo ""
+  echo "    hyprsimple-refresh-waybar.sh"
+  echo ""
+  echo "What that would change:"
+  diff "$user" "$shipped" || true
+}
+
+refresh_if_pristine config.jsonc "${CONFIG_SUMS[@]}"
+refresh_if_pristine style.css "${STYLE_SUMS[@]}"
+
+"$HOME/.local/bin/hyprsimple-restart-waybar.sh"

--- a/test/fixtures/waybar/config.jsonc.shipped
+++ b/test/fixtures/waybar/config.jsonc.shipped
@@ -1,0 +1,139 @@
+{
+    "layer": "top", // Waybar at top layer
+    "position": "top", // Waybar position (top|bottom|left|right)
+    // clock module (incl. themed calendar colors) is generated per-theme; see theme-clock.jsonc
+    "include": ["~/.config/waybar/theme-clock.jsonc"],
+    // "width": 1280, // Waybar width
+    // Choose the order of the modules
+    "modules-left": ["hyprland/workspaces", "custom/muslimtify"],
+    "modules-center": ["hyprland/window"],
+    "modules-right": ["cpu", "memory", "network", "bluetooth", "pulseaudio","pulseaudio#microphone", "backlight", "battery", "custom/screenrecording", "clock", "tray", "custom/lock", "custom/power"],
+    "hyprland/workspaces": {
+         "disable-scroll": true,
+         "sort-by-name": true,
+         "format": " {icon} ",
+         "format-icons": {
+              "default": "",
+              "1": "1",
+              "2": "2",
+              "3": "3",
+              "4": "4",
+              "5": "5",
+              "6": "6",
+              "7": "7",
+              "8": "8",
+              "9": "9",
+              "10": "0",
+              "active": ""
+         },
+     },
+    "hyprland/window": {
+        "format": "󰣇 {}",
+    },
+    "tray": {
+        "icon-size": 21,
+        "spacing": 10
+    },
+    "cpu": {
+        "interval": 10,
+        "format": "󰍛 {usage}%",
+        "format-alt": "{icon0}{icon1}{icon2}{icon3}",
+        "format-icons": ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
+    },
+    "memory": {
+        "states": {
+            "c": 90, // critical
+            "h": 60, // high
+            "m": 30 // medium
+        },
+        "interval": 10,
+        "format": "󰾆 {used}GB",
+        "format-m": "󰾅 {used}GB",
+        "format-h": "󰓅 {used}GB",
+        "format-c": " {used}GB",
+        "format-alt": "󰾆 {percentage}%",
+        "max-length": 10,
+        "tooltip": true,
+        "tooltip-format": "󰾆 {percentage}%\n {used:0.1f}GB/{total:0.1f}GB"
+    },
+    "backlight": {
+        "device": "intel_backlight",
+        "format": "{icon}",
+        "format-icons": ["", "", "", "", "", "", "", "", ""]
+    },
+    "battery": {
+        "states": {
+            "good": 95,
+            "warning": 30,
+            "critical": 20
+        },
+        "format": "{icon} {capacity}%",
+        "format-charging": " {capacity}%",
+        "format-plugged": " {capacity}%",
+        "format-alt": "{time} {icon}",
+        "format-icons": ["󰂃", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+    },
+    "bluetooth": {
+        "format": " on",
+        "format-off": "󰂲 off",
+        "format-disabled": "󰂲 off",
+        "format-connected": "󰂱 connected",
+        "format-no-controller": "",
+        "tooltip-format": "Devices connected: {num_connections}",
+        "on-click": "~/.local/bin/bluetooth-toggle.sh toggle"
+    },
+    "network": {
+        "tooltip": true,
+        "format-wifi": "  {essid}",
+        "format-ethernet": "󰈀 eth",
+        "tooltip-format": "Network: <big><b>{essid}</b></big>\nSignal strength: <b>{signaldBm}dBm ({signalStrength}%)</b>\nFrequency: <b>{frequency}MHz</b>\nInterface: <b>{ifname}</b>\nIP: <b>{ipaddr}/{cidr}</b>\nGateway: <b>{gwaddr}</b>\nNetmask: <b>{netmask}</b>",
+        "format-linked": "󰈀 {ifname} (No IP)",
+        "format-disconnected": "󰖪 no connection",
+        "tooltip-format-disconnected": "Disconnected",
+        "format-alt": "<span foreground='#99ffdd'> {bandwidthDownBytes}</span> <span foreground='#ffcc66'> {bandwidthUpBytes}</span>",
+        "interval": 2
+    },
+    "pulseaudio": {
+        // "scroll-step": 1, // %, can be a float
+        "format": "{icon} {volume}%",
+        "format-muted": "",
+        "on-click": "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle",
+        "on-scroll-up": "wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 5%+",
+        "on-scroll-down": "wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 5%-",
+        "scroll-step": 5,
+        "format-icons": {
+            "default": ["", "", " "]
+        }
+    },
+    "pulseaudio#microphone": {
+        "format": "{format_source}",
+        "format-source": " {volume}%",
+        "format-source-muted": "  Muted",
+        "on-click": "wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle",
+        "on-scroll-up": "wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SOURCE@ 5%+",
+        "on-scroll-down": "wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SOURCE@ 5%-",
+        "scroll-step": 5
+    },
+    "custom/lock": {
+        "tooltip": false,
+        "on-click": "hyprlock",
+        "format": "",
+    },
+    "custom/screenrecording": {
+        "exec": "~/.local/bin/waybar-screenrecording.sh",
+        "return-type": "json",
+        "signal": 8,
+        "on-click": "~/.local/bin/screen-record.sh"
+    },
+    "custom/muslimtify": {
+        "exec": "~/.local/bin/waybar-muslimtify.sh",
+        "return-type": "json",
+        "interval": 30,
+        "tooltip": true
+    },
+    "custom/power": {
+        "tooltip": false,
+        "on-click": "~/.config/rofi/powermenu/powermenu.sh",
+        "format": "⏻"
+    }
+}

--- a/test/fixtures/waybar/style.css.shipped
+++ b/test/fixtures/waybar/style.css.shipped
@@ -1,0 +1,188 @@
+@import "theme-active.css";
+
+* {
+  font-family: JetbrainsMono Nerd Font;
+  font-size: 12px;
+  min-height: 0;
+}
+
+#waybar {
+  background: transparent;
+  color: @fg;
+}
+
+#workspaces {
+  border-radius: 1rem;
+  background-color: @bg-widget;
+  margin: 5px 0 0 1rem;
+}
+
+#workspaces button {
+  color: @secondary;
+  border-radius: 1rem;
+}
+
+#workspaces button.active {
+  color: @accent-bright;
+  border-radius: 1rem;
+}
+
+#workspaces button:hover {
+  color: @accent-dim;
+  border-radius: 1rem;
+}
+
+tooltip {
+    background-color: @bg-deep;
+    border: 1.5px solid alpha(@warning, 0.4);
+    border-radius: 0.8rem;
+    padding: 0.6rem;
+    color: @fg;
+}
+
+tooltip label {
+    color: @fg;
+    font-size: 13px;
+}
+
+#network,
+#bluetooth {
+    background-color: @bg-widget;
+    padding: 0.5rem 0.5rem;
+    margin: 5px 0 0 0;
+}
+
+
+#cpu,
+#memory {
+    background-color: @bg-widget;
+    padding: 0.5rem 0.5rem;
+    margin: 5px 0 0 0;
+}
+
+#tray,
+#backlight,
+#clock,
+#battery,
+#pulseaudio.microphone,
+#pulseaudio,
+#custom-lock,
+#custom-power {
+  background-color: @bg-widget;
+  padding: 0.5rem 0.5rem;
+  margin: 5px 0 0 0;
+}
+
+#clock {
+  color: @accent;
+  border-radius: 0px 1rem 1rem 0px;
+  margin-right: 1rem;
+  padding-right: 1rem;
+}
+
+#bluetooth {
+  color: @accent;
+  border-radius: 0px 1rem 1rem 0px;
+  padding-right: 1rem;
+}
+
+#network {
+  color: @success;
+  border-radius: 1rem 0px 0px 1rem;
+  padding-left: 1rem;
+
+}
+
+#battery {
+  color: @success;
+}
+
+#cpu {
+  color: @secondary;
+  border-radius: 1rem 0px 0px 1rem;
+  padding-left: 1rem;
+  margin-left: 1rem;
+}
+
+#memory {
+  color: @info;
+  border-radius: 0px 1rem 1rem 0px;
+  padding-right: 1rem;
+  margin-right: 1rem;
+}
+
+#battery.charging {
+  color: @success;
+}
+
+#battery.warning:not(.charging) {
+  color: @danger;
+}
+
+#backlight {
+  color: @warning;
+}
+
+#pulseaudio.microphone {
+  color: @muted;
+}
+
+#backlight, #battery, #pulseaudio.microphone {
+    border-radius: 0;
+}
+
+#pulseaudio {
+  color: @muted;
+  border-radius: 1rem 0px 0px 1rem;
+  margin-left: 1rem;
+  padding-left: 1rem;
+}
+
+#custom-lock {
+    border-radius: 1rem 0px 0px 1rem;
+    color: @secondary;
+    padding-left: 1rem;
+}
+
+#custom-power {
+    margin-right: 1rem;
+    padding-right: 1rem;
+    border-radius: 0px 1rem 1rem 0px;
+    color: @danger;
+}
+
+#tray {
+  margin-right: 1rem;
+  border-radius: 1rem;
+}
+
+
+#custom-muslimtify {
+    background-color: @bg-widget;
+    color: @warning;
+    border: 1.5px solid alpha(@warning, 0.35);
+    border-radius: 1.5rem 1.5rem 0.3rem 0.3rem;
+    padding: 0.4rem 1.2rem;
+    margin: 5px 0 0 1rem;
+    text-shadow: 0 0 4px alpha(@warning, 0.25);
+    box-shadow: inset 0 1px 0 alpha(@warning, 0.08), 0 1px 3px alpha(@bg-deep, 0.6);
+    transition: all 300ms ease;
+}
+
+#custom-muslimtify:hover {
+    background-color: alpha(@warning, 0.15);
+    border-color: @warning;
+    text-shadow: 0 0 10px alpha(@warning, 0.6);
+    box-shadow: inset 0 1px 0 alpha(@warning, 0.15), 0 2px 8px alpha(@warning, 0.2);
+}
+
+#custom-screenrecording {
+    min-width: 12px;
+    margin: 0 7.5px;
+    padding: 0;
+}
+
+#custom-screenrecording.active {
+    color: @danger;
+    text-shadow: 0 0 8px alpha(@danger, 0.5);
+}

--- a/test/waybar-refresh-test.sh
+++ b/test/waybar-refresh-test.sh
@@ -11,6 +11,8 @@ REFRESH_CONFIG="$REPO/.local/bin/hyprsimple-refresh-config.sh"
 RESTART="$REPO/.local/bin/hyprsimple-restart-waybar.sh"
 SCREEN_RECORD="$REPO/.local/bin/screen-record.sh"
 SHIPPED_CONFIG="$REPO/test/fixtures/waybar/config.jsonc.shipped"
+SHIPPED_STYLE="$REPO/test/fixtures/waybar/style.css.shipped"
+MIGRATION="$REPO/migrations/1788087069.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -163,6 +165,111 @@ check "the refresh command exits 0" "$refresh_status" "0"
 check "the non-default position survives the refresh" \
   "$(grep -oE '"position": "[a-z]+"' "$fixture_home/.config/waybar/config.jsonc")" \
   '"position": "bottom"'
+
+# ---- the migration: pristine, edited and idempotent installs -------------
+
+migrate_install_root="$TMP/install-migrate"
+must_be_fixture "$migrate_install_root"
+mkdir -p "$migrate_install_root/.config/waybar"
+cp "$SHIPPED_CONFIG" "$migrate_install_root/.config/waybar/config.jsonc"
+cp "$SHIPPED_STYLE" "$migrate_install_root/.config/waybar/style.css"
+
+# an old-but-pristine install: config.jsonc predates the indicator (derived
+# here from the shipped fixture, not from git history) but was never hand
+# edited, so its checksum is one of CONFIG_SUMS's entries and the migration's
+# match-and-copy branch is the one that must bring it up to date.
+old_pristine_home="$TMP/home-migrate-old-pristine"
+must_be_fixture "$old_pristine_home"
+mkdir -p "$old_pristine_home/.local/bin" "$old_pristine_home/.config/waybar"
+cp "$RESTART" "$old_pristine_home/.local/bin/hyprsimple-restart-waybar.sh"
+chmod +x "$old_pristine_home/.local/bin/"*.sh
+sed -e 's/"battery", "custom\/screenrecording", "clock"/"battery", "clock"/' \
+    -e '/^    "custom\/screenrecording": {$/,/^    },$/d' \
+    "$SHIPPED_CONFIG" >"$old_pristine_home/.config/waybar/config.jsonc"
+cp "$SHIPPED_STYLE" "$old_pristine_home/.config/waybar/style.css"
+
+old_sum=$(md5sum "$old_pristine_home/.config/waybar/config.jsonc" | cut -d' ' -f1)
+config_sums_block_check=$(sed -n '/^CONFIG_SUMS=(/,/^)/p' "$MIGRATION")
+check "the reconstructed old config.jsonc's checksum is one CONFIG_SUMS lists" \
+  "$(grep -c "$old_sum" <<<"$config_sums_block_check")" "1"
+
+HOME="$old_pristine_home" HYPRSIMPLE_PATH="$migrate_install_root" bash "$MIGRATION" \
+  >"$TMP/migrate_old_pristine_out" 2>&1
+
+check "an old pristine config.jsonc is replaced by the install's version after the migration" \
+  "$(cmp -s "$old_pristine_home/.config/waybar/config.jsonc" "$migrate_install_root/.config/waybar/config.jsonc" && echo same || echo different)" \
+  "same"
+
+# a pristine install: the user's files already match what ships
+pristine_home="$TMP/home-migrate-pristine"
+must_be_fixture "$pristine_home"
+mkdir -p "$pristine_home/.local/bin" "$pristine_home/.config/waybar"
+cp "$RESTART" "$pristine_home/.local/bin/hyprsimple-restart-waybar.sh"
+chmod +x "$pristine_home/.local/bin/"*.sh
+cp "$SHIPPED_CONFIG" "$pristine_home/.config/waybar/config.jsonc"
+cp "$SHIPPED_STYLE" "$pristine_home/.config/waybar/style.css"
+
+HOME="$pristine_home" HYPRSIMPLE_PATH="$migrate_install_root" bash "$MIGRATION" \
+  >"$TMP/migrate_pristine_out" 2>&1
+
+check "a config.jsonc identical to the shipped fixture matches the install's version after the migration" \
+  "$(cmp -s "$pristine_home/.config/waybar/config.jsonc" "$migrate_install_root/.config/waybar/config.jsonc" && echo same || echo different)" \
+  "same"
+
+# an edited install: config.jsonc carries a line hyprsimple never shipped
+edited_home="$TMP/home-migrate-edited"
+must_be_fixture "$edited_home"
+mkdir -p "$edited_home/.local/bin" "$edited_home/.config/waybar"
+cp "$RESTART" "$edited_home/.local/bin/hyprsimple-restart-waybar.sh"
+chmod +x "$edited_home/.local/bin/"*.sh
+{ cat "$SHIPPED_CONFIG"; echo "// a user's own comment"; } >"$edited_home/.config/waybar/config.jsonc"
+cp "$SHIPPED_STYLE" "$edited_home/.config/waybar/style.css"
+
+edited_before=$(md5sum "$edited_home/.config/waybar/config.jsonc" | cut -d' ' -f1)
+HOME="$edited_home" HYPRSIMPLE_PATH="$migrate_install_root" bash "$MIGRATION" \
+  >"$TMP/migrate_edited_out" 2>&1
+edited_after=$(md5sum "$edited_home/.config/waybar/config.jsonc" | cut -d' ' -f1)
+
+check "a config.jsonc with an added line is byte-unchanged by the migration" "$edited_after" "$edited_before"
+
+check "the migration points an edited install at hyprsimple-refresh-waybar.sh" \
+  "$(grep -c 'hyprsimple-refresh-waybar\.sh' "$TMP/migrate_edited_out")" "1"
+
+# the migration must end by restarting waybar so config changes take effect
+restart_home="$TMP/home-migrate-restart-check"
+must_be_fixture "$restart_home"
+mkdir -p "$restart_home/.local/bin" "$restart_home/.config/waybar"
+restart_marker="$TMP/restart-called"
+rm -f "$restart_marker"
+printf '#!/bin/sh\ntouch "%s"\n' "$restart_marker" >"$restart_home/.local/bin/hyprsimple-restart-waybar.sh"
+chmod +x "$restart_home/.local/bin/hyprsimple-restart-waybar.sh"
+cp "$SHIPPED_CONFIG" "$restart_home/.config/waybar/config.jsonc"
+cp "$SHIPPED_STYLE" "$restart_home/.config/waybar/style.css"
+
+HOME="$restart_home" HYPRSIMPLE_PATH="$migrate_install_root" bash "$MIGRATION" >/dev/null 2>&1
+
+check "the migration restarts waybar so config changes take effect" \
+  "$([[ -f $restart_marker ]] && echo called || echo not-called)" "called"
+
+# a second run of the migration against an already-migrated home changes nothing
+idem_before=$(find "$pristine_home" -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+HOME="$pristine_home" HYPRSIMPLE_PATH="$migrate_install_root" bash "$MIGRATION" >/dev/null 2>&1
+idem_after=$(find "$pristine_home" -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
+
+check "a second migration run changes no file in the fixture home" "$idem_after" "$idem_before"
+
+# each vendored fixture's checksum must be listed in the migration's matching
+# array, so a fixture that drifts out of step with the migration reports itself
+config_shipped_sum=$(md5sum "$SHIPPED_CONFIG" | cut -d' ' -f1)
+style_shipped_sum=$(md5sum "$SHIPPED_STYLE" | cut -d' ' -f1)
+config_sums_block=$(sed -n '/^CONFIG_SUMS=(/,/^)/p' "$MIGRATION")
+style_sums_block=$(sed -n '/^STYLE_SUMS=(/,/^)/p' "$MIGRATION")
+
+check "the shipped config.jsonc fixture's checksum is listed in the migration's CONFIG_SUMS" \
+  "$(grep -c "$config_shipped_sum" <<<"$config_sums_block")" "1"
+
+check "the shipped style.css fixture's checksum is listed in the migration's STYLE_SUMS" \
+  "$(grep -c "$style_shipped_sum" <<<"$style_sums_block")" "1"
 
 if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
 printf '\nall checks passed\n'

--- a/test/waybar-refresh-test.sh
+++ b/test/waybar-refresh-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Checks the screen recording indicator and the waybar refresh command against
+# fixtures. Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INDICATOR="$REPO/.local/bin/waybar-screenrecording.sh"
+REFRESH="$REPO/.local/bin/hyprsimple-refresh-waybar.sh"
+REFRESH_CONFIG="$REPO/.local/bin/hyprsimple-refresh-config.sh"
+RESTART="$REPO/.local/bin/hyprsimple-restart-waybar.sh"
+SCREEN_RECORD="$REPO/.local/bin/screen-record.sh"
+SHIPPED_CONFIG="$REPO/test/fixtures/waybar/config.jsonc.shipped"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# Every fixture home goes through this before a run touches it. An empty path
+# would make later rm/cp calls operate against the real $HOME, which is the
+# environment this suite runs in.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'fixture: refusing to use path [%s], expected a path under %s\n' "${1:-}" "$TMP" >&2
+    exit 2
+  fi
+}
+
+# Strip JSONC's // comments and trailing commas for parsing only. Never write
+# the stripped form back anywhere.
+strip_jsonc() {
+  sed -E 's#//.*##' "$1" | perl -0pe 's/,(\s*[}\]])/$1/g'
+}
+
+# ---- the indicator, with a real wl-screenrec sentinel on PATH ------------
+# This block needs a REAL pgrep so the indicator can find the sentinel. The
+# stub PATH installed further down neutralises pgrep for every check after
+# this one, so the indicator checks run first, against a PATH of their own.
+
+REAL_PGREP="$(command -v pgrep)"
+SENTINEL_BIN="$TMP/sentinel-bin"
+mkdir -p "$SENTINEL_BIN"
+# A copied binary named wl-screenrec, not a renamed argument or a shell
+# function: pgrep -x matches on the process's comm name, which for a shell
+# function or a relaunch under a different argv0 would not be "wl-screenrec".
+cp "$(command -v sleep)" "$SENTINEL_BIN/wl-screenrec"
+chmod +x "$SENTINEL_BIN/wl-screenrec"
+
+"$SENTINEL_BIN/wl-screenrec" 300 &
+sentinel_pid=$!
+# Give the process a moment to be visible to pgrep before we query for it.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  "$REAL_PGREP" -x wl-screenrec >/dev/null && break
+  sleep 0.1
+done
+
+indicator_running="$("$INDICATOR")"
+kill "$sentinel_pid" 2>/dev/null
+wait "$sentinel_pid" 2>/dev/null
+
+running_text=$(printf '%s' "$indicator_running" | grep -o '"text": "[^"]*"' | cut -d'"' -f4)
+running_class=$(printf '%s' "$indicator_running" | grep -o '"class": "[^"]*"' | cut -d'"' -f4)
+
+check "the indicator's text is non-empty while wl-screenrec runs" \
+  "$([[ -n $running_text ]] && echo nonempty || echo empty)" "nonempty"
+check "the indicator reports the active class while wl-screenrec runs" \
+  "$running_class" "active"
+
+# Confirm nothing is left running before the stub-PATH checks begin.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  "$REAL_PGREP" -x wl-screenrec >/dev/null || break
+  sleep 0.1
+done
+
+# ---- the indicator, with none running -------------------------------------
+# No sentinel process exists on this PATH, real pgrep included, so this
+# exercises the "nothing running" branch honestly rather than vacuously.
+
+indicator_idle="$("$INDICATOR")"
+idle_text=$(printf '%s' "$indicator_idle" | grep -o '"text": "[^"]*"' | cut -d'"' -f4)
+idle_has_class=$(printf '%s' "$indicator_idle" | grep -q '"class"' && echo yes || echo no)
+
+check "the indicator's text is empty with nothing running" "$idle_text" ""
+check "the indicator carries no class with nothing running" "$idle_has_class" "no"
+
+# ---- stub PATH for everything from here on --------------------------------
+# From here on checks must NOT be able to touch the real session: the refresh
+# script ends by calling hyprsimple-restart-waybar.sh, which calls pkill and
+# uwsm. A stub pgrep that exits 1 by default also keeps that restart's own
+# internals (should it ever grow a pgrep check) from seeing the real session.
+STUB_BIN="$TMP/stub-bin"
+mkdir -p "$STUB_BIN"
+for stub in pgrep pkill uwsm; do
+  printf '#!/bin/sh\nexit 1\n' >"$STUB_BIN/$stub"
+  chmod +x "$STUB_BIN/$stub"
+done
+export PATH="$STUB_BIN:$PATH"
+
+# ---- the shipped config.jsonc fixture -------------------------------------
+
+stripped="$TMP/shipped-stripped.json"
+strip_jsonc "$SHIPPED_CONFIG" >"$stripped"
+
+if jq -e . "$stripped" >/dev/null 2>&1; then
+  pass "the shipped config.jsonc parses as JSON once comments and trailing commas are stripped"
+else
+  fail "the shipped config.jsonc parses as JSON once comments and trailing commas are stripped"
+fi
+
+check "custom/screenrecording carries signal 8" \
+  "$(jq -r '."custom/screenrecording".signal // empty' "$stripped")" "8"
+
+check "custom/screenrecording carries no interval key" \
+  "$(jq -e '."custom/screenrecording" | has("interval")' "$stripped")" "false"
+
+check "modules-right lists custom/screenrecording" \
+  "$(jq -e '."modules-right" | index("custom/screenrecording") != null' "$stripped")" "true"
+
+check "custom/screenrecording's on-click names screen-record.sh" \
+  "$(jq -r '."custom/screenrecording"."on-click"' "$stripped" | grep -c 'screen-record\.sh')" "1"
+
+# ---- consolidating restarts did not scatter the relaunch or drop the signal
+
+hits=$(grep -rlE 'uwsm app -- waybar|nohup waybar' "$REPO/.local/bin" "$REPO/install.sh" 2>/dev/null | grep -v 'hyprsimple-restart-waybar\.sh$' | wc -l)
+check "no file besides hyprsimple-restart-waybar.sh relaunches waybar directly" "$hits" "0"
+
+if grep -q 'RTMIN+8' "$SCREEN_RECORD"; then
+  pass "screen-record.sh still signals waybar with RTMIN+8"
+else
+  fail "screen-record.sh still signals waybar with RTMIN+8"
+fi
+
+# ---- refresh: a non-default position survives the refresh -----------------
+
+fixture_home="$TMP/home-refresh"
+must_be_fixture "$fixture_home"
+mkdir -p "$fixture_home/.local/bin" "$fixture_home/.config/waybar"
+cp "$REFRESH_CONFIG" "$fixture_home/.local/bin/hyprsimple-refresh-config.sh"
+cp "$RESTART" "$fixture_home/.local/bin/hyprsimple-restart-waybar.sh"
+chmod +x "$fixture_home/.local/bin/"*.sh
+
+install_root="$TMP/install-refresh"
+must_be_fixture "$install_root"
+mkdir -p "$install_root/.config/waybar"
+cp "$SHIPPED_CONFIG" "$install_root/.config/waybar/config.jsonc"
+: >"$install_root/.config/waybar/style.css"
+
+sed 's/"position": "top"/"position": "bottom"/' "$SHIPPED_CONFIG" \
+  >"$fixture_home/.config/waybar/config.jsonc"
+: >"$fixture_home/.config/waybar/style.css"
+
+HOME="$fixture_home" HYPRSIMPLE_PATH="$install_root" bash "$REFRESH" >"$TMP/refresh_out" 2>&1
+refresh_status=$?
+
+check "the refresh command exits 0" "$refresh_status" "0"
+
+check "the non-default position survives the refresh" \
+  "$(grep -oE '"position": "[a-z]+"' "$fixture_home/.config/waybar/config.jsonc")" \
+  '"position": "bottom"'
+
+if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
+printf '\nall checks passed\n'

--- a/test/waybar-refresh-test.sh
+++ b/test/waybar-refresh-test.sh
@@ -104,6 +104,46 @@ for stub in pgrep pkill uwsm; do
 done
 export PATH="$STUB_BIN:$PATH"
 
+# ---- restart-waybar.sh: --if-running only restarts a running waybar -------
+# An exit status alone can't tell a skipped launch from a completed one,
+# since both are 0, so a uwsm stub that writes a marker file is used instead,
+# and the marker's presence or absence is what gets asserted.
+
+ifrun_marker="$TMP/ifrun-launched"
+ifrun_bin="$TMP/ifrun-bin"
+mkdir -p "$ifrun_bin"
+printf '#!/bin/sh\ntouch "%s"\n' "$ifrun_marker" >"$ifrun_bin/uwsm"
+chmod +x "$ifrun_bin/uwsm"
+
+# not running: the shared stub pgrep (installed above, exits 1) is still
+# first on this PATH.
+rm -f "$ifrun_marker"
+PATH="$ifrun_bin:$PATH" bash "$RESTART" --if-running >/dev/null 2>&1
+marker_seen=no
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [[ -f $ifrun_marker ]] && { marker_seen=yes; break; }
+  sleep 0.1
+done
+check "--if-running launches nothing when waybar is not running" "$marker_seen" "no"
+
+# running: a second, separate stub dir gives pgrep exit 0, prepended only for
+# this call so the shared stub is left untouched.
+running_pgrep_bin="$TMP/running-pgrep-bin"
+mkdir -p "$running_pgrep_bin"
+printf '#!/bin/sh\nexit 0\n' >"$running_pgrep_bin/pgrep"
+chmod +x "$running_pgrep_bin/pgrep"
+
+rm -f "$ifrun_marker"
+saved_path="$PATH"
+PATH="$running_pgrep_bin:$ifrun_bin:$PATH" bash "$RESTART" --if-running >/dev/null 2>&1
+marker_seen=no
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [[ -f $ifrun_marker ]] && { marker_seen=yes; break; }
+  sleep 0.1
+done
+PATH="$saved_path"
+check "--if-running launches waybar when it is already running" "$marker_seen" "yes"
+
 # ---- the shipped config.jsonc fixture -------------------------------------
 
 stripped="$TMP/shipped-stripped.json"


### PR DESCRIPTION
Adds a screen recording indicator to waybar, and the delivery mechanism without which it would reach nobody.

## The indicator completes a mechanism that was already half built

`.local/bin/screen-record.sh` has always sent `pkill -RTMIN+8 waybar` on both start and stop, and has always had the predicate:

```bash
screenrecording_active() {
  pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null
}
```

Nothing listened. A recording in progress was invisible unless you remembered starting it. The new module declares `"signal": 8` and no `interval`, so it costs nothing while idle and redraws the instant a recording starts or stops. Clicking it stops the recording, because `screen-record.sh` toggles.

## Why waybar is not split, unlike lua, dunst and the hypr configs

`man 5 waybar` says that for `include`, "the first defined value takes precedence, i.e. including file -> first included file". That is genuine key-level override, better than hyprlang. But `modules-left`, `modules-center` and `modules-right` are **arrays**, and first-wins means adding one module requires restating the whole list. `modules-right` has 12 entries, and adding or reordering a module is the most common waybar edit.

A split would also break `hyprsimple-muslimtify.sh remove`, which strips a module the default would then re-supply.

omarchy reached the same conclusion. Its waybar config is a 202-line file in user space, and updates arrive through `omarchy-refresh-waybar`, whose own summary calls it a reset. This PR follows that model.

## What ships

**`hyprsimple-restart-waybar.sh`** replaces three divergent idioms, in `install.sh`, `theme-switcher.sh` and `hyprsimple-muslimtify.sh`, which variously used `nohup`, bare `uwsm app`, and different sleeps. It carries `setsid` and a redirect, so a piped or non-interactive caller returns instead of waiting on the daemon's inherited stdout. That bug stalled a real `hyprsimple-update` during development.

`--if-running` preserves the distinction the three call sites actually had: a theme switch reloads a running bar and does nothing otherwise, while the installer starts one regardless.

**`hyprsimple-refresh-waybar.sh`** preserves `position`, refreshes both files through the existing `hyprsimple-refresh-config.sh`, and restarts.

**The migration is gated per file on a checksum.** A file byte-identical to any of the 17 `config.jsonc` or 11 `style.css` versions hyprsimple has shipped was never edited, so it is refreshed. A file matching none is left alone, and the migration prints the refresh command together with the exact diff it would apply.

On a real machine this splits, which is the point: a pristine `style.css` updates silently while an edited `config.jsonc` is preserved and its owner gets the command and the diff.

## Testing

New `test/waybar-refresh-test.sh`, 24 checks, wired into CI. Nine suites now, 162 checks.

The suite has one subtlety worth naming. It needs `pgrep` **unstubbed** for the indicator checks, so the script can find a real sentinel process, and **stubbed** for everything after, so a migration cannot touch the live session. It captures the real `pgrep` before mutating `PATH` and runs the indicator checks first.

Non-vacuity was verified by mutation rather than assumed. Making the indicator always report idle turns 2 checks red. Neutering the migration's copy turns 1 red. Removing its restart call turns 1 red. Deleting the `--if-running` guard turns 1 red.

The suite reads no git history, and passes from a `git archive` export with no `.git` and from a `git clone --depth 1`, which is what the runner has.

## Not covered

Nothing in CI starts a real waybar, so the bar rendering the module, the CSS applying, and the click stopping a recording are manual checks.

Two things worth knowing. `on-click` runs `screen-record.sh` with no arguments, so clicking while **not** recording opens a region selector rather than doing nothing. And `RTMIN+8` is shared by convention only: anything else sending that signal redraws this module.
