### PR TITLE
Make the wlogout power menu follow the active theme

### DIFF
--- a/.config/hypr/themes/templates/wlogout-colors.css.tpl
+++ b/.config/hypr/themes/templates/wlogout-colors.css.tpl
@@ -1,0 +1,4 @@
+/* Generated from the theme's colors.toml. Do not edit: a theme switch
+   overwrites this file. Edit ~/.config/wlogout/style.css instead. */
+@define-color wl_background {{ background }};
+@define-color wl_foreground {{ foreground }};

--- a/.config/wlogout/style.css
+++ b/.config/wlogout/style.css
@@ -1,3 +1,11 @@
+/* Colours come from the active theme. wlogout-colors.css is rewritten on every
+   theme switch from the theme's colors.toml.
+
+   This import must resolve. GTK treats a missing @import as a fatal parse error
+   and returns an empty stylesheet, so a broken link here leaves the power menu
+   completely unstyled rather than merely uncoloured. */
+@import url("wlogout-colors.css");
+
 * {
     font-family: JetBrains Mono, Symbols Nerd Font;
     font-size: 24px;
@@ -6,12 +14,12 @@
 }
 
 window {
-    background-color: #11111b;
+    background-color: @wl_background;
     /* border-radius: 10px; */
 }
 
 button {
-    background-color: #11111b;
+    background-color: @wl_background;
     border-style: solid;
     /* border-width: 2px; */
     border-radius: 50px;
@@ -23,11 +31,11 @@ button {
 
 button:active,
 button:hover {
-    background-color: #cdd6f4;
+    background-color: @wl_foreground;
 }
 
 button:focus {
-    background-color: #cdd6f4;
+    background-color: @wl_foreground;
 }
 
 #lock {
@@ -36,7 +44,7 @@ button:focus {
 
 #lock:hover {
     background-image: image(url("~/.local/share/assets/wlogout/lock-hover.png"), url("/usr/local/share/wlogout/icons/lock.png"));
-    color: #11111b;
+    color: @wl_background;
 }
 
 #logout {
@@ -45,7 +53,7 @@ button:focus {
 
 #logout:hover {
     background-image: image(url("~/.local/share/assets/wlogout/logout-hover.png"), url("/usr/local/share/wlogout/icons/logout.png"));
-    color: #11111b;
+    color: @wl_background;
 }
 
 #suspend {
@@ -54,7 +62,7 @@ button:focus {
 
 #suspend:hover {
     background-image: image(url("~/.local/share/assets/wlogout/sleep-hover.png"), url("/usr/local/share/wlogout/icons/suspend.png"));
-    color: #11111b;
+    color: @wl_background;
 }
 
 #shutdown {
@@ -63,7 +71,7 @@ button:focus {
 
 #shutdown:hover {
     background-image: image(url("~/.local/share/assets/wlogout/power-hover.png"), url("/usr/local/share/wlogout/icons/shutdown.png")); 
-    color: #11111b;
+    color: @wl_background;
 }
 
 #reboot {
@@ -72,17 +80,17 @@ button:focus {
 
 #reboot:hover {
     background-image: image(url("~/.local/share/assets/wlogout/restart-hover.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
-    color: #11111b;
+    color: @wl_background;
 }
 
 #exit {
     background-image: image(url("~/.local/share/assets/wlogout/restart.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
-    background-color: #11111b;
+    background-color: @wl_background;
 
 }
 
 #exit:hover {
     background-image: image(url("~/.local/share/assets/wlogout/restart-hover.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
-    color: #11111b;
-    background-color: #cdd6f4;
+    color: @wl_background;
+    background-color: @wl_foreground;
 }

--- a/.config/wlogout/wlogout-colors.css
+++ b/.config/wlogout/wlogout-colors.css
@@ -1,0 +1,8 @@
+/* Replaced on every theme switch from the theme's colors.toml. These values are
+   only what a fresh install shows before the first switch.
+
+   style.css imports this file, and GTK treats a missing import as a fatal
+   parse error that yields an empty stylesheet, so this file existing is what
+   keeps the power menu styled at all. */
+@define-color wl_background #11111b;
+@define-color wl_foreground #cdd6f4;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Lua and ImageMagick
         run: |
           sudo apt-get update
-          sudo apt-get install -y lua5.4 imagemagick
+          sudo apt-get install -y lua5.4 imagemagick python3-gi gir1.2-gtk-3.0
           # The suites invoke `lua`. Ubuntu installs `lua5.4`, so make the
           # plain name exist rather than relying on the package to register it.
           sudo ln -sf /usr/bin/lua5.4 /usr/bin/lua
@@ -70,3 +70,6 @@ jobs:
 
       - name: template-cleanup-test
         run: bash test/template-cleanup-test.sh
+
+      - name: wlogout-theme-test
+        run: bash test/wlogout-theme-test.sh

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -78,6 +78,17 @@ if [[ -f "$GEN/hyprlock.conf" ]]; then
   cp "$GEN/hyprlock.conf" "$HOME/.config/hypr/theme-hyprlock.conf"
 fi
 
+# 6b. Update wlogout colors
+#
+# Copied rather than symlinked, deliberately. style.css imports this file, and
+# GTK treats a missing import as a fatal parse error that yields an empty
+# stylesheet, so a dangling link would leave the power menu entirely unstyled.
+# A copy means a theme without colors.toml keeps the previous colours instead.
+if [[ -f "$GEN/wlogout-colors.css" ]]; then
+  mkdir -p "$HOME/.config/wlogout"
+  cp "$GEN/wlogout-colors.css" "$HOME/.config/wlogout/wlogout-colors.css"
+fi
+
 # 7. Update Dunst colors
 # generated/dunst-colors is already valid dunst config, so it drops straight in
 # as an override. Drop-ins outrank the base dunstrc, and lexical order decides

--- a/migrations/1788279207.sh
+++ b/migrations/1788279207.sh
@@ -1,0 +1,68 @@
+echo "Make the wlogout power menu follow the active theme"
+
+# wlogout's colours were hardcoded catppuccin, so the power menu stayed
+# catppuccin whatever theme was active. style.css now imports
+# wlogout-colors.css, which a theme switch rewrites from the theme's
+# colors.toml.
+#
+# Order matters here. GTK treats a missing @import as a fatal parse error and
+# returns an empty stylesheet, so style.css must never be replaced before the
+# file it imports exists, or the power menu renders completely unstyled until
+# the next theme switch.
+
+WL="$HOME/.config/wlogout"
+[[ -d $WL ]] || exit 0
+
+SHIPPED_STYLE="$HYPRSIMPLE_PATH/.config/wlogout/style.css"
+SHIPPED_COLORS="$HYPRSIMPLE_PATH/.config/wlogout/wlogout-colors.css"
+[[ -f $SHIPPED_STYLE && -f $SHIPPED_COLORS ]] || exit 0
+
+# Every version of style.css this project has shipped before the import was
+# added. A copy matching one of these was never edited.
+STYLE_SUMS=(
+  23c98a2fd7995835b53e3a03bfa3c5cf
+  d755cc157e17e63dc8aa1b4f091d4517
+)
+
+# 1. The imported file first, always. Idempotent: rendering it again from the
+#    active theme is what the next theme switch would do anyway.
+if [[ ! -f $WL/wlogout-colors.css ]]; then
+  cp "$SHIPPED_COLORS" "$WL/wlogout-colors.css"
+  echo "Installed $WL/wlogout-colors.css"
+fi
+
+active=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null)
+if [[ -n $active ]]; then
+  gen="${active%/*}"
+  if [[ -f $gen/wlogout-colors.css ]]; then
+    cp "$gen/wlogout-colors.css" "$WL/wlogout-colors.css"
+    echo "Applied the active theme's colours to wlogout"
+  fi
+fi
+
+# 2. Only then the stylesheet that imports it.
+if cmp -s "$WL/style.css" "$SHIPPED_STYLE"; then
+  exit 0
+fi
+
+sum=$(md5sum "$WL/style.css" | cut -d' ' -f1)
+for s in "${STYLE_SUMS[@]}"; do
+  if [[ $sum == "$s" ]]; then
+    cp "$SHIPPED_STYLE" "$WL/style.css"
+    echo "Updated $WL/style.css"
+    exit 0
+  fi
+done
+
+echo ""
+echo "$WL/style.css has your own edits, so it was left alone."
+echo "It still uses hardcoded colours. To follow the theme, add this line at"
+echo "the top and replace the colour literals with @wl_background and"
+echo "@wl_foreground:"
+echo ""
+echo "    @import url(\"wlogout-colors.css\");"
+echo ""
+echo "Or take hyprsimple's version, keeping a backup of yours:"
+echo ""
+echo "    hyprsimple-refresh-config.sh wlogout/style.css"
+echo ""

--- a/test/fixtures/templates-precleanup/btop.theme.tpl
+++ b/test/fixtures/templates-precleanup/btop.theme.tpl
@@ -1,0 +1,83 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="{{ background }}"
+
+# Main text color
+theme[main_fg]="{{ foreground }}"
+
+# Title color for boxes
+theme[title]="{{ foreground }}"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="{{ accent }}"
+
+# Background color of selected item in processes box
+theme[selected_bg]="{{ color8 }}"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="{{ accent }}"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="{{ color8 }}"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="{{ foreground }}"
+
+# Background color of the percentage meters
+theme[meter_bg]="{{ color8 }}"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="{{ foreground }}"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="{{ color5 }}"
+theme[mem_box]="{{ color2 }}"
+theme[net_box]="{{ color1 }}"
+theme[proc_box]="{{ accent }}"
+
+# Box divider line and small boxes line color
+theme[div_line]="{{ color8 }}"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="{{ color2 }}"
+theme[temp_mid]="{{ color3 }}"
+theme[temp_end]="{{ color1 }}"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="{{ color6 }}"
+theme[cpu_mid]="{{ color4 }}"
+theme[cpu_end]="{{ color5 }}"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="{{ color5 }}"
+theme[free_mid]="{{ color4 }}"
+theme[free_end]="{{ color6 }}"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="{{ color4 }}"
+theme[cached_mid]="{{ color6 }}"
+theme[cached_end]="{{ color5 }}"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="{{ color3 }}"
+theme[available_mid]="{{ color1 }}"
+theme[available_end]="{{ color1 }}"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="{{ color2 }}"
+theme[used_mid]="{{ color6 }}"
+theme[used_end]="{{ color4 }}"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="{{ color3 }}"
+theme[download_mid]="{{ color1 }}"
+theme[download_end]="{{ color1 }}"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="{{ color2 }}"
+theme[upload_mid]="{{ color6 }}"
+theme[upload_end]="{{ color4 }}"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="{{ color6 }}"
+theme[process_mid]="{{ color4 }}"
+theme[process_end]="{{ color5 }}"

--- a/test/fixtures/templates-precleanup/dunst-colors.OLD.tpl
+++ b/test/fixtures/templates-precleanup/dunst-colors.OLD.tpl
@@ -1,0 +1,14 @@
+[urgency_low]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ color7 }}"
+
+[urgency_normal]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ accent }}"
+
+[urgency_critical]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ color1 }}"

