### PR TITLE
Render the new wlogout template for themes that already exist

### DIFF
--- a/migrations/1788280106.sh
+++ b/migrations/1788280106.sh
@@ -1,0 +1,33 @@
+echo "Render the new wlogout colours for the themes you already have"
+
+# The migration that themed wlogout installed the shipped fallback and updated
+# style.css, but nothing rendered the new template, so every existing install
+# sat on the fallback's catppuccin colours until its next theme switch. The
+# template is a new build input, and a build input that is never built reaches
+# nobody. 1788069834.sh had the same shape and re-rendered for the same reason.
+
+THEMES="$HOME/.config/hypr/themes"
+RENDER="$HOME/.local/bin/theme-apply-templates.sh"
+[[ -d $THEMES && -x $RENDER ]] || exit 0
+[[ -f $HYPRSIMPLE_PATH/.config/hypr/themes/templates/wlogout-colors.css.tpl ]] || exit 0
+
+# Idempotent: rendering is deterministic from colors.toml, so a re-run writes
+# the same bytes. Only themes that can be rendered at all are touched.
+rendered=0
+for dir in "$THEMES"/*/; do
+  name=$(basename "$dir")
+  [[ $name == templates || $name == templates.user ]] && continue
+  [[ -f $dir/colors.toml ]] || continue
+  "$RENDER" "$dir" >/dev/null 2>&1 && rendered=$((rendered + 1))
+done
+echo "Rendered templates for $rendered theme(s)"
+
+# Then put the active theme's colours where wlogout reads them. theme-active.lua
+# points into the active theme's generated directory, which is the same place
+# theme-switcher.sh copies from.
+active=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null)
+if [[ -n $active && -f ${active%/*}/wlogout-colors.css ]]; then
+  mkdir -p "$HOME/.config/wlogout"
+  cp "${active%/*}/wlogout-colors.css" "$HOME/.config/wlogout/wlogout-colors.css"
+  echo "wlogout now uses your active theme's colours"
+fi

--- a/test/wlogout-theme-test.sh
+++ b/test/wlogout-theme-test.sh
@@ -138,6 +138,40 @@ check "and the user is told how to take it" \
 HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >/dev/null 2>&1
 check "a second run exits 0" "$?" "0"
 
+# --- 5. the follow-up migration renders the new template ------------------
+#
+# The theming migration installs the fallback and updates style.css but does
+# not render, so without this an existing install sits on the fallback's
+# catppuccin colours until its next theme switch. A build input that is never
+# built reaches nobody.
+
+RENDER_MIGRATION="$REPO/migrations/1788280106.sh"
+
+HOMEDIR="$TMP/render"
+must_be_fixture "$HOMEDIR"
+mkdir -p "$HOMEDIR/.local/bin" "$HOMEDIR/.config/hypr/themes/solo" "$HOMEDIR/.config/wlogout"
+cp "$RENDER" "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+chmod +x "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+printf 'background = "#2d353b"\nforeground = "#d3c6aa"\n' >"$HOMEDIR/.config/hypr/themes/solo/colors.toml"
+mkdir -p "$HOMEDIR/.config/hypr/themes/solo/generated"
+ln -sfn "$HOMEDIR/.config/hypr/themes/solo/generated/hyprland-colors.lua" \
+  "$HOMEDIR/.config/hypr/theme-active.lua"
+cp "$REPO/.config/wlogout/wlogout-colors.css" "$HOMEDIR/.config/wlogout/wlogout-colors.css"
+
+check "before the render migration wlogout holds the fallback" \
+  "$(grep -c 'wl_background #11111b' "$HOMEDIR/.config/wlogout/wlogout-colors.css")" "1"
+
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$RENDER_MIGRATION" >"$TMP/render_out" 2>&1
+check "the template is rendered for an existing theme" \
+  "$(grep -c 'wl_background #2d353b' "$HOMEDIR/.config/hypr/themes/solo/generated/wlogout-colors.css")" "1"
+check "and the active theme's colours reach wlogout" \
+  "$(grep -c 'wl_background #2d353b' "$HOMEDIR/.config/wlogout/wlogout-colors.css")" "1"
+
+before_render=$(md5sum "$HOMEDIR/.config/wlogout/wlogout-colors.css" | cut -d' ' -f1)
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$RENDER_MIGRATION" >/dev/null 2>&1
+check "a second render run changes nothing" \
+  "$(md5sum "$HOMEDIR/.config/wlogout/wlogout-colors.css" | cut -d' ' -f1)" "$before_render"
+
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
#47 themed wlogout, and it reached new installs only. Found by running the update on a real machine straight after merging it and seeing the power menu still catppuccin.

## What was missing

#47's migration installed the shipped fallback and updated `style.css`, but nothing rendered the new template. The fallback carries catppuccin's colours by design, since it only has to exist so the `@import` resolves before any theme switch. So an existing install got a stylesheet correctly wired to a file holding the wrong colours, and stayed there until its next theme switch.

A template is a build input, and a build input that is never built reaches nobody. `1788069834.sh` had exactly this shape and re-rendered for the same reason, which is the precedent I should have followed the first time.

## What changed

One migration renders every theme that has a `colors.toml`, then copies the active theme's result to where wlogout reads it. `theme-active.lua` points into the active theme's generated directory, which is the same place `theme-switcher.sh` copies from, so this is the switch's own path rather than a parallel one.

Idempotent: rendering is deterministic from `colors.toml`, so a re-run writes the same bytes, and there is a check for that.

## Testing

Four checks added to `test/wlogout-theme-test.sh`, which now covers both migrations. The first asserts the fixture really is on the fallback before the migration runs, so the later checks cannot pass against a home that was already correct.

Both sabotages land: skipping the render loop turns two red, and rendering without copying to wlogout turns one red.

Verified on a shallow clone with `init.defaultBranch` forced to `master`, since two suites were recently broken by assuming otherwise.