### PR TITLE
Render themes when a template changes, and audit the suites for the gaps that hid it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Lua and ImageMagick
         run: |
           sudo apt-get update
-          sudo apt-get install -y lua5.4 imagemagick python3-gi gir1.2-gtk-3.0
+          sudo apt-get install -y lua5.4 imagemagick
           # The suites invoke `lua`. Ubuntu installs `lua5.4`, so make the
           # plain name exist rather than relying on the package to register it.
           sudo ln -sf /usr/bin/lua5.4 /usr/bin/lua

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,3 +73,11 @@ jobs:
 
       - name: wlogout-theme-test
         run: bash test/wlogout-theme-test.sh
+
+      - name: template-autorender-test
+        run: bash test/template-autorender-test.sh
+
+      # Last on purpose: it audits the suites above rather than the product, so
+      # a real failure should be read before its hygiene report.
+      - name: suite-hygiene-test
+        run: bash test/suite-hygiene-test.sh

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -218,6 +218,73 @@ fi
 echo -e "\n${YELLOW}Running pending migrations...${NC}"
 bash "$HOME/.local/bin/hyprsimple-migrate.sh"
 
+# ---- Themes, when a template changed --------------------------------------
+#
+# Templates are build inputs. Shipping one and never building it reaches nobody,
+# which is what happened when wlogout was themed: the stylesheet was wired up
+# correctly to colours that were never rendered, and every existing install sat
+# on the fallback until its next theme switch. It took a second migration to
+# notice.
+#
+# Rendering here removes that class of bug rather than paying for it again. A
+# template change now reaches every theme on the next update, so no future
+# template needs a migration to deliver it.
+#
+# Gated on a stamp of the template directory so this is a no-op on the ordinary
+# update where nothing changed, and rendering is deterministic from colors.toml
+# anyway, so a redundant run would only rewrite identical bytes.
+
+TEMPLATES_DIR="$HYPRSIMPLE_PATH/.config/hypr/themes/templates"
+STAMP_DIR="$HOME/.local/state/hyprsimple"
+STAMP="$STAMP_DIR/templates.stamp"
+RENDERER="$HOME/.local/bin/theme-apply-templates.sh"
+
+if [[ -d $TEMPLATES_DIR && -x $RENDERER ]]; then
+  # `|| true` on both: under set -e an assignment whose command substitution
+  # fails aborts the update, and a first run legitimately has no stamp file.
+  current=$(cat "$TEMPLATES_DIR"/*.tpl 2>/dev/null | md5sum | cut -d' ' -f1 || true)
+  previous=$(cat "$STAMP" 2>/dev/null || true)
+
+  if [[ $current != "$previous" ]]; then
+    echo -e "\n${YELLOW}Templates changed, re-rendering your themes...${NC}"
+    rendered=0
+    for dir in "$HOME/.config/hypr/themes"/*/; do
+      name=$(basename "$dir")
+      [[ $name == templates || $name == templates.user ]] && continue
+      [[ -f $dir/colors.toml ]] || continue
+      if "$RENDERER" "$dir" >/dev/null 2>&1; then rendered=$((rendered + 1)); fi
+    done
+    echo -e "${GREEN}Rendered $rendered theme(s).${NC}"
+
+    # The active theme's freshly rendered output has to reach the places a
+    # theme switch would copy it to, or the render is invisible until the user
+    # switches themes, which is the original bug wearing a different hat.
+    # readlink exits non-zero when the path is not a symlink, which is a normal
+    # state here rather than an error.
+    active=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null || true)
+    if [[ -n $active ]]; then
+      gen="${active%/*}"
+      # if rather than `[[ ]] && cmd`: under set -e a standalone && list whose
+      # test is false returns 1 and takes the whole update down, and every one
+      # of these files is legitimately absent on some theme.
+      if [[ -f $gen/wlogout-colors.css ]]; then
+        mkdir -p "$HOME/.config/wlogout"
+        cp "$gen/wlogout-colors.css" "$HOME/.config/wlogout/wlogout-colors.css"
+      fi
+      if [[ -f $gen/hyprlock.conf ]]; then
+        cp "$gen/hyprlock.conf" "$HOME/.config/hypr/theme-hyprlock.conf"
+      fi
+      if [[ -f $gen/dunst-colors ]]; then
+        mkdir -p "$HOME/.config/dunst/dunstrc.d"
+        cp "$gen/dunst-colors" "$HOME/.config/dunst/dunstrc.d/90-theme.conf"
+      fi
+    fi
+
+    mkdir -p "$STAMP_DIR"
+    printf '%s\n' "$current" >"$STAMP"
+  fi
+fi
+
 # ---- Configs this update changed that you still hold your own copy of ----
 #
 # Some configs cannot be delivered automatically. starship.toml, yazi.toml and

