### PR TITLE
Remove the unread template copy from existing homes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,3 +67,6 @@ jobs:
 
       - name: config-drift-report-test
         run: bash test/config-drift-report-test.sh
+
+      - name: template-cleanup-test
+        run: bash test/template-cleanup-test.sh

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Themes are rendered from the `.tpl` files in `~/.local/share/hyprsimple/.config/
 
 To change one, copy it to `~/.config/hypr/themes/templates.user/` under the same name and edit it there. That directory wins over the install, and a file in it with no shipped counterpart is rendered too, so you can add templates of your own.
 
-Older installs have a copy of the templates at `~/.config/hypr/themes/templates`. That directory is no longer read. If a file in it differs from the shipped one, the theme switcher says so and tells you where to move it.
+Older installs have a copy of the templates at `~/.config/hypr/themes/templates`. That directory is no longer read, and an update removes it once every file in it is one hyprsimple shipped. If you had edited one, the whole directory is left alone and you are told which file it was, so you can move it to `templates.user/`.
 
 ## Network
 

--- a/migrations/1788278344.sh
+++ b/migrations/1788278344.sh
@@ -1,0 +1,65 @@
+echo "Remove the unread copy of the theme templates from your home directory"
+
+# Templates now come from the install, so ~/.config/hypr/themes/templates is no
+# longer read at all. Leaving it there is harmless but misleading: it looks like
+# the thing being rendered and is not.
+#
+# The directory is removed only when every file in it is byte-identical to some
+# version this project shipped, which proves nothing in it was written by the
+# user. A single unrecognised file leaves the whole directory alone, because a
+# customised template is the one thing here worth keeping and its owner is told
+# where it now belongs.
+
+TPL="$HOME/.config/hypr/themes/templates"
+USER_TPL="$HOME/.config/hypr/themes/templates.user"
+[[ -d $TPL ]] || exit 0
+
+# Every version of each template this project has shipped, from git history.
+SHIPPED_SUMS=(
+  3cd9a00a3fc011b0aa3d8beb5f32d0dc
+  1b3ce88f8c8a7cb8e4f3498ef2464c30
+  7ff17d249dac01bdf72a504155020617
+  db181291a4aae21a0390328c710a4340
+  66af45d722e9dcb49006a577144995ea
+  216e8b8f3440d905c19a7893d8b08059
+  921725a8b29c1306bbfb23afa1b18229
+  edab07891813c11fa38845dc1fac41b1
+  aed01ea1a0febd9ee4eec702187f46d9
+  52330767a402caa38b17f66f8ccfe10f
+  f30ed02d79c3f8be57da9a8c606cd489
+)
+
+is_shipped() {
+  local sum
+  sum=$(md5sum "$1" | cut -d' ' -f1)
+  local s
+  for s in "${SHIPPED_SUMS[@]}"; do
+    [[ $sum == "$s" ]] && return 0
+  done
+  return 1
+}
+
+own=()
+while IFS= read -r -d '' f; do
+  is_shipped "$f" || own+=("$f")
+done < <(find "$TPL" -type f -print0)
+
+if [[ ${#own[@]} -gt 0 ]]; then
+  echo ""
+  echo "$TPL was left alone: these are not versions hyprsimple shipped."
+  for f in "${own[@]}"; do
+    echo "    ${f#"$HOME"/}"
+  done
+  echo ""
+  echo "That directory is no longer read. To keep any of those, move them to"
+  echo "    $USER_TPL/"
+  echo "and delete the rest yourself."
+  echo ""
+  exit 0
+fi
+
+# Every file was one of ours, so nothing is lost. rm -rf is scoped to a path
+# this migration built itself from $HOME, and the directory existence check
+# above is what makes a re-run a no-op.
+rm -rf "$TPL"
+echo "Removed $TPL, which is no longer read."

--- a/test/template-cleanup-test.sh
+++ b/test/template-cleanup-test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Checks the migration that removes the unread copy of the theme templates,
+# and only when every file in it is one this project shipped.
+# Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$REPO/migrations/1788278344.sh"
+SHIPPED="$REPO/.config/hypr/themes/templates"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+new_home() {
+  HOMEDIR="$TMP/$1"
+  must_be_fixture "$HOMEDIR"
+  TPL="$HOMEDIR/.config/hypr/themes/templates"
+  mkdir -p "$TPL"
+  cp "$SHIPPED"/*.tpl "$TPL/"
+  # A fixture that did not populate must fail loudly rather than let a later
+  # check pass against an empty directory.
+  if [[ $(ls "$TPL" | wc -l) -eq 0 ]]; then
+    printf 'not ok - fixture templates did not copy (%s)\n' "$1" >&2
+    exit 1
+  fi
+}
+
+run() { HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/out" 2>&1; }
+
+# --- 1. a directory of untouched shipped templates is removed --------------
+
+new_home pristine
+run
+check "a directory of shipped templates is removed" \
+  "$([[ -d $TPL ]] && echo present || echo gone)" "gone"
+
+# --- 2. a re-run is a no-op ------------------------------------------------
+
+run
+check "a second run exits 0 with the directory already gone" "$?" "0"
+
+# --- 3. one customised file protects the whole directory ------------------
+
+new_home customised
+printf '/* mine */\n' >>"$TPL/waybar-colors.css.tpl"
+before=$(find "$TPL" -type f -exec md5sum {} + | sort | md5sum)
+run
+check "a customised template stops the removal" \
+  "$([[ -d $TPL ]] && echo present || echo gone)" "present"
+check "and nothing in the directory is touched" \
+  "$(find "$TPL" -type f -exec md5sum {} + | sort | md5sum)" "$before"
+check "and the user is told where to move it" \
+  "$(grep -c 'templates.user' "$TMP/out")" "1"
+check "and the offending file is named" \
+  "$(grep -c 'waybar-colors.css.tpl' "$TMP/out")" "1"
+
+# --- 4. a file the user added protects the directory too ------------------
+
+new_home added
+printf '/* mine */\n' >"$TPL/my-own.tpl"
+run
+check "an added file stops the removal" \
+  "$([[ -d $TPL ]] && echo present || echo gone)" "present"
+
+# --- 5. an older shipped version still counts as ours ---------------------
+#
+# The point of carrying history rather than only the current checksum: a home
+# that never took a template update holds an old version, which is still not
+# the user's work.
+
+new_home stale
+old=$(git -C "$REPO" log --format=%H -- .config/hypr/themes/templates/dunst-colors.tpl | tail -1)
+git -C "$REPO" show "$old:.config/hypr/themes/templates/dunst-colors.tpl" >"$TPL/dunst-colors.tpl"
+run
+check "an older shipped version does not block removal" \
+  "$([[ -d $TPL ]] && echo present || echo gone)" "gone"
+
+# --- 6. a home without the directory at all -------------------------------
+
+HOMEDIR="$TMP/nodir"
+must_be_fixture "$HOMEDIR"
+mkdir -p "$HOMEDIR/.config"
+run
+check "a home without the directory exits 0" "$?" "0"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Since #44 the theme templates come from the install, so `~/.config/hypr/themes/templates` is no longer read at all. Leaving it there is harmless but misleading: it looks like the thing being rendered and is not. #44 deferred this deliberately rather than smuggling a directory removal into a delivery change.

## What changed

One migration removes that directory, and only when **every** file in it is byte-identical to some version this project shipped, taken from git history rather than guessed. A single unrecognised file leaves the whole directory alone, names it, and says to move it to `templates.user/`, because a customised template is the one thing here worth keeping.

Carrying the full history rather than only the current checksum is load-bearing. A home that never took a template update holds an older shipped version, which is still not the user's work, and there is a check for exactly that.

## Testing

New `test/template-cleanup-test.sh`, 9 checks, wired into the workflow by name.

Every check is sabotage-tested. Removing the checksum gate turns five red, deleting despite the gate turns three red, and reducing the list to only the current checksum turns two red, including the older-shipped-version case.

The fixture asserts it actually populated before any check runs. That habit comes from #45, where a fixture failed to build and four checks still reported `ok` because they asserted on absence and an empty fixture produces no output either.

All 17 suites pass, run with `init.defaultBranch` forced to `master` so the CI default is covered locally.

## Also settled: `wlogout/style.css`

It was the last file in no group. It belongs in F and should **not** be split.

wlogout is GTK3, and GTK3 CSS does support `@import url(...)` with `@define-color`, so a split is technically possible. But a missing import **raises and yields an empty stylesheet**, verified against `Gtk.CssProvider` rather than assumed. wlogout would render completely unstyled. That is a worse failure than hyprlang's silent `found no match`, and far worse than rofi's, where a missing import costs only the imported properties. The file is 88 static lines with two shipped versions in its entire history, and since #45 an update that changes it already tells the user, so the delivery problem is solved without taking that risk.

No code change for it here.

## A bug found while classifying it, not fixed here

wlogout does not follow the theme. Its two colours, `#11111b` and `#cdd6f4`, are catppuccin's crust and foreground, hardcoded. No script writes the file and there is no wlogout template, so the power menu stays catppuccin on every theme. Closing that means a `wlogout-colors.css.tpl` emitting `@define-color`, which turns the file into theme-generated output rather than an F file, and the empty-stylesheet failure above is what that design has to handle. Recorded rather than done, since it is a feature rather than part of this cleanup.