### PR TITLE
Follow release tags by default, with an opt-in branch channel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,3 +49,6 @@ jobs:
 
       - name: theme-picker-test
         run: bash test/theme-picker-test.sh
+
+      - name: update-channel-test
+        run: bash test/update-channel-test.sh

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -3,6 +3,12 @@
 # Update hyprsimple in place: pull the repo, refresh the helper scripts,
 # install any newly required packages, then run pending migrations.
 #
+# Which commits you get is the "channel". A fresh install follows release tags.
+# `hyprsimple-update <branch>` moves this install onto a branch and it stays
+# there, `hyprsimple-update --stable` moves it back onto releases. The channel
+# is remembered by git's own HEAD, so there is no state file to fall out of
+# sync with the checkout.
+#
 # Your ~/.config files are never overwritten here. When a default config has to
 # change, the matching migration says so and uses hyprsimple-refresh-config.sh,
 # which keeps a backup and shows you the diff.
@@ -17,6 +23,53 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 trap 'echo -e "\n${RED}Update failed. Fix the error above and run hyprsimple-update again.${NC}"' ERR
+
+usage() {
+  cat <<'EOF'
+Usage: hyprsimple-update [--stable | <branch>]
+
+  (no argument)  Update within the channel this install already follows:
+                 a release tag fetches the newest release, a branch pulls
+                 that branch.
+  --stable       Switch to the newest release tag, and stay on releases.
+  <branch>       Switch to that branch of origin, and stay on it.
+
+You only pass an argument when you want to change channel.
+EOF
+}
+
+CHANNEL_ARG=""
+case "${1-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --stable)
+    CHANNEL_ARG="--stable"
+    ;;
+  "") ;;
+  -*)
+    echo -e "${RED}Unknown option: $1${NC}" >&2
+    usage >&2
+    exit 1
+    ;;
+  *)
+    CHANNEL_ARG="$1"
+    ;;
+esac
+
+# The tag list cannot come from the local repository. The history-shrinking
+# migration deletes every tag ref, and the fetch refspec only covers branches,
+# so a shrunk install has no tags at all and never grows any on its own.
+# Sorted on a v-stripped key so a tag named 0.2.3 and one named v0.2.4 order by
+# their numbers. A plain `sort -V` puts every unprefixed tag below every
+# prefixed one, which is only accidentally right while the newest tag has a v.
+latest_release_tag() {
+  git -C "$HYPRSIMPLE_PATH" ls-remote --tags origin |
+    sed 's|.*refs/tags/||; s|\^{}$||' | sort -u |
+    awk '{ key = $0; sub(/^v/, "", key); print key "\t" $0 }' |
+    sort -V | tail -1 | cut -f2
+}
 
 if [[ ! -d $HYPRSIMPLE_PATH ]]; then
   echo -e "${RED}hyprsimple is not installed at $HYPRSIMPLE_PATH.${NC}"
@@ -35,13 +88,60 @@ if [[ -d $HYPRSIMPLE_PATH/.git ]]; then
     exit 1
   fi
 
