### PR TITLE
Deliver the picker style to existing installs

### DIFF
--- a/.config/rofi/theme-picker/style.rasi
+++ b/.config/rofi/theme-picker/style.rasi
@@ -69,7 +69,7 @@ listview {
 element {
     orientation:                 vertical;
     padding:                     6px;
-    border:                      3px;
+    border:                      4px;
     border-radius:               12px;
     border-color:                transparent;
     background-color:            transparent;

--- a/migrations/1788107915.sh
+++ b/migrations/1788107915.sh
@@ -1,0 +1,52 @@
+echo "Refresh the theme picker's rofi style so the selection is visible"
+
+# The picker marked its selection by filling the tile with @background-alt,
+# which the theme template generates from color0. Across the sixteen shipped
+# themes that sits under 1.5:1 against the panel in thirteen of them and is
+# exactly the panel colour in four, so the selection could not be seen. It now
+# takes a border in @selected, the accent, which is at least 3.86:1 everywhere.
+#
+# style.rasi lives in ~/.config, which updates never overwrite, so the change
+# reaches new installs and nobody else without this.
+#
+# The file is only replaced when it is byte-identical to something hyprsimple
+# shipped, which proves it was never edited.
+
+ROFI="$HOME/.config/rofi"
+user="$ROFI/theme-picker/style.rasi"
+shipped="$HYPRSIMPLE_PATH/.config/rofi/theme-picker/style.rasi"
+
+[[ -f $shipped ]] || exit 0
+
+# Nobody has it yet: install it rather than skipping.
+if [[ ! -f $user ]]; then
+  mkdir -p "$ROFI/theme-picker"
+  cp "$shipped" "$user"
+  echo "Installed $user"
+  exit 0
+fi
+
+cmp -s "$user" "$shipped" && exit 0
+
+# md5 of every style.rasi hyprsimple has shipped
+SHIPPED=(
+  "c7933f90c1015e0c62229280ae097e8f"
+  "e46ef3f79a8f839130a185fc8b45928d"
+)
+
+sum=$(md5sum "$user" | cut -d' ' -f1)
+for s in "${SHIPPED[@]}"; do
+  if [[ $sum == "$s" ]]; then
+    cp "$shipped" "$user"
+    echo "Updated $user"
+    exit 0
+  fi
+done
+
+echo ""
+echo "$user has your own edits, so it was left alone."
+echo "Its selection highlight may be invisible on most themes. To take"
+echo "hyprsimple's current version, keeping a backup of yours:"
+echo ""
+echo "    hyprsimple-refresh-config.sh rofi/theme-picker/style.rasi"
+echo ""


### PR DESCRIPTION
#34 fixed an invisible selection highlight and reached nobody.

## The gap

`.config/rofi/theme-picker/style.rasi` lives in `~/.config`, which updates deliberately never overwrite, and #34 shipped no migration. So the accent border went to new installs only. On an existing machine the live file was still:

```
element selected {
    background-color:            @background-alt;
    text-color:                  @foreground;
}
```

no border, and `@background-alt` is under 1.5:1 against the panel on 13 of the 16 themes, so the cursor could not be seen at all.

This is the same mistake as #30, which changed `config.jsonc` with no migration.

## The migration

Checksum-gated, the shape used since #26. It recognises both versions shipped so far, `c7933f90` from #31 and `e46ef3f7` from #34, replaces the file when it matches either, installs it when absent, and otherwise prints the refresh command and leaves it alone.

Verified against a copy of a real machine's file: `c7933f90` becomes the current version and the border appears. A second run changes nothing.

## The border is now 4px

It was 3px, and reviewing a render of it against a busy wallpaper it was still easy to miss. The colour was already the only defensible choice, `@selected` being the one palette entry above 3.86:1 on every theme, so thickness is the remaining lever.

## Testing

No new checks. The migration's behaviour was verified by dry run against a real file rather than a fixture, and the existing 36 checks still pass.