### PR TITLE
Force the tag fetch, so a re-pointed release actually lands

### DIFF
--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -109,9 +109,14 @@ if [[ -d $HYPRSIMPLE_PATH/.git ]]; then
     if [[ -n $current_branch ]]; then
       echo -e "${YELLOW}Leaving branch $current_branch for releases.${NC}"
     fi
-    # --depth 1 on every fetch: an install that was shrunk to a shallow clone
-    # must stay one, or the 165 MB that migration reclaimed comes straight back.
-    git -C "$HYPRSIMPLE_PATH" fetch --quiet --depth 1 origin tag "$tag" || {
+    # --depth 1: an install that was shrunk to a shallow clone must stay one, or
+    # the 165 MB that migration reclaimed comes straight back.
+    #
+    # --force: a tag that already exists locally is never updated without it.
+    # git prints "! [rejected] (would clobber existing tag)" and still exits 0,
+    # so a re-pointed release would leave the install on the old commit while
+    # this script reported success.
+    git -C "$HYPRSIMPLE_PATH" fetch --quiet --force --depth 1 origin tag "$tag" || {
       echo -e "${RED}Could not fetch $tag from origin.${NC}"
       exit 1
     }

--- a/install.sh
+++ b/install.sh
@@ -434,8 +434,10 @@ follow_latest_release() {
     sort -V | tail -1 | cut -f2) || return 0
   [[ -n $tag ]] || return 0
 
-  # --depth 1 so this never undoes the history-shrinking migration.
-  git -C "$HYPRSIMPLE_PATH" fetch --quiet --depth 1 origin tag "$tag" 2>/dev/null || return 0
+  # --depth 1 so this never undoes the history-shrinking migration. --force
+  # because .git is copied from the source clone, which may carry a stale tag of
+  # the same name, and git leaves such a tag alone while still exiting 0.
+  git -C "$HYPRSIMPLE_PATH" fetch --quiet --force --depth 1 origin tag "$tag" 2>/dev/null || return 0
   git -C "$HYPRSIMPLE_PATH" checkout --quiet --detach "$tag" 2>/dev/null || return 0
 
   echo -e "${GREEN}Following releases, now on $tag.${NC}"

--- a/test/update-channel-test.sh
+++ b/test/update-channel-test.sh
@@ -107,6 +107,18 @@ check "bare run on a tag exits 0" "$(rc)" 0
 check "bare run on a tag stays detached" "$(head_state)" DETACHED
 check "bare run on a tag moves to the new release" "$(installed_version)" 0.5.0
 
+# --- a re-pointed release reaches an install already holding that tag -------
+# git refuses to update an existing tag without --force, prints
+# "! [rejected] (would clobber existing tag)", and still exits 0. Without the
+# force flag this check passes its exit code and fails on content.
+commit_version 0.5.0-hotfix
+git -C "$WORK" tag -f v0.5.0 >/dev/null 2>&1
+git -C "$WORK" push -q --force origin v0.5.0
+
+run_update
+check "a moved tag exits 0" "$(rc)" 0
+check "a moved tag actually updates the install" "$(installed_version)" 0.5.0-hotfix
+
 # --- a branch argument moves back, and sticks -------------------------------
 commit_version 0.6.0-dev
 git -C "$WORK" push -q origin main


### PR DESCRIPTION
Found while preparing to move `v0.3.0` onto the commit that merged #40.

Moving a published tag is a normal release operation, and the channel code from #40 could not follow one. Git refuses to update a tag that already exists locally, and it does so **without failing**:

```
--- non-forced tag fetch after the tag moved ---
     ! [rejected] v1         -> v1  (would clobber existing tag)
    rc=0
    content now: A   (want B)
--- forced ---
    content now: B   (want B)
```

Exit code 0. `hyprsimple-update` would have printed `hyprsimple is up to date` while leaving the install on the old commit.

## Fix

Both tag fetches now pass `--force`. `install.sh` needs it as well, because `.git` is copied wholesale from the source clone and can carry a stale tag of the same name.

The branch path is unaffected: it never fetches a tag.

## Verification

New check in `test/update-channel-test.sh` that re-points a tag in the fixture and asserts the install follows it. Suite is now 29 checks, all pass.

Removing `--force` turns it red:

```
not ok - a moved tag exits 0 (want 0, got 1)
not ok - a moved tag actually updates the install (want 0.5.0-hotfix, got 0.5.0)
```