-  branch=$(git -C "$HYPRSIMPLE_PATH" rev-parse --abbrev-ref HEAD)
-  git -C "$HYPRSIMPLE_PATH" pull --ff-only origin "$branch"
+  # symbolic-ref fails exactly when HEAD is detached, and HEAD is detached
+  # exactly when this install is sitting on a release tag.
+  current_branch=$(git -C "$HYPRSIMPLE_PATH" symbolic-ref --quiet --short HEAD) || current_branch=""
+
+  target="$CHANNEL_ARG"
+  if [[ -z $target ]]; then
+    if [[ -n $current_branch ]]; then target="$current_branch"; else target="--stable"; fi
+  fi
+
+  if [[ $target == "--stable" ]]; then
+    tag=$(latest_release_tag) || {
+      echo -e "${RED}Could not reach origin to list releases.${NC}"
+      exit 1
+    }
+    if [[ -z $tag ]]; then
+      echo -e "${RED}origin has no release tags. Use: hyprsimple-update main${NC}"
+      exit 1
+    fi
+    if [[ -n $current_branch ]]; then
+      echo -e "${YELLOW}Leaving branch $current_branch for releases.${NC}"
+    fi
+    # --depth 1 on every fetch: an install that was shrunk to a shallow clone
+    # must stay one, or the 165 MB that migration reclaimed comes straight back.
+    git -C "$HYPRSIMPLE_PATH" fetch --quiet --depth 1 origin tag "$tag" || {
+      echo -e "${RED}Could not fetch $tag from origin.${NC}"
+      exit 1
+    }
+    git -C "$HYPRSIMPLE_PATH" checkout --quiet --detach "$tag"
+    CHANNEL_LABEL="release $tag"
+  else
+    # No --depth here, unlike the tag path. On a shallow clone --depth 1 moves
+    # the shallow boundary to the new tip, which disconnects the commit this
+    # install is on and turns the fast-forward below into "refusing to merge
+    # unrelated histories". A plain fetch keeps the boundary and stays shallow.
+    if ! git -C "$HYPRSIMPLE_PATH" fetch --quiet origin "$target"; then
+      echo -e "${RED}origin has no branch called '$target'.${NC}"
+      exit 1
+    fi
+    if [[ $target == "$current_branch" ]]; then
+      # Staying put keeps today's guarantee that an update never discards a
+      # local commit.
+      git -C "$HYPRSIMPLE_PATH" merge --quiet --ff-only FETCH_HEAD
+    else
+      # Changing channel is an explicit instruction, so this one force-moves.
+      echo -e "${YELLOW}Switching from ${current_branch:-releases} to branch $target.${NC}"
+      git -C "$HYPRSIMPLE_PATH" checkout --quiet -B "$target" FETCH_HEAD
+    fi
+    CHANNEL_LABEL="branch $target"
+  fi
 else
   echo -e "${YELLOW}$HYPRSIMPLE_PATH is not a git checkout, skipping pull.${NC}"
 fi
 
-echo -e "${GREEN}Now on hyprsimple $(cat "$HYPRSIMPLE_PATH/version" 2>/dev/null || echo unknown)${NC}"
+echo -e "${GREEN}Now on hyprsimple $(cat "$HYPRSIMPLE_PATH/version" 2>/dev/null || echo unknown)${CHANNEL_LABEL:+ (${CHANNEL_LABEL})}${NC}"
 
 # ---- Helper scripts ------------------------------------------------------
 # These are program code, not user config, so they are replaced wholesale.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ hyprsimple-update
 This pulls the latest hyprsimple, refreshes the helper scripts in `~/.local/bin`,
 installs any newly required packages, and runs pending migrations.
 
+#### Releases or main
+
+A fresh install follows release tags, so `hyprsimple-update` on its own moves
+you from one release to the next and never to an untagged commit.
+
+```bash
+hyprsimple-update            # stay on the channel you are already on
+hyprsimple-update --stable   # switch to the newest release
+hyprsimple-update main       # switch to main, and stay there
+hyprsimple-update <branch>   # switch to any branch of origin, for testing
+```
+
+The choice sticks. Once you run `hyprsimple-update main`, every later bare
+`hyprsimple-update` pulls main until you run `hyprsimple-update --stable`. There
+is no config file behind this: the channel is whatever the checkout at
+`~/.local/share/hyprsimple` is on, which you can read with `hyprsimple-debug`.
+
+Tracking main gets you fixes the day they merge, at the cost of landing on
+commits no release has covered.
+
 **An update never edits your `~/.config` files on its own.** Only a migration
 does, and only when a default genuinely has to change. Every migration says what
 it touched.
@@ -280,7 +300,7 @@ Most are wired to keybindings or waybar; all can also be run directly from a ter
 
 | Script | Description |
 |--------|-------------|
-| `hyprsimple-update.sh` | Pull hyprsimple, refresh scripts and packages, run pending migrations |
+| `hyprsimple-update.sh` | Pull hyprsimple, refresh scripts and packages, run pending migrations. `--stable` or `<branch>` switches channel |
 | `hyprsimple-migrate.sh` | Run any migrations that have not run on this machine yet |
 | `hyprsimple-refresh-config.sh` | Reset one `~/.config` file to the shipped default, with a backup and a diff |
 | `hyprsimple-refresh-waybar.sh` | Reset waybar's config and style, keeping your bar position |

