### PR TITLE
Deliver theme templates from the install instead of the home directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,3 +61,6 @@ jobs:
 
       - name: update-self-replace-test
         run: bash test/update-self-replace-test.sh
+
+      - name: template-delivery-test
+        run: bash test/template-delivery-test.sh

--- a/.local/bin/hyprsimple-theme-picker.sh
+++ b/.local/bin/hyprsimple-theme-picker.sh
@@ -25,7 +25,9 @@ swatches_for() {
 
 for dir in "$THEMES_DIR"/*/; do
   name=$(basename "$dir")
-  [[ $name == templates ]] && continue
+  # templates holds the render inputs and templates.user holds a user's
+  # overrides of them. Neither is a theme.
+  [[ $name == templates || $name == templates.user ]] && continue
 
   wallpaper=$(find "$dir/backgrounds" -maxdepth 1 -type f \
     \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | sort | head -n 1)

--- a/.local/bin/theme-apply-templates.sh
+++ b/.local/bin/theme-apply-templates.sh
@@ -4,7 +4,40 @@
 # Reads colors.toml from theme dir, processes templates, outputs generated configs
 
 THEME_DIR="$1"
-TEMPLATES_DIR="$HOME/.config/hypr/themes/templates"
+# Templates are build inputs, not config, so the install owns them and a change
+# to one reaches every user through hyprsimple-update alone. No migration.
+#
+# The install always wins over ~/.config/hypr/themes/templates. install.sh
+# copied every template into every existing home, and a stale copy cannot be
+# told apart from a customised one by comparing it to the current shipped file:
+# both simply differ. Honouring the home directory would therefore leave every
+# existing install pinned to the templates it was installed with, which is the
+# gap this closes.
+#
+# An override lives in templates.user/ instead, where its presence is a
+# deliberate act rather than a leftover.
+TEMPLATES_DIR="${HYPRSIMPLE_PATH:-$HOME/.local/share/hyprsimple}/.config/hypr/themes/templates"
+USER_TEMPLATES_DIR="$HOME/.config/hypr/themes/templates.user"
+STALE_TEMPLATES_DIR="$HOME/.config/hypr/themes/templates"
+
+# Resolve one template name to the file to render.
+template_path() {
+  local name="$1"
+  [[ -f $USER_TEMPLATES_DIR/$name ]] && { printf '%s' "$USER_TEMPLATES_DIR/$name"; return 0; }
+  [[ -f $TEMPLATES_DIR/$name ]] && printf '%s' "$TEMPLATES_DIR/$name"
+}
+
+# A home template that differs from the shipped one was probably edited on
+# purpose, and is now being ignored. Say so rather than change the result
+# silently. Identical leftovers are not worth mentioning.
+warn_about_stale() {
+  local name="$1" stale="$STALE_TEMPLATES_DIR/$1"
+  [[ -f $stale && -f $TEMPLATES_DIR/$name ]] || return 0
+  cmp -s "$stale" "$TEMPLATES_DIR/$name" && return 0
+  [[ -f $USER_TEMPLATES_DIR/$name ]] && return 0
+  echo "Note: $stale differs from hyprsimple's and is no longer used." >&2
+  echo "      Move it to $USER_TEMPLATES_DIR/ to keep it." >&2
+}
 COLORS_FILE="$THEME_DIR/colors.toml"
 
 if [[ ! -f $COLORS_FILE ]]; then
@@ -38,10 +71,19 @@ done <"$COLORS_FILE" >"$sed_script"
 # Generate configs from templates
 mkdir -p "$THEME_DIR/generated"
 
-for tpl in "$TEMPLATES_DIR"/*.tpl; do
-  filename=$(basename "$tpl" .tpl)
-  sed -f "$sed_script" "$tpl" >"$THEME_DIR/generated/$filename"
-done
+# The union of the install and the override directory, so a template added to
+# the repository renders without the user having anything at all.
+while IFS= read -r name; do
+  warn_about_stale "$name"
+  tpl=$(template_path "$name")
+  [[ -n $tpl ]] || continue
+  sed -f "$sed_script" "$tpl" >"$THEME_DIR/generated/${name%.tpl}"
+done < <(
+  {
+    [[ -d $TEMPLATES_DIR ]] && ls "$TEMPLATES_DIR" 2>/dev/null | grep '\.tpl$'
+    [[ -d $USER_TEMPLATES_DIR ]] && ls "$USER_TEMPLATES_DIR" 2>/dev/null | grep '\.tpl$'
+  } | sort -u
+)
 
 rm "$sed_script"
 echo "Templates generated in $THEME_DIR/generated/"

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ hyprsimple-refresh-config rofi/config.rasi
 the active theme and their styles are rewritten on every theme switch, so they
 belong to the theme rather than to you.
 
+#### Theme templates
+
+Themes are rendered from the `.tpl` files in `~/.local/share/hyprsimple/.config/hypr/themes/templates`, and the install owns them, so a template change reaches you through `hyprsimple-update` with no migration.
+
+To change one, copy it to `~/.config/hypr/themes/templates.user/` under the same name and edit it there. That directory wins over the install, and a file in it with no shipped counterpart is rendered too, so you can add templates of your own.
+
+Older installs have a copy of the templates at `~/.config/hypr/themes/templates`. That directory is no longer read. If a file in it differs from the shipped one, the theme switcher says so and tells you where to move it.
+
 ## Network
 
 To see the available network interfaces, run `wifi`. To connect to a network, run `wifi <network name>` for example `wifi "MY NETWORK"`

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -144,11 +144,15 @@ check "switching to a colourless theme removes the drop-in" \
 
 # ---- theme-apply-templates.sh renders a [global] frame_color ------------
 
+# The renderer reads templates from the install, not from the home directory,
+# so the fixture install is where this one goes.
 tpl_home="$TMP/template-home"
+tpl_inst="$TMP/template-install"
 must_be_fixture "$tpl_home"
-mkdir -p "$tpl_home/.config/hypr/themes/templates"
+must_be_fixture "$tpl_inst"
+mkdir -p "$tpl_home/.config/hypr" "$tpl_inst/.config/hypr/themes/templates"
 cp "$REPO/.config/hypr/themes/templates/dunst-colors.tpl" \
-  "$tpl_home/.config/hypr/themes/templates/"
+  "$tpl_inst/.config/hypr/themes/templates/"
 
 tpl_theme="$TMP/template-theme"
 mkdir -p "$tpl_theme"
@@ -160,7 +164,7 @@ color1 = "#f38ba8"
 color7 = "#bac2de"
 EOF
 
-HOME="$tpl_home" bash "$TEMPLATER" "$tpl_theme" >"$TMP/tpl_out" 2>&1
+HOME="$tpl_home" HYPRSIMPLE_PATH="$tpl_inst" bash "$TEMPLATER" "$tpl_theme" >"$TMP/tpl_out" 2>&1
 check "theme-apply-templates.sh exits 0" "$?" "0"
 
 rendered="$tpl_theme/generated/dunst-colors"

--- a/test/template-delivery-test.sh
+++ b/test/template-delivery-test.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Checks that theme templates are delivered from the install rather than from
+# whatever a home directory happens to hold, while a genuinely customised home
+# template still wins. Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RENDER="$REPO/.local/bin/theme-apply-templates.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+# One install, one template, one colour. Every case below renders a theme and
+# reads the rendered file, never the renderer's own text: a grep for a path
+# would prove the line exists, not that resolution works.
+new_case() {
+  local name="$1"
+  CASE="$TMP/$name"
+  must_be_fixture "$CASE"
+  INST="$CASE/install"
+  HOMEDIR="$CASE/home"
+  THEME="$CASE/theme"
+  mkdir -p "$INST/.config/hypr/themes/templates" "$HOMEDIR/.config/hypr" "$THEME"
+  printf 'background = "#111111"\n' >"$THEME/colors.toml"
+}
+
+render() {
+  HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INST" bash "$RENDER" "$THEME" >"$CASE/out" 2>&1
+  printf '%s' "$?" >"$CASE/rc"
+}
+
+rendered() { cat "$THEME/generated/$1" 2>/dev/null; }
+
+# --- 1. a template only the install has -----------------------------------
+
+new_case only-install
+printf 'FROM-INSTALL {{ background }}\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+check "a template only the install has is rendered" "$(rendered probe)" "FROM-INSTALL #111111"
+check "the renderer exits 0" "$(cat "$CASE/rc")" "0"
+
+# --- 2. a changed install template reaches a home that has no copy ---------
+
+new_case changed-install
+printf 'V1\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+first=$(rendered probe)
+printf 'V2\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+check "a template changed in the install is delivered, no migration" \
+  "$first -> $(rendered probe)" "V1 -> V2"
+
+# --- 3. a home copy identical to the shipped one must not pin the install --
+#
+# install.sh copied every template into every existing home, so treating any
+# home copy as an override would leave every existing install frozen. This is
+# the check the whole change exists for.
+
+new_case identical-copy
+mkdir -p "$HOMEDIR/.config/hypr/themes/templates"
+printf 'V1\n' >"$HOMEDIR/.config/hypr/themes/templates/probe.tpl"
+printf 'V2\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+check "a stale home copy does not shadow the install" "$(rendered probe)" "V2"
+check "and the user is told it is being ignored" \
+  "$(grep -c 'no longer used' "$CASE/out")" "1"
+
+new_case identical-leftover
+mkdir -p "$HOMEDIR/.config/hypr/themes/templates"
+printf 'V1\n' >"$HOMEDIR/.config/hypr/themes/templates/probe.tpl"
+printf 'V1\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+check "an identical leftover is not warned about" \
+  "$(grep -c 'no longer used' "$CASE/out")" "0"
+
+# --- 4. a genuinely customised home template still wins --------------------
+
+new_case customised
+mkdir -p "$HOMEDIR/.config/hypr/themes/templates.user"
+printf 'SHIPPED\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+printf 'MINE {{ background }}\n' >"$HOMEDIR/.config/hypr/themes/templates.user/probe.tpl"
+render
+check "a templates.user override wins over the install" "$(rendered probe)" "MINE #111111"
+
+new_case user-only
+mkdir -p "$HOMEDIR/.config/hypr/themes/templates.user"
+printf 'ONLY-MINE\n' >"$HOMEDIR/.config/hypr/themes/templates.user/extra.tpl"
+printf 'S\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+check "a templates.user file with no shipped counterpart renders" "$(rendered extra)" "ONLY-MINE"
+
+# --- 5. a home with no template directory at all ---------------------------
+
+new_case no-home-dir
+printf 'A\n' >"$INST/.config/hypr/themes/templates/a.tpl"
+printf 'B\n' >"$INST/.config/hypr/themes/templates/b.tpl"
+render
+check "every install template renders with no home directory" \
+  "$(rendered a)$(rendered b)" "AB"
+
+# --- 6. a template added to the install, home dir exists but lacks it ------
+
+new_case added-template
+mkdir -p "$HOMEDIR/.config/hypr/themes/templates"
+printf 'OLD\n' >"$INST/.config/hypr/themes/templates/old.tpl"
+printf 'NEW\n' >"$INST/.config/hypr/themes/templates/new.tpl"
+render
+check "a newly shipped template renders without a home copy" "$(rendered new)" "NEW"
+
+# --- 7. every real shipped template still renders --------------------------
+
+new_case real-templates
+cp "$REPO/.config/hypr/themes/templates/"*.tpl "$INST/.config/hypr/themes/templates/"
+cp "$REPO/.config/hypr/themes/everforest/colors.toml" "$THEME/colors.toml" 2>/dev/null ||
+  printf 'background = "#111111"\n' >"$THEME/colors.toml"
+render
+shipped_count=$(ls "$REPO/.config/hypr/themes/templates/"*.tpl | wc -l)
+check "every shipped template produces a rendered file" \
+  "$(ls "$THEME/generated" 2>/dev/null | wc -l)" "$shipped_count"
+
+# --- 8. no colors.toml is still a clean exit -------------------------------
+
+new_case no-colors
+rm -f "$THEME/colors.toml"
+printf 'X\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
+render
+check "a theme without colors.toml exits 0" "$(cat "$CASE/rc")" "0"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/theme-picker-test.sh
+++ b/test/theme-picker-test.sh
@@ -362,10 +362,11 @@ check "every key from the theme producer names a directory in the fixture themes
 
 tmpl_themes="$TMP/themes-templates"
 must_be_fixture "$tmpl_themes"
-mkdir -p "$tmpl_themes/one" "$tmpl_themes/two" "$tmpl_themes/three" "$tmpl_themes/templates"
+mkdir -p "$tmpl_themes/one" "$tmpl_themes/two" "$tmpl_themes/three" \
+  "$tmpl_themes/templates" "$tmpl_themes/templates.user"
 tmpl_out="$TMP/out-templates"
 THEMES_DIR="$tmpl_themes" XDG_CACHE_HOME="$TMP/cache-templates" bash "$PICKER" >"$tmpl_out"
-check "the theme producer emits one row per theme directory, excluding templates" "$(wc -l <"$tmpl_out")" "3"
+check "the theme producer excludes templates and templates.user" "$(wc -l <"$tmpl_out")" "3"
 
 # ---- the wallpaper producer's keys, and its label shape --------------------
 


### PR DESCRIPTION
The eight `.tpl` files every theme renders from lived in user space, which updates never overwrite by design, so a template changed in this repository reached new installs only.

That has already cost a migration. `1788069834.sh` exists solely to deliver a `[global]` section added to `dunst-colors.tpl`, and had to re-render every installed theme afterwards. The other seven templates have the same gap with nothing behind them, so an install predating any of their changes renders themes from stale inputs with nothing to tell it.

## What changed

`theme-apply-templates.sh` now reads templates from the install. Since `hyprsimple-update` already refreshes `~/.local/bin`, this needs **no migration** and writes nothing into user space.

## Why the install wins over the home directory

This is the part the design got wrong first, and the tests caught it.

The original plan was per-file resolution with the home directory winning, which reads as the conservative choice. It does not work. `install.sh` copied every template into every existing home, and a stale copy cannot be told apart from a customised one by comparing it against the current shipped file, because both simply differ. Honouring that directory would leave every existing install pinned to the templates it was installed with, which is precisely the gap being closed. Only new installs would have benefited.

So the install is authoritative, and an override lives in `~/.config/hypr/themes/templates.user/`, where its presence is a deliberate act rather than a leftover. A file there with no shipped counterpart renders too, so a user can add templates of their own. A stale home template that differs from the shipped one is reported on stderr rather than silently ignored.

`hyprsimple-theme-picker.sh` skips `templates.user` as well, or it would be offered as a theme.

## Testing

New `test/template-delivery-test.sh`, 12 checks, wired into the workflow by name. Every fixture run sets `HOME` and `HYPRSIMPLE_PATH` explicitly and asserts on rendered output rather than on the renderer's own text, both traps learned from the rofi split where a suite passed for the wrong reason.

Every check is sabotage-tested. Restoring the old home-wins behaviour turns three red, dropping the stale warning turns one red, and cutting the install out of resolution turns six red.

Two existing suites needed updating, and both are honest consequences rather than accommodations: `dunst-split-test.sh` placed its template in the fixture's home, which the renderer no longer reads, and `theme-picker-test.sh` now includes a `templates.user` directory in the fixture it counts rows from.

All 15 suites pass.

## Verified against a real install

A real theme rendered with the new script produces all eight files byte-identical to what that machine already had, and no stale warnings fire, because its copied templates match the shipped ones.

## Known gap

`1788069834.sh` refreshes the home copy of `dunst-colors.tpl`, which is no longer read. It is a shipped migration that has already run, so it is left alone. Removing the now-unread `~/.config/hypr/themes/templates` directory from existing homes would take its own migration, gated on every file matching something shipped, and is worth doing on its own terms rather than smuggling in here.