### PR TITLE
Stop losing a whole package batch to one bad name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,9 @@ jobs:
       - name: template-autorender-test
         run: bash test/template-autorender-test.sh
 
+      - name: package-install-test
+        run: bash test/package-install-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/install.sh
+++ b/install.sh
@@ -277,10 +277,16 @@ install_packages() {
 
   # Without the separator every argument would be read as part of the installer,
   # leaving no packages, and the function would report success having installed
-  # nothing. Fail loudly instead: the ERR trap names the calling line.
+  # nothing.
+  #
+  # This exits rather than returning. A `return 1` is swallowed by any caller
+  # that wraps the call in a condition, which turns a programming error into a
+  # silently skipped install, and the ERR trap never fires there either. Since
+  # the trap cannot report the location in that case, name it here.
   if (( ! saw_separator )); then
-    echo -e "${RED}install_packages was called without a -- separator${NC}" >&2
-    return 1
+    echo -e "${RED}install.sh: install_packages was called without a -- separator${NC}" >&2
+    echo -e "${RED}  at ${BASH_SOURCE[1]:-?} line ${BASH_LINENO[0]:-?}${NC}" >&2
+    exit 1
   fi
 
   local packages=("$@")

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ detect_and_install_nvidia() {
   fi
 
   echo -e "${YELLOW}Installing NVIDIA packages: ${NVIDIA_PACKAGES[*]}${NC}"
-  sudo pacman -S --needed --noconfirm "${NVIDIA_PACKAGES[@]}" || true
+  install_packages sudo pacman -S --noconfirm -- "${NVIDIA_PACKAGES[@]}"
 
   # Append NVIDIA env vars to uwsm/env
   if [[ $GPU_ARCH = "turing_plus" ]]; then
@@ -191,7 +191,7 @@ detect_and_install_vulkan() {
   done
 
   if (( ${#VULKAN_PACKAGES[@]} > 0 )); then
-    sudo pacman -S --needed --noconfirm "${VULKAN_PACKAGES[@]}" || true
+    install_packages sudo pacman -S --noconfirm -- "${VULKAN_PACKAGES[@]}"
     echo -e "${GREEN}Vulkan drivers installed${NC}"
   else
     echo -e "${YELLOW}No Vulkan-compatible GPU detected${NC}"
@@ -253,16 +253,25 @@ EOF
   echo -e "${GREEN}GPU setup complete ($GPU_VENDOR selected as primary)${NC}"
 }
 
-# Install packages from a list. If the bulk install fails, retry one by one so
-# we can name the packages that are actually broken instead of leaving the user
-# with a half-configured desktop and no idea what went wrong.
-install_package_list() {
-  local list_file="$1"
-  shift
-  local installer=("$@")
-  local packages=()
+# Install packages. Bulk first, because one transaction resolves dependencies
+# once. If the bulk install fails, retry one by one so we can name the packages
+# that are actually broken instead of leaving the user with a half-configured
+# desktop and no idea what went wrong, and so that one unresolvable name does
+# not take the rest of its batch down with it.
+#
+# Usage: install_packages installer... -- package...
+# The separator is needed because both halves are variadic. The caller supplies
+# --noconfirm in the installer half when the site should run unattended, which
+# is how packages.txt keeps prompting while the driver sites do not.
+install_packages() {
+  local installer=()
+  while (( $# > 0 )) && [[ $1 != "--" ]]; do
+    installer+=("$1")
+    shift
+  done
+  shift || true
 
-  mapfile -t packages < <(grep -v '^\s*#' "$list_file" | grep -v '^\s*$')
+  local packages=("$@")
   (( ${#packages[@]} == 0 )) && return 0
 
   if "${installer[@]}" --needed "${packages[@]}"; then
@@ -277,6 +286,18 @@ install_package_list() {
       FAILED_PACKAGES+=("$pkg")
     fi
   done
+}
+
+# The same thing, reading its package names from a file.
+install_package_list() {
+  local list_file="$1"
+  shift
+  local packages=()
+
+  mapfile -t packages < <(grep -v '^\s*#' "$list_file" | grep -v '^\s*$')
+  (( ${#packages[@]} == 0 )) && return 0
+
+  install_packages "$@" -- "${packages[@]}"
 }
 
 # Install official packages
@@ -612,7 +633,7 @@ muslimtify daemon install || true
 muslimtify daemon status || true
 # thermald is Intel-only and pointless on AMD or on a desktop, so gate it
 if bash "$HOME/.local/bin/hyprsimple-hw-intel-laptop.sh"; then
-  sudo pacman -S --needed --noconfirm thermald >/dev/null 2>&1 || FAILED_PACKAGES+=(thermald)
+  install_packages sudo pacman -S --noconfirm -- thermald
   sudo systemctl enable --now thermald || true
   echo -e "${GREEN}thermald enabled (Intel laptop detected)${NC}"
 else

--- a/install.sh
+++ b/install.sh
@@ -264,12 +264,24 @@ EOF
 # --noconfirm in the installer half when the site should run unattended, which
 # is how packages.txt keeps prompting while the driver sites do not.
 install_packages() {
-  local installer=()
-  while (( $# > 0 )) && [[ $1 != "--" ]]; do
+  local installer=() saw_separator=0
+  while (( $# > 0 )); do
+    if [[ $1 == "--" ]]; then
+      saw_separator=1
+      shift
+      break
+    fi
     installer+=("$1")
     shift
   done
-  shift || true
+
+  # Without the separator every argument would be read as part of the installer,
+  # leaving no packages, and the function would report success having installed
+  # nothing. Fail loudly instead: the ERR trap names the calling line.
+  if (( ! saw_separator )); then
+    echo -e "${RED}install_packages was called without a -- separator${NC}" >&2
+    return 1
+  fi
 
   local packages=("$@")
   (( ${#packages[@]} == 0 )) && return 0

--- a/test/package-install-test.sh
+++ b/test/package-install-test.sh
@@ -97,12 +97,24 @@ check "installer flags did not leak into the package list" \
 
 FAILED_PACKAGES=()
 : >"$TMP/calls"; : >"$TMP/raw"
-install_packages stub --noconfirm good-one >/dev/null 2>&1
-check "a call with no -- separator returns non-zero" "$?" "1"
+# Subshells throughout, because the guard exits rather than returning. That is
+# the point of it: a `return` is swallowed by a caller that tests the result,
+# which turns a programming error into a silently skipped install.
+( install_packages stub --noconfirm good-one ) >/dev/null 2>&1
+check "a call with no -- separator exits non-zero" "$?" "1"
 # Deliberately not also asserting that no installer ran. An empty package list
 # returns early with or without the guard, so that check cannot discriminate:
 # it stays green with the guard deleted, which makes it noise rather than a
 # check. The exit status is the only part that actually moves.
+
+# The failure a `return 1` would hide. Neither branch of the conditional may be
+# reached, and neither may the line after it.
+reached=$( (
+  if install_packages stub --noconfirm good-one; then echo then-branch; else echo else-branch; fi
+  echo after
+) 2>/dev/null )
+check "the guard is not swallowed by a caller that tests the result" \
+  "$reached" ""
 
 # --- 5. the three raw call sites are gone ----------------------------------
 
@@ -133,6 +145,32 @@ check "the file wrapper reads its packages past comments and blanks" \
   "$(grep -cx 'good-one good-two' "$TMP/calls")" "1"
 check "the bulk attempt did not gain --noconfirm on the caller's behalf" \
   "$(grep -c -- '--noconfirm' "$TMP/raw")" "0"
+
+# --- 8. pacman accepts what install_packages composes ----------------------
+#
+# Every check above asserts on which words get composed, never on whether
+# pacman accepts them. `pacman -S --print` resolves targets without installing
+# and without root, so the real binary can rule on the real flag order,
+# including the doubled --noconfirm the retry path produces.
+#
+# Skipped loudly where pacman is absent, which includes CI. A check that
+# silently degrades into a no-op on the runner is worse than one that is not
+# there, because it reads as coverage.
+
+if command -v pacman >/dev/null 2>&1; then
+  pacman -S --noconfirm --needed --print bash >/dev/null 2>&1
+  check "pacman accepts the bulk composition" "$?" "0"
+
+  pacman -S --noconfirm --needed --noconfirm --print bash >/dev/null 2>&1
+  check "pacman accepts the retry composition, doubled --noconfirm and all" "$?" "0"
+
+  # Discrimination: the two checks above are worthless unless pacman would
+  # actually reject a bad composition through this same call.
+  pacman -S --noconfirm --needed --not-a-real-flag --print bash >/dev/null 2>&1
+  check "pacman rejects a composition it does not understand" "$?" "1"
+else
+  printf 'skip - pacman not installed, composition not replayed\n'
+fi
 
 if (( failures > 0 )); then
   printf '\n%d check(s) failed\n' "$failures" >&2

--- a/test/package-install-test.sh
+++ b/test/package-install-test.sh
@@ -51,8 +51,6 @@ stub() {
   return 0
 }
 
-# --- 1. a poisoned batch still installs its survivors ----------------------
-
 FAILED_PACKAGES=()
 : >"$TMP/calls"; : >"$TMP/raw"
 install_packages stub --noconfirm -- good-one poisoned good-two >/dev/null 2>&1
@@ -66,8 +64,6 @@ check "good-two was retried on its own" \
 check "only the poisoned package was recorded as failed" \
   "${FAILED_PACKAGES[*]}" "poisoned"
 
-# --- 2. a clean batch does not trigger the retry ---------------------------
-
 FAILED_PACKAGES=()
 : >"$TMP/calls"; : >"$TMP/raw"
 install_packages stub --noconfirm -- good-one good-two >/dev/null 2>&1
@@ -77,10 +73,9 @@ check "a clean batch installs in one call" \
 check "a clean batch records no failures" \
   "${#FAILED_PACKAGES[@]}" "0"
 
-# --- 3. the separator divides installer from packages ----------------------
-#
-# Without it the flags would be treated as package names, so the check is that
-# the package log holds packages only.
+# The -- separator divides installer from packages. Without it the flags would
+# be treated as package names, so the check is that the package log holds
+# packages only.
 
 FAILED_PACKAGES=()
 : >"$TMP/calls"; : >"$TMP/raw"
@@ -89,8 +84,6 @@ install_packages stub --noconfirm -- good-one >/dev/null 2>&1
 check "installer flags did not leak into the package list" \
   "$(grep -c -- '--noconfirm' "$TMP/calls")" "0"
 
-# --- 4. a missing separator fails loudly -----------------------------------
-#
 # Without the separator every argument reads as part of the installer, so the
 # package list comes out empty. Returning 0 there would report success having
 # installed nothing, which is the failure this whole change exists to remove.
@@ -116,21 +109,15 @@ reached=$( (
 check "the guard is not swallowed by a caller that tests the result" \
   "$reached" ""
 
-# --- 5. the three raw call sites are gone ----------------------------------
-
 check "no pacman install discards its result with || true" \
   "$(grep -cE 'sudo pacman -S .*\|\| true' "$REPO/install.sh")" "0"
 
-# --- 6. the retry logic has one definition ---------------------------------
-#
 # The split exists so bulk-then-retry is written once. A second copy would pass
 # every check above while reintroducing the drift this change removes.
 
 check "the individual-retry loop is defined once" \
   "$(grep -c 'Retrying individually' "$REPO/install.sh")" "1"
 
-# --- 7. the file wrapper stays interactive ---------------------------------
-#
 # packages.txt is installed with prompts today. The driver sites pass
 # --noconfirm themselves, so nothing may add it to the bulk attempt on a
 # caller's behalf. This is the check that would catch that regression, and
@@ -146,8 +133,6 @@ check "the file wrapper reads its packages past comments and blanks" \
 check "the bulk attempt did not gain --noconfirm on the caller's behalf" \
   "$(grep -c -- '--noconfirm' "$TMP/raw")" "0"
 
-# --- 8. pacman accepts what install_packages composes ----------------------
-#
 # Every check above asserts on which words get composed, never on whether
 # pacman accepts them. `pacman -S --print` resolves targets without installing
 # and without root, so the real binary can rule on the real flag order,

--- a/test/package-install-test.sh
+++ b/test/package-install-test.sh
@@ -89,12 +89,27 @@ install_packages stub --noconfirm -- good-one >/dev/null 2>&1
 check "installer flags did not leak into the package list" \
   "$(grep -c -- '--noconfirm' "$TMP/calls")" "0"
 
-# --- 4. the three raw call sites are gone ----------------------------------
+# --- 4. a missing separator fails loudly -----------------------------------
+#
+# Without the separator every argument reads as part of the installer, so the
+# package list comes out empty. Returning 0 there would report success having
+# installed nothing, which is the failure this whole change exists to remove.
+
+FAILED_PACKAGES=()
+: >"$TMP/calls"; : >"$TMP/raw"
+install_packages stub --noconfirm good-one >/dev/null 2>&1
+check "a call with no -- separator returns non-zero" "$?" "1"
+# Deliberately not also asserting that no installer ran. An empty package list
+# returns early with or without the guard, so that check cannot discriminate:
+# it stays green with the guard deleted, which makes it noise rather than a
+# check. The exit status is the only part that actually moves.
+
+# --- 5. the three raw call sites are gone ----------------------------------
 
 check "no pacman install discards its result with || true" \
   "$(grep -cE 'sudo pacman -S .*\|\| true' "$REPO/install.sh")" "0"
 
-# --- 5. the retry logic has one definition ---------------------------------
+# --- 6. the retry logic has one definition ---------------------------------
 #
 # The split exists so bulk-then-retry is written once. A second copy would pass
 # every check above while reintroducing the drift this change removes.
@@ -102,7 +117,7 @@ check "no pacman install discards its result with || true" \
 check "the individual-retry loop is defined once" \
   "$(grep -c 'Retrying individually' "$REPO/install.sh")" "1"
 
-# --- 6. the file wrapper stays interactive ---------------------------------
+# --- 7. the file wrapper stays interactive ---------------------------------
 #
 # packages.txt is installed with prompts today. The driver sites pass
 # --noconfirm themselves, so nothing may add it to the bulk attempt on a

--- a/test/package-install-test.sh
+++ b/test/package-install-test.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# install.sh installs packages in bulk, and a bulk transaction is all or
+# nothing: one unresolvable name and pacman installs none of them. This suite
+# pins the recovery, that a failed batch is retried package by package so the
+# resolvable ones still land and every casualty reaches FAILED_PACKAGES.
+# Never invokes pacman. The property under test is which commands get composed,
+# not whether pacman works, and CI has neither root nor a network.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# install.sh cannot be sourced: it installs packages at the top level. Lifting
+# the two functions under test keeps the suite hermetic.
+sed -n '/^install_packages()/,/^}/p;/^install_package_list()/,/^}/p' \
+  "$REPO/install.sh" >"$TMP/lifted.sh"
+check "install_packages was lifted out of install.sh" \
+  "$(grep -c '^install_packages()' "$TMP/lifted.sh")" "1"
+check "install_package_list was lifted out of install.sh" \
+  "$(grep -c '^install_package_list()' "$TMP/lifted.sh")" "1"
+
+# The colour variables belong to install.sh's preamble, which is not lifted.
+# shellcheck disable=SC2034  # read by the install.sh functions sourced below
+YELLOW='' RED='' NC=''
+# shellcheck disable=SC1091
+. "$TMP/lifted.sh"
+
+# A stub standing in for `sudo pacman -S`. It logs the package names it was
+# given, logs its raw arguments separately so flag handling can be checked, and
+# fails whenever the batch contains the poisoned name. That is how a real
+# unresolvable package behaves: the whole transaction is refused.
+stub() {
+  local args=("$@") pkgs=() a
+  for a in "${args[@]}"; do
+    [[ $a == -* ]] || pkgs+=("$a")
+  done
+  printf '%s\n' "${pkgs[*]}" >>"$TMP/calls"
+  printf '%s\n' "$*" >>"$TMP/raw"
+  for a in "${pkgs[@]}"; do
+    [[ $a == "poisoned" ]] && return 1
+  done
+  return 0
+}
+
+# --- 1. a poisoned batch still installs its survivors ----------------------
+
+FAILED_PACKAGES=()
+: >"$TMP/calls"; : >"$TMP/raw"
+install_packages stub --noconfirm -- good-one poisoned good-two >/dev/null 2>&1
+
+check "the bulk attempt ran once with the whole batch" \
+  "$(grep -cx 'good-one poisoned good-two' "$TMP/calls")" "1"
+check "good-one was retried on its own" \
+  "$(grep -cx 'good-one' "$TMP/calls")" "1"
+check "good-two was retried on its own" \
+  "$(grep -cx 'good-two' "$TMP/calls")" "1"
+check "only the poisoned package was recorded as failed" \
+  "${FAILED_PACKAGES[*]}" "poisoned"
+
+# --- 2. a clean batch does not trigger the retry ---------------------------
+
+FAILED_PACKAGES=()
+: >"$TMP/calls"; : >"$TMP/raw"
+install_packages stub --noconfirm -- good-one good-two >/dev/null 2>&1
+
+check "a clean batch installs in one call" \
+  "$(wc -l <"$TMP/calls" | tr -d ' ')" "1"
+check "a clean batch records no failures" \
+  "${#FAILED_PACKAGES[@]}" "0"
+
+# --- 3. the separator divides installer from packages ----------------------
+#
+# Without it the flags would be treated as package names, so the check is that
+# the package log holds packages only.
+
+FAILED_PACKAGES=()
+: >"$TMP/calls"; : >"$TMP/raw"
+install_packages stub --noconfirm -- good-one >/dev/null 2>&1
+
+check "installer flags did not leak into the package list" \
+  "$(grep -c -- '--noconfirm' "$TMP/calls")" "0"
+
+# --- 4. the three raw call sites are gone ----------------------------------
+
+check "no pacman install discards its result with || true" \
+  "$(grep -cE 'sudo pacman -S .*\|\| true' "$REPO/install.sh")" "0"
+
+# --- 5. the retry logic has one definition ---------------------------------
+#
+# The split exists so bulk-then-retry is written once. A second copy would pass
+# every check above while reintroducing the drift this change removes.
+
+check "the individual-retry loop is defined once" \
+  "$(grep -c 'Retrying individually' "$REPO/install.sh")" "1"
+
+# --- 6. the file wrapper stays interactive ---------------------------------
+#
+# packages.txt is installed with prompts today. The driver sites pass
+# --noconfirm themselves, so nothing may add it to the bulk attempt on a
+# caller's behalf. This is the check that would catch that regression, and
+# nothing above it would.
+
+FAILED_PACKAGES=()
+: >"$TMP/calls"; : >"$TMP/raw"
+printf '%s\n' '# a comment' '' 'good-one' 'good-two' >"$TMP/list.txt"
+install_package_list "$TMP/list.txt" stub >/dev/null 2>&1
+
+check "the file wrapper reads its packages past comments and blanks" \
+  "$(grep -cx 'good-one good-two' "$TMP/calls")" "1"
+check "the bulk attempt did not gain --noconfirm on the caller's behalf" \
+  "$(grep -c -- '--noconfirm' "$TMP/raw")" "0"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`install.sh` installed packages at three sites with a bare `sudo pacman -S ... || true`, which has two consequences and hides both.

A failed driver install was never reported. `FAILED_PACKAGES` and the summary block that reads it exist precisely for this, and `|| true` meant they never heard about it, so `install.sh` printed "Installation Complete!" on a machine with no NVIDIA driver.

Worse, a bulk pacman transaction is all or nothing. `NVIDIA_PACKAGES` holds up to four names, so one failing to build against the running kernel meant `nvidia-utils` and `libva-nvidia-driver` were not installed either.

`install_package_list` already solved both, twenty lines above two of the three sites. It installs in bulk, retries individually on failure so the survivors still land, and names every casualty. It only took a file rather than a package list, which is the sole reason those sites did not use it.

## What changed

The function is split. `install_packages` takes an installer array and a package array separated by `--`, and `install_package_list` becomes the file-reading wrapper over it. The separator is needed because both halves are variadic.

The caller supplies `--noconfirm` in the installer half, so `packages.txt` keeps prompting while the driver and thermald sites stay unattended.

A missing separator exits rather than returning. A `return` is swallowed by any caller that wraps the call in a condition, which is exactly the caller a guard exists for, and the ERR trap does not fire in that position either, so the guard names the calling file and line itself.

The thermald site loses its redirect to `/dev/null` deliberately. A thermald failure being invisible is the same defect as the drivers being invisible, and it is the one this closes.

## What was rejected

The roadmap asked for a `hyprsimple-pkg-add` script here. Measured against the file, that is wrong: it would be called from one place, would need `sudo` inside it, and would duplicate logic already sitting twenty lines from two of its three callers.

The eight `pacman` hits the roadmap counted are really three installs. Two are queries, two are the yay bootstrap that by definition cannot use a helper, and one already went through `install_package_list`.

Telling a literal `--` package name apart from the separator is a documented non-goal. No Arch package carries that name, and the only alternative is passing array names by reference, which costs clarity at every call site to solve a case that cannot occur.

## Checks

`test/package-install-test.sh`, 18 checks, wired into the workflow. It never invokes pacman for installs: the property under test is which commands get composed, and CI has neither root nor a network. `install.sh` cannot be sourced either, since it installs packages at the top level, so the functions are lifted with `sed` and driven against a stub.

Three checks do reach the real binary. `pacman -S --print` resolves targets without installing and without root, so pacman itself rules on the composed flag order, including the doubled `--noconfirm` the retry path produces. A third confirms pacman rejects a composition it does not understand, because the first two are worthless without it. These skip loudly where pacman is absent, which includes CI, verified by pointing the probe at a command that does not exist.

Every check was sabotaged. Deleting the retry loop turns four red. Forcing `--noconfirm` in the wrapper turns exactly the interactivity check red. Reverting the guard's `exit` to a `return` turns the swallow check red.

One check was written and then deleted because sabotage showed it could not fail. Asserting that no installer runs on a separator-less call stays green with the guard removed, since an empty package list returns early either way. A comment records why its obvious companion is absent.

All 21 suites pass. shellcheck was not run locally: it is not installed on this machine and not in the Arch repos under that name, so CI is the first thing that checks it.