--- a/test/fixtures/templates-precleanup/dunst-colors.tpl
+++ b/test/fixtures/templates-precleanup/dunst-colors.tpl
@@ -1,0 +1,17 @@
+[global]
+    frame_color = "{{ color7 }}"
+
+[urgency_low]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ color7 }}"
+
+[urgency_normal]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ accent }}"
+
+[urgency_critical]
+    background = "{{ background }}"
+    foreground = "{{ foreground }}"
+    frame_color = "{{ color1 }}"

--- a/test/fixtures/templates-precleanup/ghostty.conf.tpl
+++ b/test/fixtures/templates-precleanup/ghostty.conf.tpl
@@ -1,0 +1,22 @@
+background = {{ background }}
+foreground = {{ foreground }}
+cursor-color = {{ cursor }}
+selection-background = {{ selection_background }}
+selection-foreground = {{ selection_foreground }}
+
+palette = 0={{ color0 }}
+palette = 1={{ color1 }}
+palette = 2={{ color2 }}
+palette = 3={{ color3 }}
+palette = 4={{ color4 }}
+palette = 5={{ color5 }}
+palette = 6={{ color6 }}
+palette = 7={{ color7 }}
+palette = 8={{ color8 }}
+palette = 9={{ color9 }}
+palette = 10={{ color10 }}
+palette = 11={{ color11 }}
+palette = 12={{ color12 }}
+palette = 13={{ color13 }}
+palette = 14={{ color14 }}
+palette = 15={{ color15 }}

