### PR TITLE
Enforce shellcheck at style severity, and fix what that finds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,14 @@ jobs:
           # being made. SC2016 is excluded: every occurrence here is a grep
           # pattern or a stub written to disk, where single quotes are correct,
           # and the suites read shell source as data so it recurs by design.
+          #
+          # This runner's shellcheck is older than a current Arch one, and the
+          # difference is not only that the old one knows less. SC2002 was a
+          # default check here and became optional in 0.10, so it fails this
+          # step while a newer local shellcheck reports nothing. To reproduce
+          # this step locally, add --enable=all and read only the codes this
+          # step would have caught.
+          shellcheck --version | grep version:
           shellcheck --severity=style --exclude=SC2016 \
             install.sh bootstrap.sh "${bins[@]}" test/*.sh
           # Migrations deliberately carry no shebang, so the shell is stated

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,20 @@ jobs:
           # maintain. zsh.sh is zsh, which shellcheck cannot parse at all.
           mapfile -t bins < <(find .local/bin -maxdepth 1 -name '*.sh' \
             ! -name 'hotspot.sh' ! -name 'zsh.sh' | sort)
-          shellcheck --severity=warning install.sh bootstrap.sh "${bins[@]}" test/*.sh
-          # Migrations deliberately carry no shebang, so the shell is stated here.
-          shellcheck --severity=warning --shell=bash migrations/*.sh
+          # style is the lowest severity, and it is where SC2012 lives. Parsing
+          # ls output is the one finding class this project has actually shipped
+          # as a bug, in #52, so warning was set above the severity of the bugs
+          # being made. SC2016 is excluded: every occurrence here is a grep
+          # pattern or a stub written to disk, where single quotes are correct,
+          # and the suites read shell source as data so it recurs by design.
+          shellcheck --severity=style --exclude=SC2016 \
+            install.sh bootstrap.sh "${bins[@]}" test/*.sh
+          # Migrations deliberately carry no shebang, so the shell is stated
+          # here. They are held to the same threshold, not because the shipped
+          # ones will ever run again, since install.sh pre-creates their
+          # markers, but because a future one runs unattended exactly once on
+          # every machine and cannot be re-run.
+          shellcheck --severity=style --exclude=SC2016 --shell=bash migrations/*.sh
 
       - name: install-copy-test
         run: bash test/install-copy-test.sh

--- a/.local/bin/bashrc.sh
+++ b/.local/bin/bashrc.sh
@@ -2,6 +2,7 @@
 
 # Enable bash completion
 if [[ -f /usr/share/bash-completion/bash_completion ]]; then
+  # shellcheck disable=SC1091  # ships with bash-completion, not with this repo
   . /usr/share/bash-completion/bash_completion
 fi
 

--- a/.local/bin/live-wallpaper-toggle.sh
+++ b/.local/bin/live-wallpaper-toggle.sh
@@ -25,6 +25,8 @@ turn_off() {
   # Try to get current wallpaper from hyprpaper IPC
   ACTIVE=$(hyprctl hyprpaper listactive 2>/dev/null | head -1)
   # Parse: output format is "monitor = /path/to/wallpaper"
+  # shellcheck disable=SC2001  # the run of spaces is variable width, which
+  # parameter expansion cannot match
   RESOLVED=$(echo "$ACTIVE" | sed 's/.*= *//')
 
   # Validate resolved path exists and is inside the theme backgrounds dir

--- a/.local/bin/setup-dns.sh
+++ b/.local/bin/setup-dns.sh
@@ -4,7 +4,7 @@ echo "Select DNS provider:"
 echo "1) Cloudflare (1.1.1.1)"
 echo "2) Google (8.8.8.8)"
 echo "3) DHCP (default)"
-read -p "Choice [1-3]: " choice
+read -rp "Choice [1-3]: " choice
 
 case $choice in
   1)

--- a/.local/bin/wifi.sh
+++ b/.local/bin/wifi.sh
@@ -5,8 +5,14 @@
 #   SSID      -> connect (open network, or known/saved network)
 #   SSID PASS -> connect with passphrase
 
