### PR TITLE
Fix three defects that shipped because nothing ran the code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,9 @@ jobs:
       - name: notification-idiom-test
         run: bash test/notification-idiom-test.sh
 
+      - name: screenshot-and-battery-test
+        run: bash test/screenshot-and-battery-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/battery-monitor.sh
+++ b/.local/bin/battery-monitor.sh
@@ -27,17 +27,33 @@ BATTERY_LEVEL=$(get_battery_percentage)
 BATTERY_STATE=$(get_battery_state)
 
 if [[ "$BATTERY_STATE" == "discharging" ]]; then
+  # The lowest threshold the battery has fallen past, not every threshold it is
+  # under. Acting inside the loop meant one 9% reading dimmed the screen three
+  # times and sent three identical notifications, because the flag file only
+  # ever holds the last threshold written, so the next iteration compared
+  # against a different number and fired again. At 2% it was five.
+  #
+  # Comparing rather than taking the last match, which would be shorter and
+  # would rely on BATTERY_THRESHOLD staying in descending order. Nothing states
+  # that invariant and nothing enforces it.
+  crossed=""
   for threshold in "${BATTERY_THRESHOLD[@]}"; do
-    if [[ "$BATTERY_LEVEL" -le "$threshold" ]]; then
-      brightnessctl set "${LOW_BATTERY_BRIGHTNESS}"%
-
-      # Send notification only once per threshold using flag file
-      if [[ ! -f "$FLAG_FILE" ]] || [[ $(cat "$FLAG_FILE" 2>/dev/null) != "$threshold" ]]; then
-        notify-send -u critical "Battery Low" "Battery at ${BATTERY_LEVEL}%, brightness reduced to ${LOW_BATTERY_BRIGHTNESS}%"
-        echo "$threshold" >"$FLAG_FILE"
-      fi
+    if [[ "$BATTERY_LEVEL" -le "$threshold" ]] &&
+      { [[ -z $crossed ]] || [[ "$threshold" -lt "$crossed" ]]; }; then
+      crossed="$threshold"
     fi
   done
+
+  if [[ -n $crossed ]]; then
+    brightnessctl set "${LOW_BATTERY_BRIGHTNESS}"%
+
+    # Once per crossing. Falling into a lower band writes a new value here and
+    # so notifies again, which is the escalation this file was always for.
+    if [[ ! -f "$FLAG_FILE" ]] || [[ $(cat "$FLAG_FILE" 2>/dev/null) != "$crossed" ]]; then
+      notify-send -u critical "Battery Low" "Battery at ${BATTERY_LEVEL}%, brightness reduced to ${LOW_BATTERY_BRIGHTNESS}%"
+      echo "$crossed" >"$FLAG_FILE"
+    fi
+  fi
 else
   # Clear flag when charging/charged to allow new notifications on next discharge
   rm -f "$FLAG_FILE"

--- a/.local/bin/screenshot.sh
+++ b/.local/bin/screenshot.sh
@@ -17,16 +17,16 @@ if [ "$mode" == "clipboard" ]; then
 fi
 
 if [ "$mode" == "window" ]; then
-    hyprshot -m window --freeze --output-folder $HOME/Pictures/Screenshots
+    hyprshot -m window --freeze --output-folder "$HOME/Pictures/Screenshots"
     exit 0
 fi
 
 if [ "$mode" == "region" ]; then
-    hyprshot -m region --freze --output-folder $HOME/Pictures/Screenshots
+    hyprshot -m region --freeze --output-folder "$HOME/Pictures/Screenshots"
     exit 0
 fi
 
 if [ "$mode" == "monitor" ]; then