--- a/test/fixtures/templates-precleanup/hyprland-colors.lua.tpl
+++ b/test/fixtures/templates-precleanup/hyprland-colors.lua.tpl
@@ -1,0 +1,8 @@
+hl.config({
+  general = {
+    col = {
+      active_border = "rgb({{ accent_strip }})",
+      inactive_border = "rgb({{ color8_strip }})",
+    },
+  },
+})

--- a/test/fixtures/templates-precleanup/hyprlock.conf.tpl
+++ b/test/fixtures/templates-precleanup/hyprlock.conf.tpl
@@ -1,0 +1,5 @@
+$color = rgba({{ background_rgb }}, 1.0)
+$inner_color = rgba({{ background_rgb }}, 0.8)
+$outer_color = rgba({{ foreground_rgb }}, 1.0)
+$font_color = rgba({{ foreground_rgb }}, 1.0)
+$check_color = rgba({{ accent_rgb }}, 1.0)

--- a/test/fixtures/templates-precleanup/rofi-colors.rasi.tpl
+++ b/test/fixtures/templates-precleanup/rofi-colors.rasi.tpl
@@ -1,0 +1,9 @@
+* {
+    background:     {{ background }}FF;
+    background-tr:  {{ background }}DF;
+    background-alt: {{ color0 }}99;
+    foreground:     {{ foreground }}FF;
+    selected:       {{ accent }}FF;
+    active:         {{ color2 }}FF;
+    urgent:         {{ color1 }}FF;
+}