--- a/install.sh
+++ b/install.sh
@@ -416,9 +416,36 @@ install_to_canonical_path() {
   echo -e "${GREEN}hyprsimple installed to $HYPRSIMPLE_PATH${NC}"
 }
 
+# New installs follow release tags rather than the tip of main, so a user who
+# never passes an argument to hyprsimple-update only ever sees tagged versions.
+# A source checkout on anything other than main is somebody testing a branch,
+# and every failure here leaves the install on the branch it already had.
+follow_latest_release() {
+  [[ -d $HYPRSIMPLE_PATH/.git ]] || return 0
+
+  local branch
+  branch=$(git -C "$HYPRSIMPLE_PATH" symbolic-ref --quiet --short HEAD) || return 0
+  [[ $branch == main ]] || return 0
+
+  local tag
+  tag=$(git -C "$HYPRSIMPLE_PATH" ls-remote --tags origin 2>/dev/null |
+    sed 's|.*refs/tags/||; s|\^{}$||' | sort -u |
+    awk '{ key = $0; sub(/^v/, "", key); print key "\t" $0 }' |
+    sort -V | tail -1 | cut -f2) || return 0
+  [[ -n $tag ]] || return 0
+
+  # --depth 1 so this never undoes the history-shrinking migration.
+  git -C "$HYPRSIMPLE_PATH" fetch --quiet --depth 1 origin tag "$tag" 2>/dev/null || return 0
+  git -C "$HYPRSIMPLE_PATH" checkout --quiet --detach "$tag" 2>/dev/null || return 0
+
+  echo -e "${GREEN}Following releases, now on $tag.${NC}"
+  echo "Run 'hyprsimple-update main' if you would rather track main."
+}
+
 echo ""
 echo -e "${YELLOW}Installing hyprsimple to $HYPRSIMPLE_PATH...${NC}"
 install_to_canonical_path
+follow_latest_release
 
 # A fresh install already ships every fix, so mark all migrations as done and
 # let new users skip the entire history.

