### PR TITLE
Make the picker selection visible on every theme

### DIFF
--- a/.config/rofi/theme-picker/style.rasi
+++ b/.config/rofi/theme-picker/style.rasi
@@ -64,15 +64,25 @@ listview {
 }
 
 /*****----- Elements -----*****/
+/* A transparent border of the same width as the selected one, so selecting a
+   tile does not shift the grid. */
 element {
     orientation:                 vertical;
     padding:                     6px;
+    border:                      3px;
     border-radius:               12px;
+    border-color:                transparent;
     background-color:            transparent;
     text-color:                  @foreground;
 }
 
+/* The selection is marked with @selected, the theme accent, not with
+   @background-alt. background-alt is generated from color0, which sits under
+   1.5:1 against the panel in 13 of the 16 shipped themes and is exactly equal
+   to it in four, so a fill alone is invisible. Every theme's accent is at
+   least 3.86:1. */
 element selected {
+    border-color:                @selected;
     background-color:            @background-alt;
     text-color:                  @foreground;
 }

--- a/.local/bin/wallpaper-switcher.sh
+++ b/.local/bin/wallpaper-switcher.sh
@@ -47,11 +47,12 @@ elif [[ $MODE == "next" ]]; then
   done
   SELECTED="${WALLPAPERS[$NEXT]}"
 elif [[ $MODE == "pick" ]]; then
-  # Two columns, not three: a theme ships at most four wallpapers, so three
-  # columns would render three and then a lone one.
+  # Three columns, matching the theme picker. A theme ships at most four
+  # wallpapers, so the last row is often short, and consistency with the theme
+  # grid was preferred over a tidier final row.
   SELECTED=$("$HOME/.local/bin/hyprsimple-wallpaper-picker.sh" |
     "$HOME/.local/bin/hyprsimple-image-picker.sh" \
-      --prompt "Wallpaper" --columns 2 --selected "$CURRENT")
+      --prompt "Wallpaper" --columns 3 --selected "$CURRENT")
   [[ -z $SELECTED ]] && exit 0
 fi
 


### PR DESCRIPTION
Two small changes to the pickers merged in #33.

## The selection was invisible

A selected tile was filled with `@background-alt`, which `themes/templates/rofi-colors.rasi.tpl` generates from `{{ color0 }}`. On most themes that is very close to the panel colour.

Measured across the sixteen shipped themes, contrast of the selected fill against the panel:

| | |
|---|---|
| Under 1.5:1 | **13 of 16** themes |
| Exactly 1.00:1, identical colour | ethereal, hackerman, vantablack, white |
| The accent against the panel | at least **3.86:1** on every theme |

So a fill can never mark the selection reliably, whatever value is chosen, because `color0` is a background shade by definition. The selection now takes a 3px border in `@selected`, the theme accent, which is the only palette entry guaranteed to contrast.

Unselected tiles carry a transparent border of the same width, so selecting one does not shift the grid.

## Wallpapers use three columns

Matching the theme grid. A theme ships at most four wallpapers, so the last row is often short; consistency with the theme picker was preferred over a tidier final row.

## Testing

No new checks. Both changes are presentational and the existing 36 checks still pass, including from a tree with no `.git`. Whether the border reads well is a judgement that needs a screen, and it was checked against a render before committing.