-# Auto-detect WiFi interface
-IFACE=$(ls -d /sys/class/net/*/wireless 2>/dev/null | head -1 | cut -d'/' -f5)
+# Auto-detect WiFi interface. A glob rather than parsing ls output, so the
+# shell splits the paths instead of a newline doing it.
+IFACE=""
+for wireless in /sys/class/net/*/wireless; do
+  [[ -d $wireless ]] || continue
+  IFACE=$(basename "$(dirname "$wireless")")
+  break
+done
 
 if [[ -z $IFACE ]]; then
   echo "No WiFi interface found"

--- a/install.sh
+++ b/install.sh
@@ -688,7 +688,7 @@ echo "2. Customize ~/.config/hypr/monitors.conf for your setup"
 echo "3. Update later with: hyprsimple-update"
 echo ""
 
-read -p "Logout to take effect? (y/n) " logout
+read -rp "Logout to take effect? (y/n) " logout
 if [ "$logout" == "y" ]; then
     echo "Logging out..."
     hyprctl dispatch exit

--- a/migrations/1787992467.sh
+++ b/migrations/1787992467.sh
@@ -77,7 +77,7 @@ while IFS= read -r -d '' f; do
   esac
   if grep -q 'require("hypr\.vars")' "$f"; then
     sed -i 's|require("hypr\.vars")|require("default.hypr.vars")|g' "$f"
-    repointed+=("${f#$CONF/}")
+    repointed+=("${f#"$CONF"/}")
   fi
 done < <(find "$CONF" -name '*.lua' -type f -print0)
 

--- a/migrations/1788066582.sh
+++ b/migrations/1788066582.sh
@@ -55,7 +55,10 @@ if [[ -f $DUNSTRC ]] && ! cmp -s "$DUNSTRC" "$BASE"; then
     # The earlier migration already saved this file as it was before anything
     # touched it, which is a more complete record than the copy just made.
     # Promote it into this name so the user is left with one file, not two.
-    bak=$(ls -1 "$DUNSTRC".bak.* 2>/dev/null | tail -1)
+    bak=""
+    for candidate in "$DUNSTRC".bak.*; do
+      [[ -f $candidate ]] && bak="$candidate"
+    done
     [[ -n $bak ]] && mv -f "$bak" "$kept"
 
     echo "Kept your dunstrc at $kept"

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -312,8 +312,7 @@ check "99-user.conf exists after the run" \
 edited_home="$TMP/home-move-edited"
 must_be_fixture "$edited_home"
 mkdir -p "$edited_home/.config/dunst"
-cat "$PRESPLIT" \
-  | sed 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
+sed 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' "$PRESPLIT" \
   >"$edited_home/.config/dunst/dunstrc"
 cp "$edited_home/.config/dunst/dunstrc" "$TMP/edited_original"
 
@@ -362,9 +361,8 @@ fi
 chain_home="$TMP/home-chain"
 must_be_fixture "$chain_home"
 mkdir -p "$chain_home/.config/dunst"
-cat "$PRESPLIT" \
-  | sed -e 's|browser = /usr/bin/brave|browser = /usr/bin/firefox|' \
-        -e 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' \
+sed -e 's|browser = /usr/bin/brave|browser = /usr/bin/firefox|' \
+    -e 's/frame_color = "#a6adc8"/frame_color = "#ffcc00"/' "$PRESPLIT" \
   >"$chain_home/.config/dunst/dunstrc"
 cp "$chain_home/.config/dunst/dunstrc" "$TMP/chain_original"
 

--- a/test/template-cleanup-test.sh
+++ b/test/template-cleanup-test.sh
@@ -43,7 +43,7 @@ new_home() {
   done
   # A fixture that did not populate must fail loudly rather than let a later
   # check pass against an empty directory.
-  if [[ $(ls "$TPL" | wc -l) -eq 0 ]]; then
+  if ! compgen -G "$TPL/*" >/dev/null; then
     printf 'not ok - fixture templates did not copy (%s)\n' "$1" >&2
     exit 1
   fi

--- a/test/template-delivery-test.sh
+++ b/test/template-delivery-test.sh
@@ -128,9 +128,15 @@ cp "$REPO/.config/hypr/themes/templates/"*.tpl "$INST/.config/hypr/themes/templa
 cp "$REPO/.config/hypr/themes/everforest/colors.toml" "$THEME/colors.toml" 2>/dev/null ||
   printf 'background = "#111111"\n' >"$THEME/colors.toml"
 render
-shipped_count=$(ls "$REPO/.config/hypr/themes/templates/"*.tpl | wc -l)
+# Arrays rather than counting ls output. The difference is a filename holding a
+# newline, which ls reports as two lines and an array holds as one entry.
+# Measured, not assumed: a space does not do this, and an earlier version of
+# this comment claimed it did. It also drops a subprocess per count.
+shipped=("$REPO/.config/hypr/themes/templates/"*.tpl)
+rendered=("$THEME/generated"/*)
+[[ -e ${rendered[0]} ]] || rendered=()
 check "every shipped template produces a rendered file" \
-  "$(ls "$THEME/generated" 2>/dev/null | wc -l)" "$shipped_count"
+  "${#rendered[@]}" "${#shipped[@]}"
 
 # --- 8. no colors.toml is still a clean exit -------------------------------
 

--- a/test/waybar-refresh-test.sh
+++ b/test/waybar-refresh-test.sh
@@ -169,7 +169,7 @@ check "custom/screenrecording's on-click names screen-record.sh" \
 
 # ---- consolidating restarts did not scatter the relaunch or drop the signal
 
-hits=$(grep -rlE 'uwsm app -- waybar|nohup waybar' "$REPO/.local/bin" "$REPO/install.sh" 2>/dev/null | grep -v 'hyprsimple-restart-waybar\.sh$' | wc -l)
+hits=$(grep -rlE 'uwsm app -- waybar|nohup waybar' "$REPO/.local/bin" "$REPO/install.sh" 2>/dev/null | grep -vc 'hyprsimple-restart-waybar\.sh$')
 check "no file besides hyprsimple-restart-waybar.sh relaunches waybar directly" "$hits" "0"
 
 if grep -q 'RTMIN+8' "$SCREEN_RECORD"; then


### PR DESCRIPTION
CI enforced `--severity=warning`, and the bugs this project actually ships live below it.

`SC2012`, ls output parsed as data, is style level. It shipped in #52, where `ls | grep '\.tpl'` split a template name containing a space into two names and rendered neither. Five sites remained, two of them in `template-delivery-test.sh`, counting the same `.tpl` files in the suite meant to guard them.

`SC2086` is also below warning. It broke three of four screenshot modes for anyone with a space in their home path, and survived until #55, which found it only because shellcheck had been installed on the maintainer's machine that afternoon.

The threshold was set above the severity of the mistakes being made.

## The fifteen findings, in three groups

**Nine are real and are fixed.**

```
SC2012  ls parsed as data     wifi.sh, template-cleanup-test.sh,
                              template-delivery-test.sh x2, migration 1788066582
SC2162  read without -r       install.sh, setup-dns.sh
SC2126  grep piped to wc -l   waybar-refresh-test.sh
SC2295  ${f#$CONF/} unquoted  migration 1787992467
```

**Two are correct code shellcheck cannot verify**, and carry an inline disable naming the reason. `bashrc.sh` sources a file that is not in this repository. `live-wallpaper-toggle.sh` matches a run of spaces of variable width, which parameter expansion cannot express.

**Four are `SC2016`, and the check is excluded globally.** Every occurrence is a grep pattern or a stub written to disk, where single quotes are correct. The suites read shell source as data, so it recurs by design. Per-file disables were the alternative and were rejected: three comment lines today, and one in every future suite that greps for shell, which is most of them.

## Migrations are held to the same threshold

The two findings there change nothing for anyone. `hyprsimple-migrate.sh:9` records that fresh installs get every marker pre-created, so no shipped migration will ever run again.

The value is entirely prospective. A future migration runs unattended, exactly once, on every machine, and cannot be re-run if it goes wrong. That makes it the worst place in the repository to leave a finding, and the best place for the check to be live.

## Evidence

**Anti-vacuity.** A single `SC2012` introduced into a scratch copy exits 1 at `style` and exits 0 at `warning`. That difference is the entire justification for this change.

**Two fixes had no suite covering them** and were verified directly rather than assumed. `wifi.sh` derives a wireless interface from a sysfs glob, and both the old and new forms return `wlan0` on the maintainer's machine. The dunst backup selection in migration 1788066582 was run against constructed backup files, and the two forms agree, including when there are no backups at all.

**One comment was written, tested, and found to be false.** An earlier version of the `template-delivery-test.sh` note claimed a filename containing a space makes `ls` report two lines. It does not: `ls` prints one line per file regardless. The case where the two forms actually differ is a filename containing a newline, which `ls` reports as two lines and an array holds as one entry. Measured, then written down correctly.

All 23 suites pass, and both edited suites are themselves among the changed files, so each was run before and after.

## Also

`.local/bin/wifi.sh` was owned by `root:root`, the only such file in the tree, which is why it needed replacing rather than editing. It is now owned like everything else.