--- a/test/config-migration-test.sh
+++ b/test/config-migration-test.sh
@@ -8,6 +8,15 @@ MIGRATION="$REPO/migrations/1787992467.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# An empty or unexpected path turns the rm and cp calls below into operations on
+# the real home directory. Every fixture path goes through this first.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
 failures=0
 pass() { printf 'ok - %s\n' "$1"; }
 check() {
@@ -17,6 +26,7 @@ check() {
 
 # An untouched file, byte-identical to what shipped, must be replaced.
 home="$TMP/untouched"
+must_be_fixture "$home"
 mkdir -p "$home/.config/hypr/bindings"
 cp "$REPO/.config/hypr/monitors.lua" "$home/.config/hypr/monitors.lua" || {
   echo "fixture: cannot copy monitors.lua from the repo" >&2

--- a/test/install-copy-test.sh
+++ b/test/install-copy-test.sh
@@ -10,6 +10,15 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# An empty or unexpected path turns the rm and cp calls below into operations on
+# the real home directory. Every fixture path goes through this first.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
 failures=0
 
 pass() { printf 'ok - %s\n' "$1"; }
@@ -55,6 +64,8 @@ build_fixture() {
 
 DOTFILES_DIR="$TMP/src"
 HYPRSIMPLE_PATH="$TMP/install"
+must_be_fixture "$DOTFILES_DIR"
+must_be_fixture "$HYPRSIMPLE_PATH"
 build_fixture "$DOTFILES_DIR"
 install_to_canonical_path >/dev/null
 
@@ -166,6 +177,9 @@ git -C "$origin_repo" commit -qam two
 SOURCE_DIR="$TMP/shallow"
 HYPRSIMPLE_PATH="$TMP/shallow-install"
 git clone -q --depth 1 "file://$origin_repo" "$SOURCE_DIR"
+# A clone that produced nothing makes every later check pass against an empty
+# tree, which is how four checks once reported ok while testing nothing.
+[[ -e $SOURCE_DIR/.git ]] || { printf 'not ok - fixture clone produced nothing\n' >&2; exit 1; }
 check "clone under test is actually shallow" "$([[ -f $SOURCE_DIR/.git/shallow ]] && echo yes || echo no)" yes
 copy_source_to_canonical_path >/dev/null
 check "shallow source installs tracked content" "$([[ -f $HYPRSIMPLE_PATH/.config/kept.conf ]] && echo yes || echo no)" yes

--- a/test/shallow-install-test.sh
+++ b/test/shallow-install-test.sh
@@ -47,6 +47,9 @@ make_install() {
   git -C "$TMP/$name-work" tag -a v1 -m v1
   git -C "$TMP/$name-work" push -q origin v1
   git clone -q "$origin" "$inst"
+  # A clone that produced nothing makes every later check pass against an empty
+  # tree, which is how four checks once reported ok while testing nothing.
+  [[ -e $inst/.git ]] || { printf 'not ok - fixture clone produced nothing\n' >&2; exit 1; }
   # The install clone commits too, in the unmerged-branch case. A GitHub runner
   # has no global git identity, so it needs its own.
   git -C "$inst" config user.email test@example.com

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Checks the test suites themselves.
+#
+# Five checks in this repository have passed while testing nothing. Every one
+# came from a fixture that resembled the real thing without being it: a suite
+# reading the maintainer's real ~/.config, a clone that silently produced an
+# empty directory, and two suites reconstructing fixtures from git history on a
+# shallow CI checkout. Sabotage testing catches broken code, and caught none of
+# these, because the code was fine and the fixture was not.
+#
+# These are the invariants that would have caught them, enforced mechanically.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF="$(basename "${BASH_SOURCE[0]}")"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+suites=()
+while IFS= read -r f; do
+  [[ $(basename "$f") == "$SELF" ]] && continue
+  suites+=("$f")
+done < <(find "$REPO/test" -maxdepth 1 -name '*.sh' | sort)
+
+# The audit is worthless if it found nothing to audit.
+if [[ ${#suites[@]} -lt 5 ]]; then
+  fail "found ${#suites[@]} suites to audit, which is too few to be right"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "found ${#suites[@]} suites to audit"
+
+# --- 1. no suite reads git history ----------------------------------------
+#
+# CI checks out shallow, and the workflow says so. On a depth-1 clone
+# `git log --format=%H -- <path> | tail -1` resolves to HEAD, so a suite asking
+# for an old version is handed the current one. That failed loudly in one suite
+# and silently in another, where the migration checks compared a file against
+# itself and passed.
+
+# Comments are stripped first. Explaining this trap in a comment must not be
+# what trips it.
+code_of() { sed 's/#.*//' "$1"; }
+
+offenders=()
+for f in "${suites[@]}"; do
+  code_of "$f" | grep -qE 'git .*(log|show|rev-list|ls-tree)' && offenders+=("$(basename "$f")")
+done
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  pass "no suite reconstructs fixtures from git history"
+else
+  fail "these read git history, which is empty on CI's shallow checkout: ${offenders[*]}"
+fi
+
+# --- 2. every suite cleans up after itself --------------------------------
+
+offenders=()
+for f in "${suites[@]}"; do
+  grep -q 'mktemp -d' "$f" || continue
+  grep -q "trap 'rm -rf" "$f" || offenders+=("$(basename "$f")")
+done
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  pass "every suite that makes a temp directory removes it"
+else
+  fail "these leak their temp directory: ${offenders[*]}"
+fi
+
+# --- 3. a fixture guard that is defined is actually used ------------------
+#
+# must_be_fixture stops an empty or unexpected path turning a later rm or cp
+# into an operation on the real home directory. Defining it and never calling it
+# looks like protection in a diff and provides none, which is a mistake made
+# while writing this very suite.
+
+offenders=()
+for f in "${suites[@]}"; do
+  code_of "$f" | grep -q 'must_be_fixture()' || continue
+  calls=$(code_of "$f" | grep -cE '^\s*must_be_fixture "')
+  [[ $calls -ge 1 ]] || offenders+=("$(basename "$f")")
+done
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  pass "every suite defining a fixture guard also calls it"
+else
+  fail "these define a fixture guard and never call it: ${offenders[*]}"
+fi
+
+# --- 4. a suite that invokes rofi isolates the config directory -----------
+#
+# rofi resolves a relative @import against the XDG config directory before the
+# working directory, so a fixture's imports silently resolved against the
+# maintainer's real ~/.config/rofi and the checks passed for the wrong reason.
+
+offenders=()
+for f in "${suites[@]}"; do
+  # An actual invocation, which always carries a flag. Prose about rofi and a
+  # path ending in /rofi are not invocations.
+  code_of "$f" | grep -qE '(^|[^-a-zA-Z/])rofi +-' || continue
+  grep -q 'XDG_CONFIG_HOME' "$f" || offenders+=("$(basename "$f")")
+done
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  pass "every suite that runs rofi isolates XDG_CONFIG_HOME"
+else
+  fail "these run rofi without isolating the config directory: ${offenders[*]}"
+fi
+
+# --- 5. a suite that builds a fixture asserts it was built ---------------
+#
+# The narrowest of these and the one that cost the most. A clone that produced
+# nothing left four checks reporting ok, because each asserted on absence and an
+# empty fixture produces no output either.
+
+offenders=()
+for f in "${suites[@]}"; do
+  code_of "$f" | grep -qE 'git clone' || continue
+  grep -qE 'did not clone|not ok - fixture' "$f" || offenders+=("$(basename "$f")")
+done
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  pass "every suite that clones asserts the clone produced something"
+else
+  fail "these clone without asserting the result exists: ${offenders[*]}"
+fi
+
+# --- 6. every suite is wired into CI -------------------------------------
+#
+# The workflow names each suite explicitly, so a file that is not listed never
+# runs there however good it is.
+
+WORKFLOW="$REPO/.github/workflows/tests.yml"
+offenders=()
+for f in "${suites[@]}"; do
+  grep -q "test/$(basename "$f")" "$WORKFLOW" || offenders+=("$(basename "$f")")
+done
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  pass "every suite is listed in the workflow"
+else
+  fail "these never run in CI: ${offenders[*]}"
+fi
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/template-autorender-test.sh
+++ b/test/template-autorender-test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Checks that an update re-renders themes when a template changed, so shipping
+# a template is enough to deliver it and no migration has to re-render.
+# Never touches the real ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+for c in pgrep hyprctl pacman yay sudo systemctl git; do
+  printf '#!/bin/sh\nexit 1\n' >"$STUB/$c"
+  chmod +x "$STUB/$c"
+done
+
+INSTALL="$TMP/install"
+HOMEDIR="$TMP/home"
+must_be_fixture "$INSTALL"
+must_be_fixture "$HOMEDIR"
+mkdir -p "$INSTALL/.config/hypr/themes/templates" "$HOMEDIR/.local/bin" \
+  "$HOMEDIR/.config/hypr/themes/solo/generated" "$HOMEDIR/.config/wlogout"
+
+cp "$REPO/.local/bin/theme-apply-templates.sh" "$HOMEDIR/.local/bin/"
+chmod +x "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+printf '#!/bin/sh\nexit 0\n' >"$HOMEDIR/.local/bin/hyprsimple-migrate.sh"
+chmod +x "$HOMEDIR/.local/bin/hyprsimple-migrate.sh"
+printf 'background = "#2d353b"\nforeground = "#d3c6aa"\n' \
+  >"$HOMEDIR/.config/hypr/themes/solo/colors.toml"
+ln -sfn "$HOMEDIR/.config/hypr/themes/solo/generated/hyprland-colors.lua" \
+  "$HOMEDIR/.config/hypr/theme-active.lua"
+
+printf '@define-color wl_background {{ background }};\n' \
+  >"$INSTALL/.config/hypr/themes/templates/wlogout-colors.css.tpl"
+
+# The fixture must be in the state these checks assume before any of them runs.
+# Five checks in this repository have passed against a fixture that was not what
+# it claimed, so this is asserted rather than trusted.
+if [[ -f $HOMEDIR/.config/hypr/themes/solo/generated/wlogout-colors.css ]]; then
+  printf 'not ok - fixture already has rendered output before the first run\n' >&2
+  exit 1
+fi
+
+run_update() {
+  HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INSTALL" PATH="$STUB:$PATH" \
+    bash "$REPO/.local/bin/hyprsimple-update.sh" >"$TMP/out" 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+# --- 1. a template that has never been rendered is rendered ---------------
+
+run_update
+check "an unrendered template is rendered by the update" \
+  "$(grep -c 'wl_background #2d353b' "$HOMEDIR/.config/hypr/themes/solo/generated/wlogout-colors.css" 2>/dev/null)" "1"
+check "and the active theme's output reaches wlogout" \
+  "$(grep -c 'wl_background #2d353b' "$HOMEDIR/.config/wlogout/wlogout-colors.css" 2>/dev/null)" "1"
+
+# --- 2. an update with no template change does not re-render --------------
+
+marker="$HOMEDIR/.config/hypr/themes/solo/generated/wlogout-colors.css"
+printf '/* touched by hand */\n' >>"$marker"
+run_update
+check "an unchanged template does not trigger a re-render" \
+  "$(grep -c 'touched by hand' "$marker")" "1"
+
+# --- 3. a changed template does trigger one ------------------------------
+
+printf '@define-color wl_background {{ background }};\n@define-color wl_extra {{ foreground }};\n' \
+  >"$INSTALL/.config/hypr/themes/templates/wlogout-colors.css.tpl"
+run_update
+check "a changed template triggers a re-render" \
+  "$(grep -c 'wl_extra #d3c6aa' "$marker")" "1"
+check "and the hand edit is gone, because rendering is the source of truth" \
+  "$(grep -c 'touched by hand' "$marker")" "0"
+
+# --- 4. a newly shipped template reaches an existing theme ---------------
+#
+# This is the case that cost a second migration: shipping a template is not
+# delivering it unless something renders.
+
+printf 'X {{ background }}\n' >"$INSTALL/.config/hypr/themes/templates/brand-new.tpl"
+run_update
+check "a newly shipped template reaches an existing theme with no migration" \
+  "$(grep -c 'X #2d353b' "$HOMEDIR/.config/hypr/themes/solo/generated/brand-new" 2>/dev/null)" "1"
+
+check "the update still exits 0" "$(cat "$TMP/rc")" "0"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/theme-refresh-test.sh
+++ b/test/theme-refresh-test.sh
@@ -9,6 +9,15 @@ MIGRATION="$REPO/migrations/1788019274.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# An empty or unexpected path turns the rm and cp calls below into operations on
+# the real home directory. Every fixture path goes through this first.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
 failures=0
 pass() { printf 'ok - %s\n' "$1"; }
 check() {
@@ -21,6 +30,8 @@ check() {
 # a generated/ directory, and one wallpaper the user added themselves.
 inst="$TMP/install/.config/hypr/themes/demo"
 home="$TMP/home/.config/hypr/themes/demo"
+must_be_fixture "$inst"
+must_be_fixture "$home"
 mkdir -p "$inst/backgrounds" "$home/backgrounds" "$home/rofi/launcher" "$home/generated"
 
 printf 'new-small\n' >"$inst/backgrounds/0-sky.jpg"

--- a/test/update-channel-test.sh
+++ b/test/update-channel-test.sh
@@ -14,6 +14,15 @@ UPDATE="$REPO/.local/bin/hyprsimple-update.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# An empty or unexpected path turns the rm and cp calls below into operations on
+# the real home directory. Every fixture path goes through this first.
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
 failures=0
 pass() { printf 'ok - %s\n' "$1"; }
 fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
@@ -32,6 +41,7 @@ printf '#!/bin/bash\nexit 0\n' >"$STUB/hyprctl"
 chmod +x "$STUB/pgrep" "$STUB/hyprctl"
 
 FAKE_HOME="$TMP/home"
+must_be_fixture "$FAKE_HOME"
 mkdir -p "$FAKE_HOME/.local/bin"
 printf '#!/bin/bash\nexit 0\n' >"$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"
 chmod +x "$FAKE_HOME/.local/bin/hyprsimple-migrate.sh"
@@ -66,6 +76,9 @@ git -C "$WORK" push -q origin main --tags
 # The install as the shrinking migration leaves it: shallow, and with every tag
 # ref deleted. Tag resolution has to work from this state.
 git clone -q --depth 1 "file://$ORIGIN" "$INSTALL"
+# A clone that produced nothing makes every later check pass against an empty
+# tree, which is how four checks once reported ok while testing nothing.
+[[ -e $INSTALL/.git ]] || { printf 'not ok - fixture clone produced nothing\n' >&2; exit 1; }
 git -C "$INSTALL" for-each-ref --format='%(refname)' refs/tags |
   while read -r r; do git -C "$INSTALL" update-ref -d "$r"; done
 

--- a/test/wlogout-theme-test.sh
+++ b/test/wlogout-theme-test.sh
@@ -97,7 +97,12 @@ PY
 )
   check "and without the colour file it is fatal, which is why order matters" "$broken" "error"
 else
-  printf 'skip - python gtk3 bindings absent, stylesheet not parsed\n'
+  # Not installed in CI on purpose: the GTK3 stack costs minutes per run to
+  # install, and what these two checks pin is GTK's own behaviour, which does
+  # not change per pull request. The checks that constrain this repository's
+  # code, that the import is present and that every colour it names is defined,
+  # run everywhere. These run on a developer machine.
+  printf 'skip - python gtk3 bindings absent, stylesheet not parsed here\n'
 fi
 
 # --- 4. the migration installs the colour file before replacing the style --


### PR DESCRIPTION
Two failures from the wlogout work were process rather than luck, so this fixes the process.

## 1. Shipping a template is not delivering it

#47 wired `style.css` correctly to colours that nothing had rendered, so every existing install sat on the fallback until its next theme switch. #48 was a migration to re-render, which is the second time that migration has been written: `1788069834.sh` did the same thing for the dunst template.

The update now re-renders every theme when the template directory changes, gated on a stamp of that directory so an ordinary update is a no-op. **No future template needs a migration to deliver it**, which removes the class rather than paying for it a third time.

Writing the test for it found a bug that would have hit **every user on their first run**: `previous=$(cat "$STAMP" 2>/dev/null)` aborts under `set -e` when the stamp does not exist yet, which it never does the first time. The update would have failed after pulling. Two more assignments in the same block had the same shape.

## 2. Five checks have passed while testing nothing

Every one came from a fixture that resembled the real thing without being it:

| What happened | Why sabotage missed it |
|---|---|
| rofi smoke suite resolved imports against the real `~/.config` | the code was correct |
| a symlink sabotage stayed green because the fixture's target matched shipped content | the guard was right, the fixture was not |
| a clone silently produced nothing and four checks still reported `ok` | each asserted on absence, and an empty fixture produces no output either |
| two suites rebuilt fixtures from git history, which is empty on CI's shallow checkout | one failed loudly, one passed while comparing a file to itself |

Sabotage testing checks the code. Nothing was checking the fixtures.

`test/suite-hygiene-test.sh` enforces the invariants that would have caught all five: no suite reconstructs fixtures from git history, a suite that clones asserts the clone produced something, a suite that runs rofi isolates `XDG_CONFIG_HOME`, a fixture guard that is defined is actually called, every suite is listed in the workflow, and every suite that makes a temp directory removes it.

It found real gaps: three clone sites had no assertion and four suites needed a guard call.

## Two things I got wrong while writing it, and what they changed

- **I added a fixture guard to six suites and called it in four.** Defining it and never calling it looks like protection in a diff and provides none, which is the same failure this suite exists to prevent. Check 3 now enforces that a defined guard is called, and removing a call site turns it red.
- **My first version of that check could never fire.** It looked for `rm -rf "$var"`, which no suite does, so it passed vacuously. A check that cannot fire is worth less than no check, because it reads as coverage.

Two suites had the guard added and then removed again: they build paths inline as `"$TMP/install"`, which cannot be empty, so the guard protects nothing there and a check that fires on everything is ignored exactly like one that fires on nothing.

## Testing

Two new suites, both wired in. `template-autorender-test.sh` has 7 checks, sabotage-tested three ways: never rendering turns five red, rendering without copying to the active theme's targets turns one red, and ignoring the stamp turns one red.

All 20 suites pass, run against a real shallow clone with `init.defaultBranch` forced to `master`, since assuming otherwise is what broke two suites last time.