--- a/test/update-channel-test.sh
+++ b/test/update-channel-test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Checks the update channels in hyprsimple-update.sh: a bare run continues the
+# channel the install is already on, --stable moves it to the newest release
+# tag, and a branch name moves it to that branch and keeps it there.
+#
+# Everything happens against throwaway file:// origins under a temp directory.
+# The real install at ~/.local/share/hyprsimple is never read or written, and
+# HOME is redirected so the script's own helper-script refresh cannot escape.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE="$REPO/.local/bin/hyprsimple-update.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# hyprsimple-update ends by reloading Hyprland and running the migration
+# runner. Neither belongs in this test, and pgrep unstubbed would find the real
+# compositor on the machine running the suite.
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+printf '#!/bin/bash\nexit 1\n' >"$STUB/pgrep"
+printf '#!/bin/bash\nexit 0\n' >"$STUB/hyprctl"
+chmod +x "$STUB/pgrep" "$STUB/hyprctl"
+
+FAKE_HOME="$TMP/home"
+mkdir -p "$FAKE_HOME/.local/bin"
+printf '#!/bin/bash\nexit 0\n' >"$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"
+chmod +x "$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"
+
+ORIGIN="$TMP/origin.git"
+WORK="$TMP/work"
+INSTALL="$TMP/install"
+
+commit_version() {
+  printf '%s\n' "$1" >"$WORK/version"
+  git -C "$WORK" add version
+  git -C "$WORK" commit -qm "version $1"
+}
+
+git init -q --bare "$ORIGIN"
+git -C "$ORIGIN" symbolic-ref HEAD refs/heads/main
+git clone -q "$ORIGIN" "$WORK" 2>/dev/null
+git -C "$WORK" config user.email test@example.com
+git -C "$WORK" config user.name test
+
+commit_version 0.1.0
+git -C "$WORK" tag v0.1.0
+commit_version 0.2.3
+# Deliberately unprefixed, matching the real 0.2.3 tag. The sort must order it
+# by number, not put it below every v-prefixed tag.
+git -C "$WORK" tag 0.2.3
+commit_version 0.3.0
+git -C "$WORK" tag v0.3.0
+commit_version 0.4.0-dev
+git -C "$WORK" push -q origin main --tags
+
+# The install as the shrinking migration leaves it: shallow, and with every tag
+# ref deleted. Tag resolution has to work from this state.
+git clone -q --depth 1 "file://$ORIGIN" "$INSTALL"
+git -C "$INSTALL" for-each-ref --format='%(refname)' refs/tags |
+  while read -r r; do git -C "$INSTALL" update-ref -d "$r"; done
+
+run_update() {
+  HOME="$FAKE_HOME" HYPRSIMPLE_PATH="$INSTALL" PATH="$STUB:$PATH" \
+    bash "$UPDATE" "$@" >"$TMP/out" 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+rc() { cat "$TMP/rc"; }
+installed_version() { cat "$INSTALL/version"; }
+head_state() { git -C "$INSTALL" symbolic-ref --quiet --short HEAD || echo DETACHED; }
+
+check "fixture starts on main" "$(head_state)" main
+check "fixture starts at main tip" "$(installed_version)" 0.4.0-dev
+check "fixture has no local tags" "$(git -C "$INSTALL" tag | wc -l)" 0
+
+# --- bare run on a branch stays on that branch ------------------------------
+run_update
+check "bare run on a branch exits 0" "$(rc)" 0
+check "bare run on a branch stays on main" "$(head_state)" main
+
+# --- --stable moves to the newest tag ---------------------------------------
+run_update --stable
+check "--stable exits 0" "$(rc)" 0
+check "--stable detaches HEAD" "$(head_state)" DETACHED
+check "--stable picks the newest tag, not the newest v-tag" "$(installed_version)" 0.3.0
+check "--stable lands exactly on the tag" "$(git -C "$INSTALL" describe --tags)" v0.3.0
+if grep -q "Leaving branch main for releases" "$TMP/out"; then
+  pass "--stable says it is leaving the branch"
+else fail "--stable says it is leaving the branch"; fi
+
+# --- a bare run on a tag follows new releases -------------------------------
+commit_version 0.5.0
+git -C "$WORK" tag v0.5.0
+git -C "$WORK" push -q origin main --tags
+
+run_update
+check "bare run on a tag exits 0" "$(rc)" 0
+check "bare run on a tag stays detached" "$(head_state)" DETACHED
+check "bare run on a tag moves to the new release" "$(installed_version)" 0.5.0
+
+# --- a branch argument moves back, and sticks -------------------------------
+commit_version 0.6.0-dev
+git -C "$WORK" push -q origin main
+
+run_update main
+check "branch argument exits 0" "$(rc)" 0
+check "branch argument attaches HEAD" "$(head_state)" main
+check "branch argument lands on the branch tip" "$(installed_version)" 0.6.0-dev
+
+commit_version 0.7.0-dev
+git -C "$WORK" push -q origin main
+run_update
+check "the branch choice sticks across a bare run" "$(head_state)" main
+check "a later bare run pulls the branch, not the tag" "$(installed_version)" 0.7.0-dev
+
+# --- an arbitrary branch, not just main -------------------------------------
+git -C "$WORK" checkout -q -b feature-x
+commit_version 0.8.0-feature
+git -C "$WORK" push -q origin feature-x
+git -C "$WORK" checkout -q main
+
+run_update feature-x
+check "an arbitrary branch is accepted" "$(rc)" 0
+check "an arbitrary branch is checked out" "$(head_state)" feature-x
+check "an arbitrary branch brings its content" "$(installed_version)" 0.8.0-feature
+
+# --- failure modes ----------------------------------------------------------
+before=$(git -C "$INSTALL" rev-parse HEAD)
+run_update no-such-branch
+check "an unknown branch fails" "$(rc)" 1
+check "an unknown branch leaves the install alone" "$(git -C "$INSTALL" rev-parse HEAD)" "$before"
+if grep -q "no branch called 'no-such-branch'" "$TMP/out"; then
+  pass "an unknown branch is named in the error"
+else fail "an unknown branch is named in the error"; fi
+
+run_update --nonsense
+check "an unknown option fails" "$(rc)" 1
+run_update --help
+check "--help exits 0" "$(rc)" 0
+
+# --- the shrink must survive all of it --------------------------------------
+check "the install is still shallow" "$(git -C "$INSTALL" rev-parse --is-shallow-repository)" true
+
+if ((failures > 0)); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`hyprsimple-update` pulled whatever branch the install happened to be on, which was always `main`. Every user tracked untagged commits, and the GitHub releases were connected to nothing.

An install now has a **channel**.

```bash
hyprsimple-update            # continue the channel you are on
hyprsimple-update --stable   # switch to the newest release
hyprsimple-update main       # switch to main, and stay there
hyprsimple-update <branch>   # any branch of origin, for testing
```

The channel is git's own HEAD: detached means releases, attached means that branch. There is no state file to fall out of sync with the checkout. `install.sh` now lands new installs on the newest tag, but only when the source checkout is on `main`, so a contributor installing from a feature branch stays on it.

## Three things the history-shrinking migration forced

Each of these was found by running it, not by reasoning about it.

**The tag list comes from `git ls-remote`, not from the local repository.** Migration `1788011545.sh` deletes every tag ref, and the fetch refspec covers only branches, so a shrunk install has no tags at all and never grows any on its own.

**The tag path fetches with `--depth 1`, the branch path does not.** On a shallow clone `--depth 1` moves the shallow boundary to the new tip, which disconnects the commit the install is sitting on:

```
=== A: fetch --depth 1, then merge --ff-only ===
fatal: refusing to merge unrelated histories
    rc=128
=== B: fetch with NO depth, then merge --ff-only ===
Updating 6285a3b..81e46e1
Fast-forward
    rc=0
    shallow=true commits=2 size=152KB
```

A plain fetch keeps the boundary and the clone stays shallow, which is what the original `git pull` was doing.

**Tags sort on a `v`-stripped key.** A plain `sort -V` puts every unprefixed tag below every prefixed one, so the published `0.2.3` loses to `v0.1.0`:

```
old: v0.2.0
new: 0.2.3
```

That is only accidentally right today because the newest tag happens to carry a `v`. This removes the need to retag `0.2.3`.

## What is preserved

The `status --porcelain` guard runs before anything else, unchanged. Staying on your current branch still uses `merge --ff-only`, so an update cannot discard a local commit. Switching channel is an explicit instruction, so it force-moves and prints that it is doing so. No `.config/` file changes, so no migration is needed.

## Verification

New `test/update-channel-test.sh`, 27 checks against throwaway `file://` origins, with `HOME` and `PATH` redirected so the real install and the running compositor are never touched. All 27 pass, and the full suite of 10 test files passes.

Deleting the feature turns the checks red, which is the part that matters:

- drop the tag checkout: 4 checks fail
- ignore stickiness and always go stable: 4 checks fail, including `a later bare run pulls the branch, not the tag (want 0.7.0-dev, got 0.5.0)`

Smoke-tested against the real origin, whose tag list contains the unprefixed `0.2.3`:

```
=== --stable against the REAL origin ===
Leaving branch main for releases.
Now on hyprsimple 0.3.0 (release v0.3.0)
  -> describe: v0.3.0   shallow: true   .git: 19 MB
=== back to main ===
Switching from releases to branch main.
Now on hyprsimple 0.3.0 (branch main)
  -> branch: main       shallow: true   .git: 19 MB
```

## One consequence

Existing installs are on `main` and stay there, by design: nothing silently moves you backwards onto an older tag under migrations that already ran. The first update after this merges still pulls `main` and only then drops the new script into `~/.local/bin`, so the flags arrive on the run after that. `hyprsimple-update --stable` switches whenever you want.

## Known limitation

An install sitting on a tag has a detached HEAD, and `migrations/1788011545.sh` exits early on detached HEAD. Harmless now, since every existing install has that marker and `install.sh` pre-creates it, but future migrations must not assume a branch.