### PR TITLE
Generic image picker, and a wallpaper picker using it

### DIFF
--- a/.local/bin/hyprsimple-image-picker.sh
+++ b/.local/bin/hyprsimple-image-picker.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Render a list of images as a rofi grid and print the key of the one chosen.
+#
+# Reads tab separated rows on stdin:
+#
+#   key <TAB> label <TAB> image path
+#
+# The key is what gets printed. rofi runs with -format i, which returns the
+# index of the selection, so the key is looked up rather than parsed back out of
+# the label. Nothing transforms a display string into an identifier: doing that
+# is what broke theme selection when the label gained leading colour swatches.
+#
+# This is bound to a key, so nothing here may fail the whole picker.
+
+# ImageMagick 7 exposes `magick`. ImageMagick 6, which Ubuntu still ships,
+# exposes `convert`. Support both, and degrade to full size images when neither
+# is present.
+if command -v magick >/dev/null 2>&1; then
+  im() { magick "$@"; }
+elif command -v convert >/dev/null 2>&1; then
+  im() { convert "$@"; }
+else
+  im() { return 1; }
+fi
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hyprsimple/image-previews"
+RASI="${HYPRSIMPLE_PICKER_RASI:-$HOME/.config/rofi/theme-picker/style.rasi}"
+THUMB_SIZE=370
+prompt="Select"
+columns=3
+selected_key=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prompt) prompt="$2"; shift 2 ;;
+    --columns) columns="$2"; shift 2 ;;
+    --selected) selected_key="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$CACHE_DIR" 2>/dev/null
+
+# Keyed by the source path rather than a caller-supplied name, so two producers
+# naming the same image share one entry and cannot collide.
+thumbnail_for() {
+  local src="$1" hash thumb
+  hash=$(printf '%s' "$src" | md5sum | cut -d' ' -f1)
+  thumb="$CACHE_DIR/$hash.jpg"
+
+  if [[ $thumb -nt $src ]]; then
+    printf '%s' "$thumb"
+    return
+  fi
+
+  # rofi's icon box is square and takes no separate width and height, so a 16:9
+  # image would leave a dead band that strands the caption. Fill the box with a
+  # blurred zoomed copy and composite the whole undistorted image on top.
+  if im "$src" -resize "${THUMB_SIZE}x${THUMB_SIZE}^" -gravity center \
+    -extent "${THUMB_SIZE}x${THUMB_SIZE}" -blur 0x18 \
+    \( "$src" -resize "${THUMB_SIZE}x" \) -gravity center -composite \
+    "$thumb" 2>/dev/null; then
+    printf '%s' "$thumb"
+  else
+    # No ImageMagick, or it failed. rofi scales the original itself, slower but
+    # correct, which beats a picker that shows nothing.
+    printf '%s' "$src"
+  fi
+}
+
+keys=()
+feed=""
+row=0
+selected_row=""
+
+while IFS=$'\t' read -r key label image; do
+  [[ -n $key ]] || continue
+  keys+=("$key")
+  [[ $key == "$selected_key" ]] && selected_row=$row
+
+  if [[ -n $image && -f $image ]]; then
+    feed+=$(printf '%s\0icon\x1f%s' "$label" "$(thumbnail_for "$image")")$'\n'
+  else
+    # Listed without an icon rather than dropped. A row whose image is missing
+    # is still selectable.
+    feed+="$label"$'\n'
+  fi
+  row=$((row + 1))
+done
+
+((${#keys[@]})) || exit 0
+
+args=(-dmenu -show-icons -markup-rows -format i -p "$prompt" -theme "$RASI"
+      -theme-str "listview { columns: $columns; }")
+[[ -n $selected_row ]] && args+=(-selected-row "$selected_row")
+
+index=$(printf '%s' "$feed" | rofi "${args[@]}")
+[[ -n $index ]] || exit 0
+printf '%s\n' "${keys[$index]}"

--- a/.local/bin/hyprsimple-image-picker.sh
+++ b/.local/bin/hyprsimple-image-picker.sh
@@ -69,8 +69,12 @@ thumbnail_for() {
   fi
 }
 
+# The feed goes to a file, not a variable. rofi's icon protocol needs a literal
+# NUL between the label and the path, and bash cannot hold a NUL in a variable
+# at all: command substitution silently drops it and every icon disappears.
 keys=()
-feed=""
+feed_file=$(mktemp) || exit 1
+trap 'rm -f "$feed_file"' EXIT
 row=0
 selected_row=""
 
@@ -80,11 +84,11 @@ while IFS=$'\t' read -r key label image; do
   [[ $key == "$selected_key" ]] && selected_row=$row
 
   if [[ -n $image && -f $image ]]; then
-    feed+=$(printf '%s\0icon\x1f%s' "$label" "$(thumbnail_for "$image")")$'\n'
+    printf '%s\0icon\x1f%s\n' "$label" "$(thumbnail_for "$image")" >>"$feed_file"
   else
     # Listed without an icon rather than dropped. A row whose image is missing
     # is still selectable.
-    feed+="$label"$'\n'
+    printf '%s\n' "$label" >>"$feed_file"
   fi
   row=$((row + 1))
 done
@@ -95,6 +99,6 @@ args=(-dmenu -show-icons -markup-rows -format i -p "$prompt" -theme "$RASI"
       -theme-str "listview { columns: $columns; }")
 [[ -n $selected_row ]] && args+=(-selected-row "$selected_row")
 
-index=$(printf '%s' "$feed" | rofi "${args[@]}")
+index=$(rofi "${args[@]}" <"$feed_file")
 [[ -n $index ]] || exit 0
 printf '%s\n' "${keys[$index]}"

--- a/.local/bin/hyprsimple-theme-picker.sh
+++ b/.local/bin/hyprsimple-theme-picker.sh
@@ -1,39 +1,13 @@
 #!/bin/bash
 
-# Emit a rofi dmenu feed: one tile per theme, the theme's wallpaper as the icon
-# and its name plus colour swatches as pango markup.
+# Emit one row per theme for hyprsimple-image-picker.sh:
 #
-# Wallpapers are 2560px wide, so decoding sixteen of them on every open costs
-# about 1.8 seconds. Thumbnails cut that to about 0.16s. The -nt test is the
-# whole invalidation strategy: a changed wallpaper is newer than its thumbnail,
-# and a new theme has no thumbnail at all.
+#   theme directory name <TAB> display name and colour swatches <TAB> wallpaper
 #
-# rofi's icon box is square and cannot be given a width and a height, so a 16:9
-# wallpaper would sit in it with dead space above and below, stranding the
-# caption. The thumbnail is instead filled edge to edge with a blurred, zoomed
-# copy of the same wallpaper, with the whole undistorted image composited on
-# top. Nothing is cropped and the box has no empty band.
-#
-# This is bound to a key, so nothing here may fail the whole picker. A theme
-# with no wallpaper is listed without one, and with no ImageMagick the
-# full-size image is used instead of a thumbnail.
-
-# ImageMagick 7 exposes `magick`. ImageMagick 6, which Ubuntu still ships,
-# exposes `convert`. Support both, and degrade to full size images when neither
-# is present rather than failing: this is bound to a key.
-if command -v magick >/dev/null 2>&1; then
-  im() { magick "$@"; }
-elif command -v convert >/dev/null 2>&1; then
-  im() { convert "$@"; }
-else
-  im() { return 1; }
-fi
+# The key is the directory name, so the picker returns something usable directly
+# and no display string is transformed back into an identifier.
 
 THEMES_DIR="${THEMES_DIR:-$HOME/.config/hypr/themes}"
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hyprsimple/theme-previews"
-THUMB_SIZE=370
-
-mkdir -p "$CACHE_DIR" 2>/dev/null
 
 # background, foreground, accent, color1. Not the ANSI spread: accent and
 # color4 are the same value in 12 of the 16 shipped themes, so a swatch was
@@ -49,26 +23,6 @@ swatches_for() {
   printf '%s' "$out"
 }
 
-thumbnail_for() {
-  local name="$1" src="$2" thumb="$CACHE_DIR/$name.jpg"
-
-  if [[ $thumb -nt $src ]]; then
-    printf '%s' "$thumb"
-    return
-  fi
-
-  if im "$src" -resize "${THUMB_SIZE}x${THUMB_SIZE}^" -gravity center \
-    -extent "${THUMB_SIZE}x${THUMB_SIZE}" -blur 0x18 \
-    \( "$src" -resize "${THUMB_SIZE}x" \) -gravity center -composite \
-    "$thumb" 2>/dev/null; then
-    printf '%s' "$thumb"
-  else
-    # No ImageMagick, or it failed. rofi scales the original itself, slower but
-    # correct, which beats a picker that shows nothing.
-    printf '%s' "$src"
-  fi
-}
-
 for dir in "$THEMES_DIR"/*/; do
   name=$(basename "$dir")
   [[ $name == templates ]] && continue
@@ -76,13 +30,5 @@ for dir in "$THEMES_DIR"/*/; do
   wallpaper=$(find "$dir/backgrounds" -maxdepth 1 -type f \
     \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | sort | head -n 1)
 
-  label="$(swatches_for "$dir/colors.toml")  ${name//-/ }"
-
-  if [[ -n $wallpaper ]]; then
-    printf '%s\0icon\x1f%s\n' "$label" "$(thumbnail_for "$name" "$wallpaper")"
-  else
-    # Listed without an icon rather than dropped. A theme is still selectable
-    # when its wallpaper is missing.
-    printf '%s\n' "$label"
-  fi
+  printf '%s\t%s  %s\t%s\n' "$name" "$(swatches_for "$dir/colors.toml")" "${name//-/ }" "$wallpaper"
 done

--- a/.local/bin/hyprsimple-wallpaper-picker.sh
+++ b/.local/bin/hyprsimple-wallpaper-picker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Emit one row per wallpaper in the current theme for hyprsimple-image-picker.sh:
+#
+#   image path <TAB> display name <TAB> image path
+#
+# The key and the image are the same thing here, so the picker returns a path
+# the caller can apply directly.
+#
+# The theme is derived from ~/.cache/current_wallpaper_path, which is the only
+# record of which theme is applied. wallpaper-switcher.sh derives it the same
+# way at its line 12.
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+CURRENT=$(cat "$CACHE_DIR/current_wallpaper_path" 2>/dev/null)
+BG_DIR=$(dirname "$CURRENT" 2>/dev/null)
+
+[[ -d $BG_DIR ]] || exit 0
+
+find "$BG_DIR" -maxdepth 1 -type f \
+  \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null |
+  sort |
+  while read -r image; do
+    base=$(basename "$image")
+    # Strip the extension, then a leading sort prefix like "0-", then turn the
+    # remaining hyphens into spaces: "0-morning-breeze.jpg" reads "morning breeze".
+    label=${base%.*}
+    label=${label#[0-9]-}
+    printf '%s\t%s\t%s\n' "$image" "${label//-/ }" "$image"
+  done

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -14,10 +14,7 @@ if [[ -n "$1" ]]; then
   THEME="$1"
 else
   THEME=$("$HOME/.local/bin/hyprsimple-theme-picker.sh" |
-    rofi -dmenu -show-icons -markup-rows -p "Theme" \
-      -theme "$HOME/.config/rofi/theme-picker/style.rasi" |
-    sed 's/<[^>]*>//g; s/^[[:space:]]*//; s/[[:space:]]*$//' |
-    tr '[:upper:] ' '[:lower:]-')
+    "$HOME/.local/bin/hyprsimple-image-picker.sh" --prompt "Theme" --columns 3)
 fi
 [[ -z "$THEME" ]] && exit 0
 

--- a/.local/bin/wallpaper-switcher.sh
+++ b/.local/bin/wallpaper-switcher.sh
@@ -47,14 +47,12 @@ elif [[ $MODE == "next" ]]; then
   done
   SELECTED="${WALLPAPERS[$NEXT]}"
 elif [[ $MODE == "pick" ]]; then
-  # Show rofi picker with filenames
-  NAMES=()
-  for wp in "${WALLPAPERS[@]}"; do
-    NAMES+=("$(basename "$wp")")
-  done
-  CHOICE=$(printf '%s\n' "${NAMES[@]}" | rofi -dmenu -p "Wallpaper")
-  [[ -z $CHOICE ]] && exit 0
-  SELECTED="$BG_DIR/$CHOICE"
+  # Two columns, not three: a theme ships at most four wallpapers, so three
+  # columns would render three and then a lone one.
+  SELECTED=$("$HOME/.local/bin/hyprsimple-wallpaper-picker.sh" |
+    "$HOME/.local/bin/hyprsimple-image-picker.sh" \
+      --prompt "Wallpaper" --columns 2 --selected "$CURRENT")
+  [[ -z $SELECTED ]] && exit 0
 fi
 
 if [[ ! -f $SELECTED ]]; then

--- a/test/theme-picker-test.sh
+++ b/test/theme-picker-test.sh
@@ -9,8 +9,33 @@ PICKER="$REPO/.local/bin/hyprsimple-theme-picker.sh"
 MIGRATION="$REPO/migrations/1788100840.sh"
 SHIPPED_LAUNCHER="$REPO/test/fixtures/rofi/launcher-config.rasi.shipped"
 SHIPPED_ROOT="$REPO/test/fixtures/rofi/config.rasi.shipped"
+IMAGE_PICKER="$REPO/.local/bin/hyprsimple-image-picker.sh"
+WALLPAPER_PICKER="$REPO/.local/bin/hyprsimple-wallpaper-picker.sh"
+WALLPAPER_SWITCHER="$REPO/.local/bin/wallpaper-switcher.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+
+# A stub rofi on PATH. hyprsimple-image-picker.sh invokes rofi by name, so this
+# suite must put a real executable ahead of the real rofi on PATH rather than
+# ever run it: the real one would open a window on the maintainer's screen.
+# It reports the selection via $ROFI_STUB_INDEX and, when $ROFI_STUB_CAPTURE
+# is set, saves what it was fed byte for byte. That capture is the only way to
+# see the NUL icon separator: it cannot survive a shell variable or command
+# substitution, which is what let a picker that sent zero separators still
+# pass every other check.
+bin_rofi="$TMP/bin-rofi"
+mkdir -p "$bin_rofi"
+cat >"$bin_rofi/rofi" <<'STUB'
+#!/bin/bash
+if [[ -n ${ROFI_STUB_CAPTURE:-} ]]; then
+  cat >"$ROFI_STUB_CAPTURE"
+else
+  cat >/dev/null
+fi
+printf '%s\n' "${ROFI_STUB_INDEX:-0}"
+STUB
+chmod +x "$bin_rofi/rofi"
+export PATH="$bin_rofi:$PATH"
 
 failures=0
 pass() { printf 'ok - %s\n' "$1"; }
@@ -53,15 +78,27 @@ THEMES_DIR="$three_themes" XDG_CACHE_HOME="$three_cache" bash "$PICKER" >"$out_t
 
 check "a fixture with three themes emits three lines" "$(wc -l <"$out_three")" "3"
 
-# ---- every emitted line carries the icon separator and a real path --------
-# NUL bytes cannot be given as shell arguments, so this is checked in
-# python3, which can express the separator and split records on the real
-# newline byte.
+# ---- every row rofi receives for an existing image carries the icon
+# separator and a path that exists (the theme picker itself does no
+# thumbnailing any more; this now lives in hyprsimple-image-picker.sh and is
+# only observable by capturing rofi's stdin) -------------------------------
 
-b_result=$(python3 - "$out_three" <<'PY'
+rows_three=$(python3 -c "
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+for l in lines:
+    key, label, image = l.split('\t')
+    print(f'{key}\t{label}\t{image}')
+" "$out_three")
+
+rt1_cache="$TMP/cache-rt1"
+rt1_capture="$TMP/capture-rt1"
+ROFI_STUB_INDEX=0 ROFI_STUB_CAPTURE="$rt1_capture" \
+  XDG_CACHE_HOME="$rt1_cache" bash "$IMAGE_PICKER" <<<"$rows_three" >/dev/null
+
+rt1_result=$(python3 - "$rt1_capture" <<'PY'
 import sys, os
-path = sys.argv[1]
-data = open(path, 'rb').read()
+data = open(sys.argv[1], 'rb').read()
 lines = [l for l in data.split(b'\n') if l]
 ok = True
 for l in lines:
@@ -75,7 +112,7 @@ for l in lines:
 print('yes' if ok else 'no')
 PY
 )
-check "every emitted line carries the icon separator and a path that exists" "$b_result" "yes"
+check "every emitted line carries the icon separator and a path that exists" "$rt1_result" "yes"
 
 # ---- swatches carry the theme's accent, and change when it changes --------
 
@@ -118,24 +155,29 @@ check "a theme with an empty backgrounds dir carries no icon separator" \
   "$(printf '%s' "$emptybg_line" | python3 -c "import sys; print(sys.stdin.buffer.read().count(b'\x00icon\x1f'))")" "0"
 
 # ---- caching: a second run touches no thumbnail, a changed source does ----
+# Thumbnailing moved from the theme picker to the image picker, so this now
+# drives hyprsimple-image-picker.sh with rows the test constructs.
 
-cache_themes="$TMP/themes-cache"
-must_be_fixture "$cache_themes"
-mkdir -p "$cache_themes/one/backgrounds" "$cache_themes/two/backgrounds"
-make_wallpaper "$cache_themes/one/backgrounds/wall.jpg"
-make_wallpaper "$cache_themes/two/backgrounds/wall.jpg"
+cache_src_dir="$TMP/cache-src"
+must_be_fixture "$cache_src_dir"
+mkdir -p "$cache_src_dir"
+make_wallpaper "$cache_src_dir/one.jpg"
+make_wallpaper "$cache_src_dir/two.jpg"
 
 cache_dir_base="$TMP/cache-mtime"
 must_be_fixture "$cache_dir_base"
-thumb_one="$cache_dir_base/hyprsimple/theme-previews/one.jpg"
-thumb_two="$cache_dir_base/hyprsimple/theme-previews/two.jpg"
+hash_one=$(printf '%s' "$cache_src_dir/one.jpg" | md5sum | cut -d' ' -f1)
+hash_two=$(printf '%s' "$cache_src_dir/two.jpg" | md5sum | cut -d' ' -f1)
+thumb_one="$cache_dir_base/hyprsimple/image-previews/$hash_one.jpg"
+thumb_two="$cache_dir_base/hyprsimple/image-previews/$hash_two.jpg"
+cache_rows=$(printf 'one\tOne\t%s\ntwo\tTwo\t%s\n' "$cache_src_dir/one.jpg" "$cache_src_dir/two.jpg")
 
-THEMES_DIR="$cache_themes" XDG_CACHE_HOME="$cache_dir_base" bash "$PICKER" >/dev/null
+ROFI_STUB_INDEX=0 XDG_CACHE_HOME="$cache_dir_base" bash "$IMAGE_PICKER" <<<"$cache_rows" >/dev/null
 
 mtime_one_1=$(stat -c %Y "$thumb_one")
 mtime_two_1=$(stat -c %Y "$thumb_two")
 
-THEMES_DIR="$cache_themes" XDG_CACHE_HOME="$cache_dir_base" bash "$PICKER" >/dev/null
+ROFI_STUB_INDEX=0 XDG_CACHE_HOME="$cache_dir_base" bash "$IMAGE_PICKER" <<<"$cache_rows" >/dev/null
 
 mtime_one_2=$(stat -c %Y "$thumb_one")
 mtime_two_2=$(stat -c %Y "$thumb_two")
@@ -147,9 +189,9 @@ check "a second run leaves thumbnail two's mtime unchanged" "$mtime_two_2" "$mti
 # The sleep guarantees the regenerated thumbnail lands in a different second
 # than the one being compared against; mtime has only second resolution here.
 sleep 1
-touch -d '+1 hour' "$cache_themes/one/backgrounds/wall.jpg"
+touch -d '+1 hour' "$cache_src_dir/one.jpg"
 
-THEMES_DIR="$cache_themes" XDG_CACHE_HOME="$cache_dir_base" bash "$PICKER" >/dev/null
+ROFI_STUB_INDEX=0 XDG_CACHE_HOME="$cache_dir_base" bash "$IMAGE_PICKER" <<<"$cache_rows" >/dev/null
 
 mtime_one_3=$(stat -c %Y "$thumb_one")
 mtime_two_3=$(stat -c %Y "$thumb_two")
@@ -169,7 +211,7 @@ nomagick_cache="$TMP/cache-nomagick"
 
 bin_no_magick="$TMP/bin-no-magick"
 mkdir -p "$bin_no_magick"
-for u in mkdir sed cut head find sort basename; do
+for u in mkdir sed cut head find sort basename mktemp md5sum rm cat stat; do
   ln -s "$(command -v "$u")" "$bin_no_magick/$u"
 done
 
@@ -180,11 +222,18 @@ env -i "PATH=$bin_no_magick" "THEMES_DIR=$nomagick_themes" \
 check "with no magick on PATH the feed still emits a line" \
   "$([[ -s $nomagick_out ]] && echo nonempty || echo empty)" "nonempty"
 
+# Thumbnailing, and its ImageMagick fallback, moved to the image picker. Drive
+# it directly with a bare PATH (no magick, no convert) plus just the rofi stub
+# and the utilities it needs, and read the icon path back out of rofi's
+# captured stdin.
+im_nomagick_out="$TMP/im-nomagick-out"
+im_nomagick_rows=$(printf 'solo\tSolo\t%s\n' "$nomagick_themes/solo/backgrounds/wall.jpg")
+env -i "PATH=$bin_no_magick:$bin_rofi" "XDG_CACHE_HOME=$nomagick_cache" \
+  ROFI_STUB_INDEX=0 ROFI_STUB_CAPTURE="$im_nomagick_out" \
+  /usr/bin/bash "$IMAGE_PICKER" <<<"$im_nomagick_rows" >/dev/null
+
 nomagick_icon=$(python3 -c "
-data = open('$nomagick_out', 'rb').read()
-# A line with no separator is a legitimate case: a theme with no wallpaper is
-# listed without an icon. Print nothing rather than crashing, so the check that
-# follows reports a mismatch instead of the suite dying on a traceback.
+data = open('$im_nomagick_out', 'rb').read()
 parts = data.split(b'\x00icon\x1f', 1)
 print(parts[1].decode().strip() if len(parts) > 1 else '')
 ")
@@ -284,30 +333,168 @@ done
 
 check "the picker's swatch keys are distinct on every shipped theme" "$dup_themes" "0"
 
-# ---- the picker's labels survive theme-switcher's reverse transform ------
-# theme-switcher.sh strips the pango markup back to a directory name. When the
-# label gained leading swatches, that transform turned the swatch spaces into
-# ten leading hyphens and every selection resolved to nothing, while this suite
-# stayed green. The transform is read out of theme-switcher.sh rather than
-# repeated here, so changing either side re-runs this against the other.
+# ---- a key with an uppercase letter and a space round-trips byte-identical
 
-transform=$(sed -n "/hyprsimple-theme-picker.sh\" |/,/tr '\[:upper:\]/p" \
-  "$REPO/.local/bin/theme-switcher.sh" | grep -E "^[[:space:]]*(sed|tr) " |
-  sed "s/[[:space:]]*|[[:space:]]*$//; s/)$//")
+rt_rows=$(printf 'alpha\tAlpha\t\nMy Theme\tMy Theme\t\ngamma\tGamma\t\n')
 
-roundtrip_bad=0
-roundtrip_ran=0
-while IFS= read -r line; do
-  label=${line%%$'\0'*}
-  name=$(printf '%s\n' "$label" | eval "$(printf '%s' "$transform" | paste -sd'|' -)")
-  roundtrip_ran=$((roundtrip_ran + 1))
-  [[ -d "$REPO/.config/hypr/themes/$name" ]] || roundtrip_bad=$((roundtrip_bad + 1))
-done < <(THEMES_DIR="$REPO/.config/hypr/themes" XDG_CACHE_HOME="$TMP/rt-cache" \
-  bash "$REPO/.local/bin/hyprsimple-theme-picker.sh")
+rt_key=$(ROFI_STUB_INDEX=1 XDG_CACHE_HOME="$TMP/cache-rt-key" bash "$IMAGE_PICKER" <<<"$rt_rows")
+check "a key containing an uppercase letter and a space is returned byte-identical, with rofi stubbed to select a known index" \
+  "$rt_key" "My Theme"
 
-check "the reverse transform was actually extracted and run" \
-  "$((roundtrip_ran > 0 ? 1 : 0))" "1"
-check "every picker label resolves back to a real theme directory" "$roundtrip_bad" "0"
+# ---- selecting index 0, then a later index, prints that row's key both times
+
+rt_key_0=$(ROFI_STUB_INDEX=0 XDG_CACHE_HOME="$TMP/cache-rt-multi" bash "$IMAGE_PICKER" <<<"$rt_rows")
+rt_key_2=$(ROFI_STUB_INDEX=2 XDG_CACHE_HOME="$TMP/cache-rt-multi" bash "$IMAGE_PICKER" <<<"$rt_rows")
+check "with rofi stubbed to select index 0 and then a later index, the printed key is that row's key both times" \
+  "$rt_key_0|$rt_key_2" "alpha|gamma"
+
+# ---- every key from the theme producer names a directory in the fixture --
+
+tp_dirs_ok=yes
+while IFS=$'\t' read -r tp_key _ _; do
+  [[ -d "$three_themes/$tp_key" ]] || tp_dirs_ok=no
+done <"$out_three"
+check "every key from the theme producer names a directory in the fixture themes directory" "$tp_dirs_ok" "yes"
+
+# ---- the theme producer emits one row per theme directory, excluding templates
+
+tmpl_themes="$TMP/themes-templates"
+must_be_fixture "$tmpl_themes"
+mkdir -p "$tmpl_themes/one" "$tmpl_themes/two" "$tmpl_themes/three" "$tmpl_themes/templates"
+tmpl_out="$TMP/out-templates"
+THEMES_DIR="$tmpl_themes" XDG_CACHE_HOME="$TMP/cache-templates" bash "$PICKER" >"$tmpl_out"
+check "the theme producer emits one row per theme directory, excluding templates" "$(wc -l <"$tmpl_out")" "3"
+
+# ---- the wallpaper producer's keys, and its label shape --------------------
+
+wp_theme="$TMP/wp-theme"
+must_be_fixture "$wp_theme"
+mkdir -p "$wp_theme/backgrounds"
+make_wallpaper "$wp_theme/backgrounds/0-morning-breeze.jpg"
+make_wallpaper "$wp_theme/backgrounds/1-evening-glow.jpg"
+
+wp_cache="$TMP/cache-wp"
+must_be_fixture "$wp_cache"
+mkdir -p "$wp_cache"
+printf '%s\n' "$wp_theme/backgrounds/0-morning-breeze.jpg" >"$wp_cache/current_wallpaper_path"
+
+wp_out="$TMP/out-wp"
+XDG_CACHE_HOME="$wp_cache" bash "$WALLPAPER_PICKER" >"$wp_out"
+
+wp_keys_ok=yes
+while IFS=$'\t' read -r wp_key _ _; do
+  [[ -f $wp_key ]] || wp_keys_ok=no
+done <"$wp_out"
+check "every key from the wallpaper producer is a file in the fixture backgrounds directory" "$wp_keys_ok" "yes"
+
+wp_label=$(cut -f2 "$wp_out" | head -n 1)
+check "the wallpaper producer's label has no extension and no leading sort prefix" "$wp_label" "morning breeze"
+
+# ---- two producers naming the same image share one cache entry ------------
+
+dup_img="$TMP/dup-img/pic.jpg"
+mkdir -p "$TMP/dup-img"
+make_wallpaper "$dup_img"
+dup_cache="$TMP/cache-dup"
+dup_rows=$(printf 'from-theme\tFrom Theme\t%s\nfrom-wallpaper\tFrom Wallpaper\t%s\n' "$dup_img" "$dup_img")
+ROFI_STUB_INDEX=0 XDG_CACHE_HOME="$dup_cache" bash "$IMAGE_PICKER" <<<"$dup_rows" >/dev/null
+dup_count=$(find "$dup_cache/hyprsimple/image-previews" -type f | wc -l)
+check "two producers naming the same image cause one cache entry to exist, not two" "$dup_count" "1"
+
+# ---- theme-switcher.sh no longer transforms the picker's output -----------
+
+check "grep finds no sed or tr applied to the picker output in theme-switcher.sh" \
+  "$(grep -A2 'hyprsimple-theme-picker.sh"' "$REPO/.local/bin/theme-switcher.sh" | grep -cE '^[[:space:]]*(sed|tr) ')" "0"
+
+# ---- the image picker itself degrades without ImageMagick -----------------
+
+nomagick2_dir="$TMP/nomagick2"
+mkdir -p "$nomagick2_dir"
+make_wallpaper "$nomagick2_dir/pic.jpg"
+nomagick2_rows=$(printf 'solo\tSolo\t%s\n' "$nomagick2_dir/pic.jpg")
+nomagick2_out=$(env -i "PATH=$bin_no_magick:$bin_rofi" "XDG_CACHE_HOME=$TMP/cache-nomagick2" \
+  ROFI_STUB_INDEX=0 /usr/bin/bash "$IMAGE_PICKER" <<<"$nomagick2_rows")
+check "with no ImageMagick on PATH, the picker still prints a key" "$nomagick2_out" "solo"
+
+# ---- a row whose image is missing is still selectable ----------------------
+
+missing_rows=$(printf 'exists\tExists\t%s\nmissing\tMissing\t/no/such/path.jpg\n' "$dup_img")
+missing_out=$(ROFI_STUB_INDEX=1 XDG_CACHE_HOME="$TMP/cache-missing" bash "$IMAGE_PICKER" <<<"$missing_rows")
+check "a row whose image path does not exist is still selectable, checked by stubbing rofi to select it" \
+  "$missing_out" "missing"
+
+# ---- what actually reaches rofi carries the NUL separator ------------------
+# An exit status cannot see this: a picker that silently dropped every
+# separator would still return the correct key on selection. Only capturing
+# rofi's stdin catches it.
+
+sep_img1="$TMP/sep/one.jpg"
+sep_img2="$TMP/sep/two.jpg"
+mkdir -p "$TMP/sep"
+make_wallpaper "$sep_img1"
+make_wallpaper "$sep_img2"
+sep_rows=$(printf 'one\tOne\t%s\ntwo\tTwo\t%s\n' "$sep_img1" "$sep_img2")
+sep_capture="$TMP/capture-sep"
+ROFI_STUB_INDEX=0 ROFI_STUB_CAPTURE="$sep_capture" XDG_CACHE_HOME="$TMP/cache-sep" \
+  bash "$IMAGE_PICKER" <<<"$sep_rows" >/dev/null
+
+sep_result=$(python3 -c "
+import os
+data = open('$sep_capture', 'rb').read()
+lines = [l for l in data.split(b'\n') if l]
+count = data.count(b'\x00icon\x1f')
+ok = count == 2 and all(
+    os.path.exists(l.split(b'\x00icon\x1f', 1)[1])
+    for l in lines if b'\x00icon\x1f' in l
+)
+print('yes' if ok else 'no')
+")
+check "every row rofi receives for an existing image carries the NUL icon separator and a path that exists" \
+  "$sep_result" "yes"
+
+# ---- an unwritable cache directory still yields a usable picker -----------
+
+unwritable_dir="$TMP/cache-unwritable"
+mkdir -p "$unwritable_dir"
+chmod 000 "$unwritable_dir"
+uw_rows=$(printf 'solo\tSolo\t%s\n' "$dup_img")
+uw_out=$(ROFI_STUB_INDEX=0 XDG_CACHE_HOME="$unwritable_dir" bash "$IMAGE_PICKER" <<<"$uw_rows")
+chmod 755 "$unwritable_dir"
+check "with the cache directory made unwritable, the picker still prints a key" "$uw_out" "solo"
+
+# ---- a theme with exactly one wallpaper skips the picker entirely ---------
+# Four shipped themes have exactly one wallpaper, so wallpaper-switcher.sh's
+# early exit is reached in practice, not just in this fixture.
+
+ws_home="$TMP/ws-home"
+must_be_fixture "$ws_home"
+mkdir -p "$ws_home/.local/bin" "$ws_home/.cache"
+cp "$REPO/.local/bin/hypr-helpers.sh" "$ws_home/.local/bin/hypr-helpers.sh"
+
+ws_marker="$TMP/picker-invoked-marker"
+cat >"$ws_home/.local/bin/hyprsimple-image-picker.sh" <<STUB2
+#!/bin/bash
+touch "$ws_marker"
+STUB2
+chmod +x "$ws_home/.local/bin/hyprsimple-image-picker.sh"
+
+ws_theme_bg="$TMP/ws-theme/backgrounds"
+must_be_fixture "$TMP/ws-theme"
+mkdir -p "$ws_theme_bg"
+make_wallpaper "$ws_theme_bg/only.jpg"
+printf '%s\n' "$ws_theme_bg/only.jpg" >"$ws_home/.cache/current_wallpaper_path"
+
+ws_notify_bin="$TMP/ws-notify-bin"
+mkdir -p "$ws_notify_bin"
+printf '#!/bin/sh\nexit 0\n' >"$ws_notify_bin/notify-send"
+chmod +x "$ws_notify_bin/notify-send"
+
+PATH="$ws_notify_bin:$PATH" HOME="$ws_home" bash "$WALLPAPER_SWITCHER" pick >/dev/null 2>&1
+ws_exit=$?
+
+check "a fixture theme holding exactly one wallpaper makes wallpaper-switcher.sh pick exit 0" "$ws_exit" "0"
+check "a fixture theme holding exactly one wallpaper makes wallpaper-switcher.sh pick skip invoking the picker" \
+  "$([[ -e $ws_marker ]] && echo invoked || echo not-invoked)" "not-invoked"
 
 if ((failures > 0)); then printf '\n%s check(s) failed\n' "$failures" >&2; exit 1; fi
 printf '\nall checks passed\n'


### PR DESCRIPTION
Stacked on #31. Turns the theme picker into a generic image picker, adds a wallpaper picker using it, and deletes a bug class rather than duplicating it.

**Merge #31 first.** This branches off it.

## Why generalise

A wallpaper picker with the same look would have been the theme picker copied with a different data source, and two near-identical scripts drift. omarchy reached the same conclusion: its `omarchy-menu-images` is generic and serves both its theme and background switchers.

More importantly, copying it would have copied a defect. The theme picker emitted a **display label**, so `theme-switcher.sh` transformed it back into a directory name with `sed` and `tr`. That broke the moment the label changed: moving the colour swatches before the name left the spaces from inside each pango span, and `tr` turned all ten into hyphens, so every selection resolved to a directory that does not exist. The suite was green throughout.

`rofi-dmenu` documents the exit:

```
-format format
     • 'i' index (0 - (N-1))
```

The picker now carries a hidden key per row and returns the key at the selected index. Nothing transforms a display string into an identifier, so the whole class is gone. Proven with a key the old pipeline could not survive: `Deep Sea Theme` returns byte-identical, where `sed | tr` produced `deep-sea-theme`.

## Shape

```
hyprsimple-image-picker.sh     reads key<TAB>label<TAB>image, prints the chosen key
hyprsimple-theme-picker.sh     producer: theme dir name, name plus swatches, wallpaper
hyprsimple-wallpaper-picker.sh producer: image path, cleaned filename, image path
```

```bash
THEME=$(hyprsimple-theme-picker.sh | hyprsimple-image-picker.sh --prompt Theme --columns 3)
SELECTED=$(hyprsimple-wallpaper-picker.sh | hyprsimple-image-picker.sh --prompt Wallpaper --columns 2 --selected "$CURRENT")
```

The theme picker drops from 88 lines to 34, since all thumbnailing moved out. Two columns for wallpapers because a theme ships at most four, and three would render three and then a lone one. The current wallpaper is preselected.

The thumbnail cache is keyed by a hash of the source path rather than a caller-supplied name, so both pickers share one cache and cannot collide.

## What was already there and is untouched

The wallpaper feature was complete except for its presentation. Selecting a wallpaper already stopped the live cycle at `wallpaper-switcher.sh:72`, `SUPER + CTRL + W` already restored it, `SUPER + ALT + W` already cycled, and the picker was already scoped to the current theme. Only the `rofi -dmenu` over basenames changed. The single-wallpaper short circuit at lines 29 to 32 stays, and four shipped themes reach it.

## A bug this PR introduced and fixed

The first version accumulated the rofi feed in a shell variable. **A bash variable cannot hold a NUL byte**, and command substitution drops one with only a warning, so rofi's icon separator was destroyed and every row arrived as plain text with no image.

It passed `bash -n`, passed the key round trip, and returned correct selections. Measured against a stub capturing what rofi actually receives: **0 of 16 rows carried the separator before the fix, 16 of 16 after.** The feed is now written to a file.

The suite gained a check for exactly this, and reintroducing the bug now turns three checks red.

## Testing

`test/theme-picker-test.sh` goes from 24 checks to 36. Two obsolete checks for the deleted transform were removed. Three that covered thumbnailing were retargeted rather than deleted, because that behaviour moved to the image picker rather than disappearing.

The suite drives rofi through a stub executable that reports a selection index and can capture its stdin byte for byte, read with `python3` rather than `grep`, since a NUL survives neither a shell variable nor a shell argument.

Non-vacuity verified by mutation: printing the label instead of the key turns 5 checks red, and reintroducing the NUL bug turns 3 red. The suite passes from a tree with no `.git`, from a `git clone --depth 1`, and with only `convert` rather than `magick`.

## Not covered

Nothing in CI renders a grid. Whether a two column wallpaper grid looks right needs a screen.
