### PR TITLE
Tell the user which configs an update changed that they diverged from

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,3 +64,6 @@ jobs:
 
       - name: template-delivery-test
         run: bash test/template-delivery-test.sh
+
+      - name: config-drift-report-test
+        run: bash test/config-drift-report-test.sh

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -79,6 +79,11 @@ fi
 
 # ---- Pull ----------------------------------------------------------------
 
+# Recorded before the pull so the end of this run can name exactly which shipped
+# configs changed, rather than comparing every file on every update.
+PREV_COMMIT=""
+[[ -d $HYPRSIMPLE_PATH/.git ]] && PREV_COMMIT=$(git -C "$HYPRSIMPLE_PATH" rev-parse HEAD 2>/dev/null)
+
 if [[ -d $HYPRSIMPLE_PATH/.git ]]; then
   echo -e "${YELLOW}Pulling latest hyprsimple...${NC}"
 
@@ -212,6 +217,41 @@ fi
 
 echo -e "\n${YELLOW}Running pending migrations...${NC}"
 bash "$HOME/.local/bin/hyprsimple-migrate.sh"
+
+# ---- Configs this update changed that you still hold your own copy of ----
+#
+# Some configs cannot be delivered automatically. starship.toml, yazi.toml and
+# hyprsunset.conf are TOML and wlogout/layout is a stream of JSON objects, and
+# none of those formats has an include directive, so there is no equivalent of
+# the rofi stubs or the dunst drop-in for them.
+#
+# hyprsimple-refresh-config.sh has always been able to update one, but nothing
+# ever said that it needed updating, so the command existed and was never run.
+# This closes that, and it is deliberately driven by what this pull actually
+# changed rather than by comparing everything: a user who edited a file on
+# purpose is not nagged on every update, only when hyprsimple touches the same
+# file. Migrations run first, so anything already handled is not mentioned.
+
+if [[ -n $PREV_COMMIT ]] && [[ $PREV_COMMIT != "$(git -C "$HYPRSIMPLE_PATH" rev-parse HEAD 2>/dev/null)" ]]; then
+  drifted=()
+  while IFS= read -r rel; do
+    [[ -n $rel ]] || continue
+    shipped="$HYPRSIMPLE_PATH/$rel"
+    user="$HOME/.config/${rel#.config/}"
+    # Absent means the user never had it, and a symlink means something else
+    # already manages it. Neither is drift.
+    [[ -f $shipped && -f $user && ! -L $user ]] || continue
+    cmp -s "$shipped" "$user" || drifted+=("${rel#.config/}")
+  done < <(git -C "$HYPRSIMPLE_PATH" diff --name-only "$PREV_COMMIT" HEAD -- .config/ 2>/dev/null)
+
+  if [[ ${#drifted[@]} -gt 0 ]]; then
+    echo -e "\n${YELLOW}This update changed configs you have your own version of:${NC}"
+    for rel in "${drifted[@]}"; do
+      echo "  hyprsimple-refresh-config.sh $rel"
+    done
+    echo "Each one backs your version up and shows the diff. Nothing is deleted."
+  fi
+fi
 
 # ---- Reload --------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ hyprsimple-refresh-config hypr/hyprlock.conf
 
 Writing a migration is documented in [`migrations/README.md`](migrations/README.md).
 
+Some configs cannot be delivered automatically. `starship.toml`, `yazi/yazi.toml` and `hypr/hyprsunset.conf` are TOML, and `wlogout/layout` is a stream of JSON objects, so none of them has an include directive to hang a default off the way rofi and dunst do.
+
+When an update changes one of those and you have your own version, `hyprsimple-update` says so and prints the command to take the new one. It only mentions a file this update actually changed, so editing something on purpose does not nag you every time.
+
 #### Rofi
 
 Rofi's defaults live in the install, at `~/.config/rofi/hyprsimple`, which is a

--- a/test/config-drift-report-test.sh
+++ b/test/config-drift-report-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Checks that hyprsimple-update names the configs an update changed which the
+# user still holds their own version of. Never touches the real install.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE="$REPO/.local/bin/hyprsimple-update.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+# The update restarts things and installs packages. Stubbing these keeps the
+# suite off the running session and off the network. pgrep exits 1 so the
+# reload block is skipped rather than half executed.
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+for c in pgrep hyprctl pacman yay sudo systemctl; do
+  printf '#!/bin/sh\nexit 1\n' >"$STUB/$c"
+  chmod +x "$STUB/$c"
+done
+printf '#!/bin/sh\nexit 0\n' >"$STUB/hyprsimple-migrate.sh"
+chmod +x "$STUB/hyprsimple-migrate.sh"
+
+ORIGIN="$TMP/origin.git"
+git init -q --bare "$ORIGIN"
+
+# A minimal origin carrying one unsplittable config and the updater itself.
+SEED="$TMP/seed"
+must_be_fixture "$SEED"
+mkdir -p "$SEED/.config" "$SEED/.local/bin"
+git init -q "$SEED" && git -C "$SEED" config user.email t@e && git -C "$SEED" config user.name t
+printf 'V1\n' >"$SEED/.config/starship.toml"
+printf 'V1\n' >"$SEED/.config/untouched.toml"
+cp "$UPDATE" "$SEED/.local/bin/hyprsimple-update.sh"
+cp "$REPO/.local/bin/hyprsimple-refresh-config.sh" "$SEED/.local/bin/"
+printf '0.0.1\n' >"$SEED/version"
+git -C "$SEED" add -A && git -C "$SEED" commit -qm v1
+git -C "$SEED" branch -M main && git -C "$SEED" push -q "$ORIGIN" main
+
+new_case() {
+  CASE="$TMP/$1"
+  must_be_fixture "$CASE"
+  INSTALL="$CASE/install"
+  FAKE_HOME="$CASE/home"
+  git clone -q "file://$ORIGIN" "$INSTALL"
+  mkdir -p "$FAKE_HOME/.config" "$FAKE_HOME/.local/bin"
+  cp "$SEED/.local/bin/hyprsimple-refresh-config.sh" "$FAKE_HOME/.local/bin/"
+  printf '#!/bin/sh\nexit 0\n' >"$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"
+  chmod +x "$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"
+}
+
+ship() { # ship <path> <content>: publish a new version from the seed
+  printf '%s\n' "$2" >"$SEED/$1"
+  git -C "$SEED" add -A && git -C "$SEED" commit -qm "change $1"
+  git -C "$SEED" push -q "$ORIGIN" main
+}
+
+run_update() {
+  HOME="$FAKE_HOME" HYPRSIMPLE_PATH="$INSTALL" PATH="$STUB:$PATH" \
+    bash "$INSTALL/.local/bin/hyprsimple-update.sh" >"$CASE/out" 2>&1
+  printf '%s' "$?" >"$CASE/rc"
+}
+
+# --- 1. a changed config the user has their own version of is named --------
+
+new_case reports
+printf 'MINE\n' >"$FAKE_HOME/.config/starship.toml"
+ship .config/starship.toml V2
+run_update
+check "a changed config the user diverged from is reported" \
+  "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "1"
+
+# --- 2. a config this update did not touch is not named -------------------
+
+new_case untouched
+printf 'MINE\n' >"$FAKE_HOME/.config/starship.toml"
+printf 'MINE-TOO\n' >"$FAKE_HOME/.config/untouched.toml"
+ship .config/starship.toml V3
+run_update
+check "a config this update did not change is not reported" \
+  "$(grep -c 'untouched.toml' "$CASE/out")" "0"
+
+# --- 3. a user whose copy matches the new shipped one is not nagged -------
+
+new_case matching
+ship .config/starship.toml V4
+printf 'V4\n' >"$FAKE_HOME/.config/starship.toml"
+run_update
+check "a matching copy is not reported" \
+  "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "0"
+
+# --- 4. a config the user never had is not reported -----------------------
+
+new_case absent
+ship .config/starship.toml V5
+run_update
+check "a config the user does not have is not reported" \
+  "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "0"
+
+# --- 5. a symlinked config is managed elsewhere and is not drift ----------
+
+new_case symlinked
+ship .config/starship.toml V6
+# The target must differ from the shipped file, or cmp filters it out and the
+# symlink guard is never the reason it stays quiet.
+printf 'SOMETHING-ELSE\n' >"$CASE/managed-elsewhere.toml"
+ln -sfn "$CASE/managed-elsewhere.toml" "$FAKE_HOME/.config/starship.toml"
+run_update
+check "a symlinked config is not reported" \
+  "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "0"
+
+# --- 6. an update that pulls nothing new reports nothing ------------------
+
+new_case nochange
+printf 'MINE\n' >"$FAKE_HOME/.config/starship.toml"
+run_update
+check "an update with nothing to pull reports no drift" \
+  "$(grep -c 'refresh-config.sh' "$CASE/out")" "0"
+check "and still exits 0" "$(cat "$CASE/rc")" "0"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/config-drift-report-test.sh
+++ b/test/config-drift-report-test.sh
@@ -36,7 +36,12 @@ printf '#!/bin/sh\nexit 0\n' >"$STUB/hyprsimple-migrate.sh"
 chmod +x "$STUB/hyprsimple-migrate.sh"
 
 ORIGIN="$TMP/origin.git"
-git init -q --bare "$ORIGIN"
+# -b main explicitly: a bare repo takes its HEAD from the runner's
+# init.defaultBranch, which is master on the CI image and main here. A mismatch
+# makes every clone come out empty with only a warning on stderr, which is how
+# four of these checks once passed against an install that did not exist.
+git init -q --bare -b main "$ORIGIN" 2>/dev/null ||
+  { git init -q --bare "$ORIGIN"; git -C "$ORIGIN" symbolic-ref HEAD refs/heads/main; }
 
 # A minimal origin carrying one unsplittable config and the updater itself.
 SEED="$TMP/seed"
@@ -57,6 +62,13 @@ new_case() {
   INSTALL="$CASE/install"
   FAKE_HOME="$CASE/home"
   git clone -q "file://$ORIGIN" "$INSTALL"
+  # A fixture that did not clone must fail loudly. Every grep below returns 0
+  # against an empty install, so without this the suite reports success for
+  # checks it never actually ran.
+  if [[ ! -f $INSTALL/.local/bin/hyprsimple-update.sh ]]; then
+    printf 'not ok - fixture install did not clone (%s)\n' "$1" >&2
+    exit 1
+  fi
   mkdir -p "$FAKE_HOME/.config" "$FAKE_HOME/.local/bin"
   cp "$SEED/.local/bin/hyprsimple-refresh-config.sh" "$FAKE_HOME/.local/bin/"
   printf '#!/bin/sh\nexit 0\n' >"$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"


### PR DESCRIPTION
Four configs cannot be delivered automatically. `starship.toml`, `yazi/yazi.toml` and `hypr/hyprsunset.conf` are TOML, and `wlogout/layout` is a stream of JSON objects, so none of them has an include directive to hang a default off the way rofi and dunst do. The roadmap calls this group F and says it needs a refresh command.

## It does not need a refresh command

`hyprsimple-refresh-config.sh` has always been able to update one of these: it copies the shipped default, keeps a backup only when bytes actually changed, and prints the diff. Nothing is missing there.

What was missing is that **nothing ever said the file had changed**, so the command existed and was never run. Every change to one of these has cost a migration instead.

## What changed

`hyprsimple-update` records the commit it was on before pulling, and at the end names any config that changed in this pull which the user still holds a different version of, with the command to take it.

It is driven by what the pull actually changed rather than by comparing everything. That distinction is the whole design: comparing everything would flag every deliberate customisation on every update, which is noise, and noise is ignored. A user hears about a file only when hyprsimple touches the same file.

Three cases are skipped, each for its own reason: a config the user never had, a config whose copy already matches the new shipped one, and a symlinked config, which is managed by something else. Migrations run first, so anything already handled is not mentioned.

Nothing here is specific to those four files, and there is no list to maintain. Any config that stops being splittable is covered automatically.

## What was measured

- `git diff --name-only OLD HEAD` works across a pull on a **shallow** clone, and the clone stays shallow. Verified against a `file://` origin rather than assumed, because every install is shallow and diff behaviour there is exactly the kind of thing this repository has been wrong about before.

## Testing

New `test/config-drift-report-test.sh`, 7 checks, wired into the workflow by name. It builds a real git origin, clones a real shallow install, publishes real commits and runs the real updater, with `pgrep`, `hyprctl` and the package helpers stubbed so it touches neither the running session nor the network.

Every check is sabotage-tested. Reporting every changed config regardless of what the user has turns three red, comparing the whole tree instead of the pull turns one red, and dropping the symlink exemption turns one red.

That last one initially stayed green, because the fixture's symlink pointed at the install and so matched the shipped file, meaning `cmp` filtered it and the symlink guard was never the reason. The fixture now points somewhere that genuinely differs, so only the guard can keep it quiet.

All 16 suites pass, and the new updater was run against a real install with nothing to pull, leaving it clean and on the same commit.