### PR TITLE
Correct a comment that explained a bug wrongly

### DIFF
--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -264,9 +264,15 @@ if [[ -d $TEMPLATES_DIR && -x $RENDERER ]]; then
     active=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null || true)
     if [[ -n $active ]]; then
       gen="${active%/*}"
-      # if rather than `[[ ]] && cmd`: under set -e a standalone && list whose
-      # test is false returns 1 and takes the whole update down, and every one
-      # of these files is legitimately absent on some theme.
+      # Plain if blocks, because each of these files is legitimately absent on
+      # some themes and the intent reads better than a chain of && lists.
+      #
+      # Not for the reason an earlier version of this comment gave. It claimed
+      # `[[ test ]] && cmd` aborts the script under set -e when the test is
+      # false. It does not: bash exempts a command that is not the last in an
+      # && list, and a standalone list of that shape leaves set -e alone. What
+      # actually took the update down was `x=$(cmd)` where cmd fails, which is
+      # why the two assignments above carry `|| true` and these do not need it.
       if [[ -f $gen/wlogout-colors.css ]]; then
         mkdir -p "$HOME/.config/wlogout"
         cp "$gen/wlogout-colors.css" "$HOME/.config/wlogout/wlogout-colors.css"


### PR DESCRIPTION
Asked whether any bugs remained, I audited the two classes this session produced. One real defect turned up, and it is a comment I shipped in #49.

## The wrong explanation

#49 replaced three `[[ test ]] && cmd` lines with `if` blocks and justified it in a comment: that the `&&` form aborts under `set -e` when the test is false.

That is not true. Bash exempts a command that is not the last in an `&&` list, so a standalone list of that shape leaves `set -e` alone:

```
set -eEo pipefail
[[ -f /definitely/not/here ]] && echo "not reached"
echo "REACHED"        # prints, exit 0
```

What actually took the update down was an assignment whose command substitution fails:

```
x=$(cat /definitely/not/here 2>/dev/null)   # ERR trap fires, exit 1
```

Both were changed in the same commit and only one of them mattered. The `if` blocks stay, on the honest grounds that they read better.

The suite already pins the real cause, so this is a documentation fix rather than a behaviour one: removing `|| true` from the stamp read turns six checks red, while converting an `if` block back to an `&&` list changes nothing.

## What the audit cleared

- **`install.sh:457`** carries the same `[[ ]] &&` shape and is fine, by the same measurement. No change.
- **ghostty's config gaining blank lines**, which I had noticed earlier and not chased. It does not grow: simulating three theme switches leaves it at 20 blank lines and 42 total every time. A one-off artifact of the original colour strip, not a defect.

## Why this is worth a commit

This is the second time in this session I asserted that `set -e` aborts on a failing `&&` list, and the second time measuring disproved it. The first time it stayed in conversation. This time it reached a comment in shipped code, where the next reader would have believed it and possibly changed working code to match.