--- a/test/fixtures/templates-precleanup/theme-clock.jsonc.tpl
+++ b/test/fixtures/templates-precleanup/theme-clock.jsonc.tpl
@@ -1,0 +1,18 @@
+{
+    "clock": {
+        "timezone": "Asia/Jakarta",
+        "tooltip-format": "<tt>{calendar}</tt>",
+        "format": "󰥔 {:%H:%M | %d %B %Y}",
+        "calendar": {
+          "mode": "year",
+          "mode-mon-col": 3,
+          "on-scroll": 1,
+          "format": {
+            "months": "<span color='{{ foreground }}'><b>{}</b></span>",
+            "days": "<span color='{{ color5 }}'><b>{}</b></span>",
+            "weekdays": "<span color='{{ color3 }}'><b>{}</b></span>",
+            "today": "<span color='{{ accent }}'><b><u>{}</u></b></span>"
+          }
+        }
+    }
+}

--- a/test/fixtures/templates-precleanup/waybar-colors.css.tpl
+++ b/test/fixtures/templates-precleanup/waybar-colors.css.tpl
@@ -1,0 +1,12 @@
+@define-color fg {{ foreground }};
+@define-color bg-widget {{ color0 }};
+@define-color bg-deep {{ background }};
+@define-color accent {{ accent }};
+@define-color accent-bright {{ color6 }};
+@define-color accent-dim {{ color4 }};
+@define-color secondary {{ color5 }};
+@define-color success {{ color2 }};
+@define-color warning {{ color3 }};
+@define-color danger {{ color1 }};
+@define-color info {{ color6 }};
+@define-color muted {{ color1 }};

