### PR TITLE
Make the updater survive updating itself, and isolate the rofi smoke suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,3 +58,6 @@ jobs:
 
       - name: rofi-split-migration-test
         run: bash test/rofi-split-migration-test.sh
+
+      - name: update-self-replace-test
+        run: bash test/update-self-replace-test.sh

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -158,8 +158,20 @@ for script in "$HYPRSIMPLE_PATH/.local/bin"/*.sh "$HYPRSIMPLE_PATH/.local/bin"/*
   [[ -f $script ]] || continue
   target="$HOME/.local/bin/$(basename "$script")"
   if ! cmp -s "$script" "$target"; then
-    cp -f "$script" "$target"
-    chmod +x "$target"
+    # Write beside the target and rename, rather than cp -f over it.
+    #
+    # One of these scripts is this one. cp -f rewrites the same inode, and bash
+    # reads a script incrementally by byte offset, so the running shell would
+    # resume at its old offset inside the new, longer file and land mid-word.
+    # That is a real failure seen in the wild: "line 61: he: command not found",
+    # after which the pull had already happened but the migrations never ran.
+    #
+    # A rename gives the new content a different inode. The running shell keeps
+    # reading the old one through the descriptor it already holds, finishes
+    # normally, and the next run picks up the new version.
+    cp -f "$script" "$target.new"
+    chmod +x "$target.new"
+    mv -f "$target.new" "$target"
     echo -e "${GREEN}Updated:${NC} $(basename "$script")"
   fi
 done

--- a/test/rofi-split-smoke.sh
+++ b/test/rofi-split-smoke.sh
@@ -26,6 +26,13 @@ must_be_fixture() {
   fi
 }
 
+# rofi searches the XDG config dir for a relative @import before it falls back
+# to the working directory, so without this the fixture's imports resolve
+# against the maintainer's real ~/.config/rofi. That made these checks pass for
+# the wrong reason until a real install grew a hyprsimple link and they started
+# reading it instead.
+export XDG_CONFIG_HOME=""
+
 # rofi is not installed on the CI runner. The checks that need it are skipped
 # there rather than silently passing, so a local run stays the stronger one.
 HAVE_ROFI=0
@@ -82,7 +89,7 @@ if [[ $HAVE_ROFI == 1 ]]; then
   # A property rofi knows. -dump-theme silently drops unknown custom
   # properties, so asserting on an invented one would pass against anything.
   printf 'window { width: 321px; }\n' >>"$INSTALL/default/rofi/theme-picker/style.rasi"
-  got=$(cd "$FAKE_HOME/.config/rofi" && HOME="$FAKE_HOME" rofi -no-config -dump-theme \
+  got=$(cd "$FAKE_HOME/.config/rofi" && HOME="$FAKE_HOME" XDG_CONFIG_HOME="$FAKE_HOME/.config" rofi -no-config -dump-theme \
     -theme "$FAKE_HOME/.config/rofi/theme-picker/style.rasi" 2>/dev/null |
     sed -n 's/^[[:space:]]*width:[[:space:]]*\([0-9]*\)px.*/\1/p' | head -1)
   check "a default changed in the install is live through the stub" "$got" "321"
@@ -91,7 +98,7 @@ if [[ $HAVE_ROFI == 1 ]]; then
 
   printf 'window { width: 999px; }\n' >>"$FAKE_HOME/.config/rofi/theme-picker/style.rasi"
   printf 'window { height: 654px; }\n' >>"$INSTALL/default/rofi/theme-picker/style.rasi"