-    hyprshot -m output --freeze --output-folder $HOME/Pictures/Screenshots
+    hyprshot -m output --freeze --output-folder "$HOME/Pictures/Screenshots"
     exit 0
 fi

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Three defects that shipped because nothing ran the code: an unquoted path in
+# screenshot.sh, a misspelled hyprshot flag beside it, and a battery loop that
+# sent one notification per threshold rather than one per crossing.
+# Never invokes hyprshot, upower or brightnessctl for real.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+LOG="$TMP/calls"
+
+# Records one line per invocation: the argument count, then the arguments. The
+# count is the point. An unquoted path containing a space arrives as two
+# arguments and the count goes up, which is the defect, and no assertion on the
+# text alone would see it.
+cat >"$STUB/hyprshot" <<'STUBEOF'
+#!/bin/bash
+printf '%s|%s\n' "$#" "$*" >>"${CALL_LOG:?}"
+STUBEOF
+chmod +x "$STUB/hyprshot"
+printf '#!/bin/bash\nexit 0\n' >"$STUB/notify-send"; chmod +x "$STUB/notify-send"
+
+# A home directory with a space in it, which is what the quoting bug needs to
+# show itself. Nothing here touches the real home.
+SPACED="$TMP/home with space"
+mkdir -p "$SPACED"
+
+for mode in window region monitor; do
+  : >"$LOG"
+  CALL_LOG="$LOG" HOME="$SPACED" PATH="$STUB:$PATH" bash "$BIN/screenshot.sh" "$mode" >/dev/null 2>&1
+  check "screenshot $mode passes the output folder as one argument" \
+    "$(cut -d'|' -f1 <"$LOG")" "5"
+done
+
+# hyprshot documents -z, --freeze. screenshot.sh spent its whole life passing
+# --freze, which getopt rejects while the screenshot proceeds unfrozen, so the
+# one mode where freezing matters never froze.
+check "no screenshot mode passes a flag hyprshot does not know" \
+  "$(grep -c -- '--freze' "$BIN/screenshot.sh")" "0"
+check "region freezes the screen" \
+  "$(grep -c -- '-m region --freeze' "$BIN/screenshot.sh")" "1"
+
+# --- battery ---------------------------------------------------------------
+
+printf '#!/bin/bash\nexit 0\n' >"$STUB/brightnessctl"; chmod +x "$STUB/brightnessctl"
+NLOG="$TMP/notifications"
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"${NOTIFY_LOG:?}"
+STUBEOF
+chmod +x "$STUB/notify-send"
+
+battery_at() {
+  cat >"$STUB/upower" <<STUBEOF
+#!/bin/bash
+[[ \$1 == -e ]] && { echo /org/freedesktop/UPower/devices/BAT0; exit 0; }
+echo "    percentage:          $1%"
+echo "    state:               discharging"
+STUBEOF
+  chmod +x "$STUB/upower"
+}
+
+FLAG=/tmp/battery-notification-flag
+run_battery() {
+  battery_at "$1"
+  NOTIFY_LOG="$NLOG" PATH="$STUB:$PATH" bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
+}
+
+# 9% is at or below 20, 15 and 10. The old loop notified once for each.
+rm -f "$FLAG"; : >"$NLOG"
+run_battery 9
+check "one reading crossing three thresholds notifies once" \
+  "$(grep -c 'Battery Low' "$NLOG")" "1"
+check "the notification names the level the battery is at" \
+  "$(grep -c 'Battery at 9%' "$NLOG")" "1"
+
+# 2% is at or below all five.
+rm -f "$FLAG"; : >"$NLOG"
+run_battery 2
+check "one reading crossing five thresholds still notifies once" \
+  "$(grep -c 'Battery Low' "$NLOG")" "1"
+
+# Falling into a lower band must notify again. This is the half that a naive
+# once-ever flag would break, so it is asserted rather than assumed.
+rm -f "$FLAG"; : >"$NLOG"
+run_battery 9
+run_battery 4
+check "falling into a lower band notifies again" \
+  "$(grep -c 'Battery Low' "$NLOG")" "2"
+
+# Staying in the same band must not.
+: >"$NLOG"
+run_battery 4
+check "a second reading in the same band does not notify again" \
+  "$(grep -c 'Battery Low' "$NLOG")" "0"
+rm -f "$FLAG"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Three user-visible defects, in two files, with one cause between them: no test ever executed either script. A misspelled flag, an unquoted path and a loop that fired five times all read as correct to everyone who looked at them.

## `screenshot.sh`: an unquoted path

Lines 20, 25 and 30 passed `$HOME/Pictures/Screenshots` to `hyprshot --output-folder` without quotes. A home directory containing a space arrives as two arguments and three of the four screenshot modes break. Measured with a stub: the call goes from five arguments to seven.

Found by shellcheck at `--severity=style`, which CI does not enforce.

## `screenshot.sh`: a flag that does not exist

Region mode passed `--freze`. hyprshot documents `-z, --freeze`. Its getopt prints `unrecognized option '--freze'` and the screenshot proceeds anyway, unfrozen.

That is the one mode where freezing matters, because the user is dragging a selection across live content. It has never frozen. Found while fixing the line above it.

## `battery-monitor.sh`: five notifications for one event

`BATTERY_THRESHOLD` is `(20 15 10 5 3)` and the loop body ran for every threshold at or above the current level. The flag file was meant to hold it to one notification per threshold, but it only ever holds the last value written, so the next iteration compared against a different number and fired again.

A single 9% reading sent three identical notifications and dimmed the screen three times. At 2% it sent five. Every one said the same thing.

The loop now picks only the lowest threshold the battery has fallen past, and the notification and brightness change happen once, outside it.

Comparing rather than taking the last match. Taking the last would be one line shorter and would rely on `BATTERY_THRESHOLD` staying in descending order, which nothing states and nothing enforces, so a reordering would silently restore the bug.

Found by running the script under a stub while closing an unrelated gap in the notification suite. Nothing in the repository had ever executed it.

## Checks

`test/screenshot-and-battery-test.sh`, 10 checks, wired into the workflow. It never invokes hyprshot, upower or brightnessctl for real.

The screenshot checks run each mode from a `HOME` containing a space, against a stub that logs how many arguments it received. The count is the assertion, because an unquoted path arrives as two arguments and no assertion on the text alone would see it.

The battery checks cover four cases, and the last two matter most. Falling into a lower band must still notify, which a naive once-ever flag would break, and staying in the same band must not, which is what the flag is for. Fixing the first bug by breaking either of those would be worse than the bug.

Each defect was sabotaged individually and turns its own checks red:

```
paths unquoted again        argument count 5 -> 7, all three modes
--freze restored            both flag checks
per-threshold loop restored all five battery checks
```

All 23 suites pass. This is the first change in this repository linted locally before being pushed, rather than after CI rejected it.

## Not in this PR

Raising CI's shellcheck severity to `style`, which is the change that would have caught the first defect before it shipped. It touches 11 files and 18 findings, so it gets its own cycle.