--- a/test/fixtures/wlogout/style.presplit.css
+++ b/test/fixtures/wlogout/style.presplit.css
@@ -1,0 +1,88 @@
+* {
+    font-family: JetBrains Mono, Symbols Nerd Font;
+    font-size: 24px;
+    transition-property: background-color;
+    transition-duration: 0.7s;
+}
+
+window {
+    background-color: #11111b;
+    /* border-radius: 10px; */
+}
+
+button {
+    background-color: #11111b;
+    border-style: solid;
+    /* border-width: 2px; */
+    border-radius: 50px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 15%;
+    margin: 15px;
+}
+
+button:active,
+button:hover {
+    background-color: #cdd6f4;
+}
+
+button:focus {
+    background-color: #cdd6f4;
+}
+
+#lock {
+    background-image: image(url("~/.config/assets/wlogout/assets/lock.png"), url("/usr/local/share/wlogout/icons/lock.png"));
+}
+
+#lock:hover {
+    background-image: image(url("~/.config/assets/wlogout/assets/lock-hover.png"), url("/usr/local/share/wlogout/icons/lock.png"));
+    color: #11111b;
+}
+
+#logout {
+    background-image: image(url("~/.config/assets/wlogout/assets/logout.png"), url("/usr/local/share/wlogout/icons/logout.png"));
+}
+
+#logout:hover {
+    background-image: image(url("~/.config/assets/wlogout/assets/logout-hover.png"), url("/usr/local/share/wlogout/icons/logout.png"));
+    color: #11111b;
+}
+
+#suspend {
+    background-image: image(url("~/.config/assets/wlogout/assets/sleep.png"), url("/usr/local/share/wlogout/icons/suspend.png"));
+}
+
+#suspend:hover {
+    background-image: image(url("~/.config/assets/wlogout/assets/sleep-hover.png"), url("/usr/local/share/wlogout/icons/suspend.png"));
+    color: #11111b;
+}
+
+#shutdown {
+    background-image: image(url("~/.config/assets/logout/assets/power.png"), url("/usr/local/share/wlogout/icons/shutdown.png"));
+}
+
+#shutdown:hover {
+    background-image: image(url("~/.config/assets/wlogout/assets/power-hover.png"), url("/usr/local/share/wlogout/icons/shutdown.png")); 
+    color: #11111b;
+}
+
+#reboot {
+    background-image: image(url("~/.config/assets/wlogout/assets/restart.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
+}
+
+#reboot:hover {
+    background-image: image(url("~/.config/assets/wlogout/assets/restart-hover.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
+    color: #11111b;
+}
+
+#exit {
+    background-image: image(url("~/.config/assets/wlogout/assets/restart.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
+    background-color: #11111b;
+
+}
+
+#exit:hover {
+    background-image: image(url("~/.config/assets/wlogout/assets/restart-hover.png"), url("/usr/local/share/wlogout/icons/reboot.png"));
+    color: #11111b;
+    background-color: #cdd6f4;
+}

--- a/test/template-cleanup-test.sh
+++ b/test/template-cleanup-test.sh
@@ -25,12 +25,25 @@ must_be_fixture() {
   fi
 }
 
+# The templates as they were when this migration was written, not as they are
+# now. This fixture stands in for a home that predates the delivery change, and
+# such a home cannot contain a template added afterwards. Copying the current
+# set instead makes the suite fail the moment a template is added, which is a
+# fixture bug rather than a regression.
+CLEANUP_COMMIT=$(git -C "$REPO" log --diff-filter=A --format=%H -- migrations/1788278344.sh | tail -1)
+if [[ -z $CLEANUP_COMMIT ]]; then
+  printf 'not ok - could not find the commit that added the migration\n' >&2
+  exit 1
+fi
+
 new_home() {
   HOMEDIR="$TMP/$1"
   must_be_fixture "$HOMEDIR"
   TPL="$HOMEDIR/.config/hypr/themes/templates"
   mkdir -p "$TPL"
-  cp "$SHIPPED"/*.tpl "$TPL/"
+  while IFS= read -r rel; do
+    git -C "$REPO" show "$CLEANUP_COMMIT:$rel" >"$TPL/$(basename "$rel")"
+  done < <(git -C "$REPO" ls-tree --name-only "$CLEANUP_COMMIT" .config/hypr/themes/templates/ | grep '\.tpl$')
   # A fixture that did not populate must fail loudly rather than let a later
   # check pass against an empty directory.
   if [[ $(ls "$TPL" | wc -l) -eq 0 ]]; then

--- a/test/template-cleanup-test.sh
+++ b/test/template-cleanup-test.sh
@@ -25,25 +25,23 @@ must_be_fixture() {
   fi
 }
 
-# The templates as they were when this migration was written, not as they are
-# now. This fixture stands in for a home that predates the delivery change, and
-# such a home cannot contain a template added afterwards. Copying the current
-# set instead makes the suite fail the moment a template is added, which is a
-# fixture bug rather than a regression.
-CLEANUP_COMMIT=$(git -C "$REPO" log --diff-filter=A --format=%H -- migrations/1788278344.sh | tail -1)
-if [[ -z $CLEANUP_COMMIT ]]; then
-  printf 'not ok - could not find the commit that added the migration\n' >&2
-  exit 1
-fi
+# The templates as they were when this migration was written, pinned as
+# fixtures rather than read from git history. This suite stands in for a home
+# that predates the delivery change, and such a home cannot contain a template
+# added afterwards. Reading history is not an option: CI checks out shallow, so
+# `git log` there resolves to HEAD and hands back the current set, which is the
+# bug this comment exists to prevent recurring.
+PRECLEANUP="$REPO/test/fixtures/templates-precleanup"
 
 new_home() {
   HOMEDIR="$TMP/$1"
   must_be_fixture "$HOMEDIR"
   TPL="$HOMEDIR/.config/hypr/themes/templates"
   mkdir -p "$TPL"
-  while IFS= read -r rel; do
-    git -C "$REPO" show "$CLEANUP_COMMIT:$rel" >"$TPL/$(basename "$rel")"
-  done < <(git -C "$REPO" ls-tree --name-only "$CLEANUP_COMMIT" .config/hypr/themes/templates/ | grep '\.tpl$')
+  for f in "$PRECLEANUP"/*.tpl; do
+    [[ $f == *.OLD.tpl ]] && continue
+    cp "$f" "$TPL/"
+  done
   # A fixture that did not populate must fail loudly rather than let a later
   # check pass against an empty directory.
   if [[ $(ls "$TPL" | wc -l) -eq 0 ]]; then
@@ -96,8 +94,11 @@ check "an added file stops the removal" \
 # the user's work.
 
 new_home stale
-old=$(git -C "$REPO" log --format=%H -- .config/hypr/themes/templates/dunst-colors.tpl | tail -1)
-git -C "$REPO" show "$old:.config/hypr/themes/templates/dunst-colors.tpl" >"$TPL/dunst-colors.tpl"
+# dunst-colors.tpl is the only template with two shipped versions, and the
+# older one is pinned separately. A home that never took that update holds it,
+# which is still not the user's work, and only carrying the full history in the
+# migration lets it be recognised.
+cp "$PRECLEANUP/dunst-colors.OLD.tpl" "$TPL/dunst-colors.tpl"
 run
 check "an older shipped version does not block removal" \
   "$([[ -d $TPL ]] && echo present || echo gone)" "gone"

--- a/test/wlogout-theme-test.sh
+++ b/test/wlogout-theme-test.sh
@@ -102,26 +102,31 @@ fi
 
 # --- 4. the migration installs the colour file before replacing the style --
 
+# The pre-theming style.css, pinned as a fixture rather than read from git
+# history. CI checks out shallow, so `git log ... | tail -1` there resolves to
+# HEAD and hands back the themed file, and the migration checks below would
+# compare it against itself and pass without testing anything.
+PRESPLIT_STYLE="$REPO/test/fixtures/wlogout/style.presplit.css"
+
 new_home() {
   HOMEDIR="$TMP/$1"
   must_be_fixture "$HOMEDIR"
   mkdir -p "$HOMEDIR/.config/wlogout"
-  git -C "$REPO" show "$2:.config/wlogout/style.css" >"$HOMEDIR/.config/wlogout/style.css"
-  if [[ ! -s $HOMEDIR/.config/wlogout/style.css ]]; then
-    printf 'not ok - fixture style.css did not populate (%s)\n' "$1" >&2
+  cp "$PRESPLIT_STYLE" "$HOMEDIR/.config/wlogout/style.css"
+  if ! grep -q '#11111b' "$HOMEDIR/.config/wlogout/style.css"; then
+    printf 'not ok - fixture is not the pre-theming stylesheet (%s)\n' "$1" >&2
     exit 1
   fi
 }
-first_style=$(git -C "$REPO" log --format=%H -- .config/wlogout/style.css | tail -1)
 
-new_home pristine "$first_style"
+new_home pristine
 HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/mig_out" 2>&1
 check "a pristine style.css is replaced with the themed one" \
   "$(cmp -s "$HOMEDIR/.config/wlogout/style.css" "$STYLE" && echo same || echo different)" "same"
 check "and the file it imports exists afterwards" \
   "$([[ -f $HOMEDIR/.config/wlogout/wlogout-colors.css ]] && echo yes || echo no)" "yes"
 
-new_home edited "$first_style"
+new_home edited
 printf '\n/* mine */\n' >>"$HOMEDIR/.config/wlogout/style.css"
 before=$(md5sum "$HOMEDIR/.config/wlogout/style.css" | cut -d' ' -f1)
 HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/mig_edit" 2>&1

--- a/test/wlogout-theme-test.sh
+++ b/test/wlogout-theme-test.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Checks that wlogout follows the active theme: the template renders, the theme
+# switcher installs the colours, the stylesheet parses, and the migration never
+# leaves style.css importing a file that is not there.
+# Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RENDER="$REPO/.local/bin/theme-apply-templates.sh"
+MIGRATION="$REPO/migrations/1788279207.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+# --- 1. the stylesheet is themed, not hardcoded ---------------------------
+
+STYLE="$REPO/.config/wlogout/style.css"
+check "style.css imports the colour file" \
+  "$(grep -c '@import url("wlogout-colors.css")' "$STYLE")" "1"
+check "style.css has no hardcoded catppuccin colours left" \
+  "$(grep -cE '#(11111b|cdd6f4)' "$STYLE")" "0"
+check "a fallback colour file is shipped" \
+  "$([[ -f $REPO/.config/wlogout/wlogout-colors.css ]] && echo yes || echo no)" "yes"
+check "every colour the stylesheet names is defined by the fallback" \
+  "$(grep -oE '@wl_[a-z]+' "$STYLE" | sort -u | while read -r c; do
+       grep -q "define-color ${c#@} " "$REPO/.config/wlogout/wlogout-colors.css" || echo miss
+     done | grep -c miss)" "0"
+
+# --- 2. the template renders from a theme ---------------------------------
+
+THEME="$TMP/theme"
+must_be_fixture "$THEME"
+INST="$TMP/install"
+HOMEDIR="$TMP/home"
+mkdir -p "$INST/.config/hypr/themes" "$HOMEDIR/.config"
+cp -r "$REPO/.config/hypr/themes/templates" "$INST/.config/hypr/themes/templates"
+mkdir -p "$THEME"
+printf 'background = "#2d353b"\nforeground = "#d3c6aa"\n' >"$THEME/colors.toml"
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INST" bash "$RENDER" "$THEME" >/dev/null 2>&1
+check "the theme's background reaches the rendered colours" \
+  "$(grep -c 'wl_background #2d353b' "$THEME/generated/wlogout-colors.css")" "1"
+check "the theme's foreground reaches the rendered colours" \
+  "$(grep -c 'wl_foreground #d3c6aa' "$THEME/generated/wlogout-colors.css")" "1"
+
+# --- 3. GTK actually parses the pair ---------------------------------------
+#
+# The failure this guards against is specific: GTK treats a missing @import as
+# fatal and returns an empty stylesheet, so wlogout renders with no styling at
+# all. Asserting the file merely exists would not catch a stylesheet that
+# parses to nothing.
+
+PARSE="$TMP/parse"
+mkdir -p "$PARSE"
+cp "$STYLE" "$PARSE/style.css"
+cp "$THEME/generated/wlogout-colors.css" "$PARSE/wlogout-colors.css"
+if python3 -c "import gi; gi.require_version('Gtk','3.0')" 2>/dev/null; then
+  parsed=$(python3 - "$PARSE/style.css" <<'PY'
+import sys, gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gio
+p = Gtk.CssProvider()
+try:
+    p.load_from_file(Gio.File.new_for_path(sys.argv[1]))
+except Exception:
+    print("error"); raise SystemExit
+print("empty" if not p.to_string().strip() else "styled")
+PY
+)
+  check "GTK parses the stylesheet with its colours to a non-empty result" "$parsed" "styled"
+
+  rm -f "$PARSE/wlogout-colors.css"
+  broken=$(python3 - "$PARSE/style.css" <<'PY'
+import sys, gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gio
+p = Gtk.CssProvider()
+try:
+    p.load_from_file(Gio.File.new_for_path(sys.argv[1]))
+except Exception:
+    print("error"); raise SystemExit
+print("empty" if not p.to_string().strip() else "styled")
+PY
+)
+  check "and without the colour file it is fatal, which is why order matters" "$broken" "error"
+else
+  printf 'skip - python gtk3 bindings absent, stylesheet not parsed\n'
+fi
+
+# --- 4. the migration installs the colour file before replacing the style --
+
+new_home() {
+  HOMEDIR="$TMP/$1"
+  must_be_fixture "$HOMEDIR"
+  mkdir -p "$HOMEDIR/.config/wlogout"
+  git -C "$REPO" show "$2:.config/wlogout/style.css" >"$HOMEDIR/.config/wlogout/style.css"
+  if [[ ! -s $HOMEDIR/.config/wlogout/style.css ]]; then
+    printf 'not ok - fixture style.css did not populate (%s)\n' "$1" >&2
+    exit 1
+  fi
+}
+first_style=$(git -C "$REPO" log --format=%H -- .config/wlogout/style.css | tail -1)
+
+new_home pristine "$first_style"
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/mig_out" 2>&1
+check "a pristine style.css is replaced with the themed one" \
+  "$(cmp -s "$HOMEDIR/.config/wlogout/style.css" "$STYLE" && echo same || echo different)" "same"
+check "and the file it imports exists afterwards" \
+  "$([[ -f $HOMEDIR/.config/wlogout/wlogout-colors.css ]] && echo yes || echo no)" "yes"
+
+new_home edited "$first_style"
+printf '\n/* mine */\n' >>"$HOMEDIR/.config/wlogout/style.css"
+before=$(md5sum "$HOMEDIR/.config/wlogout/style.css" | cut -d' ' -f1)
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/mig_edit" 2>&1
+check "an edited style.css is left byte-identical" \
+  "$(md5sum "$HOMEDIR/.config/wlogout/style.css" | cut -d' ' -f1)" "$before"
+check "and the user is told how to take it" \
+  "$(grep -c 'refresh-config.sh wlogout/style.css' "$TMP/mig_edit")" "1"
+
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >/dev/null 2>&1
+check "a second run exits 0" "$?" "0"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
wlogout's two colours were `#11111b` and `#cdd6f4`, which are catppuccin's crust and foreground, hardcoded. Nothing wrote the file and no wlogout template existed, so the power menu stayed catppuccin on every other theme. Found while classifying `wlogout/style.css` in #46 and recorded there rather than fixed, since it is a feature.

## What changed

`style.css` imports `wlogout-colors.css`, which a theme switch rewrites from the theme's `colors.toml` through a new `wlogout-colors.css.tpl`. All 16 shipped themes define the `background` and `foreground` it needs, checked rather than assumed.

## The ordering is the whole risk

GTK treats a missing `@import` as a **fatal parse error** and returns an **empty stylesheet**. Verified against `Gtk.CssProvider`, not assumed. That is worse than hyprlang's silent `found no match`, and much worse than rofi's, where a missing import costs only the imported properties: here any moment when `style.css` exists without the file it imports leaves the power menu completely unstyled.

Three things follow from that, and each is deliberate:

- A fallback `wlogout-colors.css` ships in the repository, so the import resolves from a fresh install before any theme switch has happened.
- `theme-switcher.sh` **copies** rather than symlinks the generated file, so a theme without `colors.toml` keeps the previous colours instead of leaving a dangling link.
- The migration writes the colour file **before** it touches the stylesheet.

There is a check asserting that a missing colour file really is fatal, so the reason for that ordering cannot quietly stop being true.

## Testing

New `test/wlogout-theme-test.sh`, 13 checks, wired into the workflow by name, which now also installs `python3-gi` and `gir1.2-gtk-3.0` so CI parses the stylesheet rather than skipping.

It parses the real pair through GTK and asserts the result is non-empty, because asserting the file merely exists would not catch a stylesheet that parses to nothing. It also checks that every `@wl_*` colour the stylesheet names is defined by the shipped fallback, so adding a colour to one without the other is caught.

Every check is sabotage-tested. Replacing the stylesheet before installing the colour file turns one red, dropping the pristine gate turns two, reverting to hardcoded colours turns three, and naming an undefined colour turns one.

## A fixture bug this surfaced

Adding a template broke `template-cleanup-test.sh`. Its fixture copied the **current** shipped templates into a home meant to represent a pre-#44 install, and such a home cannot contain a template added afterwards. The fixture now builds from the templates as of the commit that introduced that migration, derived with `git log --diff-filter=A` rather than a hardcoded SHA. Re-sabotaging the migration still turns five checks red, so the fixture change did not weaken it.

## Verified live

Rendering the everforest theme produces `#2d353b` and `#d3c6aa`, and GTK resolves the stylesheet to those instead of catppuccin's.

All 18 suites pass, run with `init.defaultBranch` forced to `master` so the CI default is covered locally.