-  out=$(cd "$FAKE_HOME/.config/rofi" && HOME="$FAKE_HOME" rofi -no-config -dump-theme \
+  out=$(cd "$FAKE_HOME/.config/rofi" && HOME="$FAKE_HOME" XDG_CONFIG_HOME="$FAKE_HOME/.config" rofi -no-config -dump-theme \
     -theme "$FAKE_HOME/.config/rofi/theme-picker/style.rasi" 2>/dev/null)
   check "the stub's own override wins over the default" \
     "$(sed -n 's/^[[:space:]]*width:[[:space:]]*\([0-9]*\)px.*/\1/p' <<<"$out" | head -1)" "999"

--- a/test/update-self-replace-test.sh
+++ b/test/update-self-replace-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# hyprsimple-update.sh refreshes ~/.local/bin, and one of the scripts it
+# refreshes is itself. This suite pins the property that makes that survivable:
+# a script is replaced by rename, not rewritten in place, so a running shell
+# keeps reading the version it started with.
+# Never touches the real ~/.local/bin.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE="$REPO/.local/bin/hyprsimple-update.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- 1. the refresh loop replaces by rename, not in place ------------------
+#
+# An inode-preserving write is what corrupts a running script. Asserting on the
+# mechanism rather than on a message keeps this readable when the wording of
+# the loop changes.
+
+refresh_block=$(sed -n '/Refreshing helper scripts/,/^done$/p' "$UPDATE")
+check "the refresh loop renames into place" \
+  "$(grep -c 'mv -f' <<<"$refresh_block")" "1"
+check "the refresh loop does not cp directly over the target" \
+  "$(grep -cE '^\s*cp -f "\$script" "\$target"\s*$' <<<"$refresh_block")" "0"
+
+# --- 2. the behaviour itself, against a real self-replacing script ---------
+#
+# The property under test is bash's, not hyprsimple's, so the check runs it
+# rather than trusting either. The replacement is deliberately longer than the
+# original, because an equal-length one cannot shift the read offset and so
+# cannot fail.
+
+mkdir -p "$TMP/bin"
+cat >"$TMP/new.sh" <<'NEW'
+# a longer header, so every byte offset below it shifts
+# padding padding padding padding padding padding padding
+# padding padding padding padding padding padding padding
+echo "REPLACEMENT"
+NEW
+
+# in place, the way cp -f behaves: the tail of the running script is corrupted
+cat >"$TMP/bin/inplace.sh" <<'INPLACE'
+cp -f "$TMP_DIR/new.sh" "$0"
+echo "TAIL-REACHED"
+INPLACE
+inplace_out=$(TMP_DIR="$TMP" bash "$TMP/bin/inplace.sh" 2>&1)
+check "an in-place rewrite corrupts the running script" \
+  "$(grep -c 'TAIL-REACHED' <<<"$inplace_out")" "0"
+
+# by rename, the way the fix behaves: the running script finishes intact
+cat >"$TMP/bin/rename.sh" <<'RENAME'
+cp -f "$TMP_DIR/new.sh" "$0.new" && mv -f "$0.new" "$0"
+echo "TAIL-REACHED"
+RENAME
+rename_out=$(TMP_DIR="$TMP" bash "$TMP/bin/rename.sh" 2>&1)
+check "a rename lets the running script finish" \
+  "$(grep -c 'TAIL-REACHED' <<<"$rename_out")" "1"
+check "and the new version is what landed on disk" \
+  "$(grep -c 'REPLACEMENT' "$TMP/bin/rename.sh")" "1"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Two bugs found by running `hyprsimple-update` against a real install after #42, rather than against fixtures.

## The updater corrupted itself

`hyprsimple-update.sh` refreshes every script in `~/.local/bin`, and one of those scripts is itself. `cp -f` rewrites the same inode, and bash reads a script incrementally by byte offset, so the running shell resumed at its old offset inside the new, longer file and landed mid-word.

Observed on a real update as `line 61: he: command not found`. The pull had already succeeded at that point, so the install moved forward while the migrations never ran. The next run worked, because the new script was already on disk, and that self-healing is why this survived unnoticed.

Reduced to a four-line reproduction, which fails the same way and produces the same shape of error from a word fragment. Writing beside the target and renaming fixes it: the rename gives the new content a different inode, and the running shell keeps reading the old one through the descriptor it already holds.

Worth knowing: this fix arrives through the broken code. The update that first delivers it is still performed by the old script, so that one run can still fail and want a second. Every run after it is clean.

No migration, because `~/.local/bin` is refreshed by the updater itself rather than being user space.

## The rofi smoke suite was not hermetic

rofi searches the XDG config dir for a relative `@import` before falling back to the working directory. The fixture's stubs import `"hyprsimple/..."`, which their own directory does not contain, so resolution reached the real `~/.config/rofi` instead of the fixture.

This was invisible while no real install had a `hyprsimple` link: the lookup fell through to the working directory and found the fixture, so the checks passed for the wrong reason. The first machine to run #42's migration grew that link, and the same unchanged suite started reading the real config and failing.

Pointing `XDG_CONFIG_HOME` at the fixture fixes it. Breaking the fixture's own link now turns seven checks red where it turned four before, which is the difference between gating on the fixture and gating on whatever happens to be installed.

## Testing

New `test/update-self-replace-test.sh`, wired into the workflow by name. It pins the mechanism rather than a message: the refresh loop renames into place and does not `cp` over the target, and it runs a real self-replacing script both ways to show the in-place version corrupts and the rename version does not. Reverting the fix turns it red.

All 14 suites pass.

## Verified on a live install

#42's migration ran on a real machine and converted all five rofi files. The effective rofi config and all three theme files resolve identically to their pre-split versions, and editing a default in the install changed the live value with no migration, then reverted cleanly.