### PR TITLE
Run shellcheck in CI, and fix what it found

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,24 @@ jobs:
       - name: Install Lua and ImageMagick
         run: |
           sudo apt-get update
-          sudo apt-get install -y lua5.4 imagemagick
+          sudo apt-get install -y lua5.4 imagemagick shellcheck
           # The suites invoke `lua`. Ubuntu installs `lua5.4`, so make the
           # plain name exist rather than relying on the package to register it.
           sudo ln -sf /usr/bin/lua5.4 /usr/bin/lua
+
+      # Runs first: a shell bug is worth seeing before a suite that may fail
+      # because of it. hotspot.sh is excluded as vendored third party, 2035
+      # lines of create_ap that this project does not maintain. Migrations are
+      # checked as bash explicitly, since they deliberately carry no shebang.
+      - name: shellcheck
+        run: |
+          # hotspot.sh is vendored create_ap, 2035 lines this project does not
+          # maintain. zsh.sh is zsh, which shellcheck cannot parse at all.
+          mapfile -t bins < <(find .local/bin -maxdepth 1 -name '*.sh' \
+            ! -name 'hotspot.sh' ! -name 'zsh.sh' | sort)
+          shellcheck --severity=warning install.sh bootstrap.sh "${bins[@]}" test/*.sh
+          # Migrations deliberately carry no shebang, so the shell is stated here.
+          shellcheck --severity=warning --shell=bash migrations/*.sh
 
       - name: install-copy-test
         run: bash test/install-copy-test.sh

--- a/.local/bin/hyprsimple-debug.sh
+++ b/.local/bin/hyprsimple-debug.sh
@@ -121,6 +121,7 @@ hyprsimple_version() {
 
   section "EXPLICITLY INSTALLED PACKAGES"
   if command -v expac >/dev/null 2>&1; then
+    # shellcheck disable=SC2046  # splitting is wanted: one argument per package
     expac -Q '%n %v' $(pacman -Qqe) 2>/dev/null | sort
   else
     pacman -Qe 2>/dev/null || echo "(unavailable)"

--- a/.local/bin/screen-record.sh
+++ b/.local/bin/screen-record.sh
@@ -11,7 +11,9 @@ SCOPE="$1"      # "region", "output", or "stop"
 AUDIO_MODE="$2" # "mic", "internal", or "none"
 
 start_screenrecording() {
-  local filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
+  local stamp
+  stamp=$(date +'%Y-%m-%d_%H-%M-%S')
+  local filename="$OUTPUT_DIR/screenrecording-$stamp.mp4"
   local audio_opts=()
 
   # Detect whether wf-recorder or wl-screenrec will be used

--- a/.local/bin/theme-apply-templates.sh
+++ b/.local/bin/theme-apply-templates.sh
@@ -80,8 +80,11 @@ while IFS= read -r name; do
   sed -f "$sed_script" "$tpl" >"$THEME_DIR/generated/${name%.tpl}"
 done < <(
   {
-    [[ -d $TEMPLATES_DIR ]] && ls "$TEMPLATES_DIR" 2>/dev/null | grep '\.tpl$'
-    [[ -d $USER_TEMPLATES_DIR ]] && ls "$USER_TEMPLATES_DIR" 2>/dev/null | grep '\.tpl$'
+    # Globs rather than `ls | grep`, which splits a template name containing a
+    # space into two names and then renders neither.
+    for f in "$TEMPLATES_DIR"/*.tpl "$USER_TEMPLATES_DIR"/*.tpl; do
+      [[ -f $f ]] && basename "$f"
+    done
   } | sort -u
 )
 

--- a/test/install-copy-test.sh
+++ b/test/install-copy-test.sh
@@ -26,6 +26,7 @@ fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
 check() { if [[ $2 == "$3" ]]; then pass "$1"; else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi; }
 
 # The function depends on these globals and nothing else.
+# shellcheck disable=SC2034  # read by the bootstrap.sh function eval'd below
 RED='' GREEN='' YELLOW='' NC=''
 eval "$(sed -n '/^install_to_canonical_path() {/,/^}/p' "$REPO/install.sh")"
 eval "$(sed -n '/^copy_source_to_canonical_path() {/,/^}/p' "$REPO/bootstrap.sh")"

--- a/test/template-cleanup-test.sh
+++ b/test/template-cleanup-test.sh
@@ -7,7 +7,6 @@ set -uo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MIGRATION="$REPO/migrations/1788278344.sh"
-SHIPPED="$REPO/.config/hypr/themes/templates"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
shellcheck had never run on this repository. It was listed as an unexamined surface in every verification this session and never closed. This closes it.

It is not installed on the development machine, so the findings were gathered by pushing a non-enforcing probe branch and reading the CI log, rather than guessing.

## What it found, and what was actually wrong

94 findings at warning severity. Most are neither this project's code nor defects:

- **All 20 "errors" are noise.** 19 are missing-shebang on migrations, which `migrations/README.md` explicitly requires ("No shebang needed"), and one is `zsh.sh`, which shellcheck cannot parse. Zero real bugs at error severity.
- **65 of 74 warnings are in `hotspot.sh`**, 2035 vendored lines of the `create_ap` script this project does not maintain. Its two most suspicious findings are false positives: `yes n | cp -i` is deliberately feeding stdin to an interactive `cp`.

That leaves **9 in this project's own code**, and only **2 were real defects**, both recent:

- `theme-apply-templates.sh` listed templates with `ls | grep`, which splits a filename containing a space into two names and then renders neither. Introduced in #44. Now a glob.
- `template-cleanup-test.sh` carried a variable left dead when that suite moved from git history to fixtures in #49.

**Three are false positives**, and now carry a disable comment stating why rather than being silenced or "fixed" into something worse:

- the colour variables in `install-copy-test.sh` are read by a `bootstrap.sh` function `eval`'d further down, which shellcheck cannot see;
- the unquoted `$(pacman -Qqe)` in `hyprsimple-debug.sh` needs its word splitting, since the point is one argument per package. Quoting it would break the command.

**One was minor and real**: an assignment in `screen-record.sh` masked `date`'s exit status.

## Enforcement

CI runs shellcheck first, because a shell bug is worth seeing before a suite that may fail because of it. `hotspot.sh` and `zsh.sh` are excluded for the reasons above, with the reasons in the workflow. Migrations are checked with `--shell=bash` explicitly, since they deliberately carry no shebang.

## Honest scope

This is `--severity=warning`. Info and style findings are not enforced, and the vendored script is not covered at all. Turning either on would be a separate change with its own noise budget.