### PR TITLE
Drop the numbered section headers from the remaining suites

### DIFF
--- a/test/config-drift-report-test.sh
+++ b/test/config-drift-report-test.sh
@@ -87,16 +87,12 @@ run_update() {
   printf '%s' "$?" >"$CASE/rc"
 }
 
-# --- 1. a changed config the user has their own version of is named --------
-
 new_case reports
 printf 'MINE\n' >"$FAKE_HOME/.config/starship.toml"
 ship .config/starship.toml V2
 run_update
 check "a changed config the user diverged from is reported" \
   "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "1"
-
-# --- 2. a config this update did not touch is not named -------------------
 
 new_case untouched
 printf 'MINE\n' >"$FAKE_HOME/.config/starship.toml"
@@ -106,8 +102,6 @@ run_update
 check "a config this update did not change is not reported" \
   "$(grep -c 'untouched.toml' "$CASE/out")" "0"
 
-# --- 3. a user whose copy matches the new shipped one is not nagged -------
-
 new_case matching
 ship .config/starship.toml V4
 printf 'V4\n' >"$FAKE_HOME/.config/starship.toml"
@@ -115,15 +109,11 @@ run_update
 check "a matching copy is not reported" \
   "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "0"
 
-# --- 4. a config the user never had is not reported -----------------------
-
 new_case absent
 ship .config/starship.toml V5
 run_update
 check "a config the user does not have is not reported" \
   "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "0"
-
-# --- 5. a symlinked config is managed elsewhere and is not drift ----------
 
 new_case symlinked
 ship .config/starship.toml V6
@@ -134,8 +124,6 @@ ln -sfn "$CASE/managed-elsewhere.toml" "$FAKE_HOME/.config/starship.toml"
 run_update
 check "a symlinked config is not reported" \
   "$(grep -c 'refresh-config.sh starship.toml' "$CASE/out")" "0"
-
-# --- 6. an update that pulls nothing new reports nothing ------------------
 
 new_case nochange
 printf 'MINE\n' >"$FAKE_HOME/.config/starship.toml"

--- a/test/rofi-split-migration-test.sh
+++ b/test/rofi-split-migration-test.sh
@@ -42,8 +42,6 @@ make_home() {
   printf '* { background: #000000FF; }\n' >"$home/.config/rofi/rofi-colors.rasi"
 }
 
-# --- 1. a pristine install is converted ------------------------------------
-
 home="$TMP/pristine"
 make_home "$home"
 HOME="$home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/out" 2>&1
@@ -58,8 +56,6 @@ check "the hyprsimple link is created" \
 check "the link resolves to the install's defaults" \
   "$([[ -f $home/.config/rofi/hyprsimple/config.rasi ]] && echo yes || echo no)" "yes"
 
-# --- 2. the theme-owned paths are untouched --------------------------------
-
 check "launcher/style.rasi is untouched" \
   "$(md5sum <"$home/.config/rofi/launcher/style.rasi" | cut -d' ' -f1)" \
   "$(printf '/* theme owned */\n' | md5sum | cut -d' ' -f1)"
@@ -70,14 +66,10 @@ check "rofi-colors.rasi is untouched" \
   "$(md5sum <"$home/.config/rofi/rofi-colors.rasi" | cut -d' ' -f1)" \
   "$(printf '* { background: #000000FF; }\n' | md5sum | cut -d' ' -f1)"
 
-# --- 3. a second run changes nothing ---------------------------------------
-
 before=$(find "$home/.config/rofi" -type f -exec md5sum {} + | sort | md5sum)
 HOME="$home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >/dev/null 2>&1
 after=$(find "$home/.config/rofi" -type f -exec md5sum {} + | sort | md5sum)
 check "a second run is a no-op" "$after" "$before"
-
-# --- 4. an edited file is left alone ---------------------------------------
 
 edited="$TMP/edited"
 make_home "$edited"
@@ -90,8 +82,6 @@ check "the user is told how to convert it" \
   "$(grep -c 'hyprsimple-refresh-config.sh rofi/config.rasi' "$TMP/edited_out")" "1"
 check "an edited file does not stop the others converting" \
   "$(cmp -s "$edited/.config/rofi/font.rasi" "$REPO/.config/rofi/font.rasi" && echo same || echo different)" "same"
-
-# --- 5. a home with no rofi directory at all -------------------------------
 
 bare="$TMP/bare"
 must_be_fixture "$bare"

--- a/test/rofi-split-smoke.sh
+++ b/test/rofi-split-smoke.sh
@@ -58,8 +58,6 @@ ln -sfn "$INSTALL/default/rofi" "$FAKE_HOME/.config/rofi/hyprsimple"
 
 STUBS=(config.rasi confirm.rasi font.rasi keybindings/style.rasi theme-picker/style.rasi)
 
-# --- 1. every stub's import target exists ----------------------------------
-#
 # This is the failure that would otherwise be silent: rofi logs nothing for a
 # missing @import and renders unstyled instead of exiting non-zero.
 
@@ -83,8 +81,6 @@ done
 check "a default still imports the theme colours" \
   "$(grep -l 'rofi-colors.rasi' "$INSTALL/default/rofi/confirm.rasi" >/dev/null && echo yes || echo no)" "yes"
 
-# --- 2. a changed default is live through the stub, with no migration -------
-
 if [[ $HAVE_ROFI == 1 ]]; then
   # A property rofi knows. -dump-theme silently drops unknown custom
   # properties, so asserting on an invented one would pass against anything.
@@ -107,8 +103,6 @@ if [[ $HAVE_ROFI == 1 ]]; then
 else
   printf 'skip - rofi not installed, import resolution checks not run\n'
 fi
-
-# --- 4. the theme-owned paths are not part of the split --------------------
 
 for rel in launcher powermenu; do
   check "$rel is left out of the split" \

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -33,8 +33,6 @@ if [[ ${#suites[@]} -lt 5 ]]; then
 fi
 pass "found ${#suites[@]} suites to audit"
 
-# --- 1. no suite reads git history ----------------------------------------
-#
 # CI checks out shallow, and the workflow says so. On a depth-1 clone
 # `git log --format=%H -- <path> | tail -1` resolves to HEAD, so a suite asking
 # for an old version is handed the current one. That failed loudly in one suite
@@ -55,8 +53,6 @@ else
   fail "these read git history, which is empty on CI's shallow checkout: ${offenders[*]}"
 fi
 
-# --- 2. every suite cleans up after itself --------------------------------
-
 offenders=()
 for f in "${suites[@]}"; do
   grep -q 'mktemp -d' "$f" || continue
@@ -68,8 +64,6 @@ else
   fail "these leak their temp directory: ${offenders[*]}"
 fi
 
-# --- 3. a fixture guard that is defined is actually used ------------------
-#
 # must_be_fixture stops an empty or unexpected path turning a later rm or cp
 # into an operation on the real home directory. Defining it and never calling it
 # looks like protection in a diff and provides none, which is a mistake made
@@ -87,8 +81,6 @@ else
   fail "these define a fixture guard and never call it: ${offenders[*]}"
 fi
 
-# --- 4. a suite that invokes rofi isolates the config directory -----------
-#
 # rofi resolves a relative @import against the XDG config directory before the
 # working directory, so a fixture's imports silently resolved against the
 # maintainer's real ~/.config/rofi and the checks passed for the wrong reason.
@@ -106,11 +98,9 @@ else
   fail "these run rofi without isolating the config directory: ${offenders[*]}"
 fi
 
-# --- 5. a suite that builds a fixture asserts it was built ---------------
-#
-# The narrowest of these and the one that cost the most. A clone that produced
-# nothing left four checks reporting ok, because each asserted on absence and an
-# empty fixture produces no output either.
+# The narrowest check in this suite, and the one that cost the most. A clone
+# that produced nothing left four checks reporting ok, because each asserted on
+# absence and an empty fixture produces no output either.
 
 offenders=()
 for f in "${suites[@]}"; do
@@ -123,8 +113,6 @@ else
   fail "these clone without asserting the result exists: ${offenders[*]}"
 fi
 
-# --- 6. every suite is wired into CI -------------------------------------
-#
 # The workflow names each suite explicitly, so a file that is not listed never
 # runs there however good it is.
 

--- a/test/template-autorender-test.sh
+++ b/test/template-autorender-test.sh
@@ -63,23 +63,17 @@ run_update() {
   printf '%s' "$?" >"$TMP/rc"
 }
 
-# --- 1. a template that has never been rendered is rendered ---------------
-
 run_update
 check "an unrendered template is rendered by the update" \
   "$(grep -c 'wl_background #2d353b' "$HOMEDIR/.config/hypr/themes/solo/generated/wlogout-colors.css" 2>/dev/null)" "1"
 check "and the active theme's output reaches wlogout" \
   "$(grep -c 'wl_background #2d353b' "$HOMEDIR/.config/wlogout/wlogout-colors.css" 2>/dev/null)" "1"
 
-# --- 2. an update with no template change does not re-render --------------
-
 marker="$HOMEDIR/.config/hypr/themes/solo/generated/wlogout-colors.css"
 printf '/* touched by hand */\n' >>"$marker"
 run_update
 check "an unchanged template does not trigger a re-render" \
   "$(grep -c 'touched by hand' "$marker")" "1"
-
-# --- 3. a changed template does trigger one ------------------------------
 
 printf '@define-color wl_background {{ background }};\n@define-color wl_extra {{ foreground }};\n' \
   >"$INSTALL/.config/hypr/themes/templates/wlogout-colors.css.tpl"
@@ -89,8 +83,6 @@ check "a changed template triggers a re-render" \
 check "and the hand edit is gone, because rendering is the source of truth" \
   "$(grep -c 'touched by hand' "$marker")" "0"
 
-# --- 4. a newly shipped template reaches an existing theme ---------------
-#
 # This is the case that cost a second migration: shipping a template is not
 # delivering it unless something renders.
 

--- a/test/template-cleanup-test.sh
+++ b/test/template-cleanup-test.sh
@@ -51,19 +51,13 @@ new_home() {
 
 run() { HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$TMP/out" 2>&1; }
 
-# --- 1. a directory of untouched shipped templates is removed --------------
-
 new_home pristine
 run
 check "a directory of shipped templates is removed" \
   "$([[ -d $TPL ]] && echo present || echo gone)" "gone"
 
-# --- 2. a re-run is a no-op ------------------------------------------------
-
 run
 check "a second run exits 0 with the directory already gone" "$?" "0"
-
-# --- 3. one customised file protects the whole directory ------------------
 
 new_home customised
 printf '/* mine */\n' >>"$TPL/waybar-colors.css.tpl"
@@ -78,16 +72,12 @@ check "and the user is told where to move it" \
 check "and the offending file is named" \
   "$(grep -c 'waybar-colors.css.tpl' "$TMP/out")" "1"
 
-# --- 4. a file the user added protects the directory too ------------------
-
 new_home added
 printf '/* mine */\n' >"$TPL/my-own.tpl"
 run
 check "an added file stops the removal" \
   "$([[ -d $TPL ]] && echo present || echo gone)" "present"
 
-# --- 5. an older shipped version still counts as ours ---------------------
-#
 # The point of carrying history rather than only the current checksum: a home
 # that never took a template update holds an old version, which is still not
 # the user's work.
@@ -101,8 +91,6 @@ cp "$PRECLEANUP/dunst-colors.OLD.tpl" "$TPL/dunst-colors.tpl"
 run
 check "an older shipped version does not block removal" \
   "$([[ -d $TPL ]] && echo present || echo gone)" "gone"
-
-# --- 6. a home without the directory at all -------------------------------
 
 HOMEDIR="$TMP/nodir"
 must_be_fixture "$HOMEDIR"

--- a/test/template-delivery-test.sh
+++ b/test/template-delivery-test.sh
@@ -45,15 +45,11 @@ render() {
 
 rendered() { cat "$THEME/generated/$1" 2>/dev/null; }
 
-# --- 1. a template only the install has -----------------------------------
-
 new_case only-install
 printf 'FROM-INSTALL {{ background }}\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
 render
 check "a template only the install has is rendered" "$(rendered probe)" "FROM-INSTALL #111111"
 check "the renderer exits 0" "$(cat "$CASE/rc")" "0"
-
-# --- 2. a changed install template reaches a home that has no copy ---------
 
 new_case changed-install
 printf 'V1\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
@@ -64,8 +60,6 @@ render
 check "a template changed in the install is delivered, no migration" \
   "$first -> $(rendered probe)" "V1 -> V2"
 
-# --- 3. a home copy identical to the shipped one must not pin the install --
-#
 # install.sh copied every template into every existing home, so treating any
 # home copy as an override would leave every existing install frozen. This is
 # the check the whole change exists for.
@@ -87,8 +81,6 @@ render
 check "an identical leftover is not warned about" \
   "$(grep -c 'no longer used' "$CASE/out")" "0"
 
-# --- 4. a genuinely customised home template still wins --------------------
-
 new_case customised
 mkdir -p "$HOMEDIR/.config/hypr/themes/templates.user"
 printf 'SHIPPED\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
@@ -103,8 +95,6 @@ printf 'S\n' >"$INST/.config/hypr/themes/templates/probe.tpl"
 render
 check "a templates.user file with no shipped counterpart renders" "$(rendered extra)" "ONLY-MINE"
 
-# --- 5. a home with no template directory at all ---------------------------
-
 new_case no-home-dir
 printf 'A\n' >"$INST/.config/hypr/themes/templates/a.tpl"
 printf 'B\n' >"$INST/.config/hypr/themes/templates/b.tpl"
@@ -112,16 +102,12 @@ render
 check "every install template renders with no home directory" \
   "$(rendered a)$(rendered b)" "AB"
 
-# --- 6. a template added to the install, home dir exists but lacks it ------
-
 new_case added-template
 mkdir -p "$HOMEDIR/.config/hypr/themes/templates"
 printf 'OLD\n' >"$INST/.config/hypr/themes/templates/old.tpl"
 printf 'NEW\n' >"$INST/.config/hypr/themes/templates/new.tpl"
 render
 check "a newly shipped template renders without a home copy" "$(rendered new)" "NEW"
-
-# --- 7. every real shipped template still renders --------------------------
 
 new_case real-templates
 cp "$REPO/.config/hypr/themes/templates/"*.tpl "$INST/.config/hypr/themes/templates/"
@@ -137,8 +123,6 @@ rendered=("$THEME/generated"/*)
 [[ -e ${rendered[0]} ]] || rendered=()
 check "every shipped template produces a rendered file" \
   "${#rendered[@]}" "${#shipped[@]}"
-
-# --- 8. no colors.toml is still a clean exit -------------------------------
 
 new_case no-colors
 rm -f "$THEME/colors.toml"

--- a/test/update-self-replace-test.sh
+++ b/test/update-self-replace-test.sh
@@ -19,8 +19,6 @@ check() {
   else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
 }
 
-# --- 1. the refresh loop replaces by rename, not in place ------------------
-#
 # An inode-preserving write is what corrupts a running script. Asserting on the
 # mechanism rather than on a message keeps this readable when the wording of
 # the loop changes.
@@ -31,8 +29,6 @@ check "the refresh loop renames into place" \
 check "the refresh loop does not cp directly over the target" \
   "$(grep -cE '^\s*cp -f "\$script" "\$target"\s*$' <<<"$refresh_block")" "0"
 
-# --- 2. the behaviour itself, against a real self-replacing script ---------
-#
 # The property under test is bash's, not hyprsimple's, so the check runs it
 # rather than trusting either. The replacement is deliberately longer than the
 # original, because an equal-length one cannot shift the read offset and so

--- a/test/wlogout-theme-test.sh
+++ b/test/wlogout-theme-test.sh
@@ -26,8 +26,6 @@ must_be_fixture() {
   fi
 }
 
-# --- 1. the stylesheet is themed, not hardcoded ---------------------------
-
 STYLE="$REPO/.config/wlogout/style.css"
 check "style.css imports the colour file" \
   "$(grep -c '@import url("wlogout-colors.css")' "$STYLE")" "1"
@@ -39,8 +37,6 @@ check "every colour the stylesheet names is defined by the fallback" \
   "$(grep -oE '@wl_[a-z]+' "$STYLE" | sort -u | while read -r c; do
        grep -q "define-color ${c#@} " "$REPO/.config/wlogout/wlogout-colors.css" || echo miss
      done | grep -c miss)" "0"
-
-# --- 2. the template renders from a theme ---------------------------------
 
 THEME="$TMP/theme"
 must_be_fixture "$THEME"
@@ -56,8 +52,6 @@ check "the theme's background reaches the rendered colours" \
 check "the theme's foreground reaches the rendered colours" \
   "$(grep -c 'wl_foreground #d3c6aa' "$THEME/generated/wlogout-colors.css")" "1"
 
-# --- 3. GTK actually parses the pair ---------------------------------------
-#
 # The failure this guards against is specific: GTK treats a missing @import as
 # fatal and returns an empty stylesheet, so wlogout renders with no styling at
 # all. Asserting the file merely exists would not catch a stylesheet that
@@ -105,8 +99,6 @@ else
   printf 'skip - python gtk3 bindings absent, stylesheet not parsed here\n'
 fi
 
-# --- 4. the migration installs the colour file before replacing the style --
-
 # The pre-theming style.css, pinned as a fixture rather than read from git
 # history. CI checks out shallow, so `git log ... | tail -1` there resolves to
 # HEAD and hands back the themed file, and the migration checks below would
@@ -143,8 +135,6 @@ check "and the user is told how to take it" \
 HOME="$HOMEDIR" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >/dev/null 2>&1
 check "a second run exits 0" "$?" "0"
 
-# --- 5. the follow-up migration renders the new template ------------------
-#
 # The theming migration installs the fallback and updates style.css but does
 # not render, so without this an existing install sits on the fallback's
 # catppuccin colours until its next theme switch. A build input that is never


### PR DESCRIPTION
#53 removed these from one suite and left nine carrying them, so the codebase has been half and half since. This finishes it.

The `# --- N. title ---` dividers restated what the check names already say, and the numbers had to be renumbered by hand whenever a section was inserted, which happened twice while writing a single suite.

## What stays

The explanatory comments. They carry reasoning the check names cannot:

- why rofi's import resolution made a fixture pass against the maintainer's real `~/.config`
- why a fixture guard that is defined and never called is worse than none
- why a clone that produced nothing left four checks reporting `ok`

## The one thing that needed judgement

Removing a heading is how a pronoun loses its referent, so every comment that had followed a deleted header was reread for that. One had the problem: "The narrowest of these" took its subject from the numbered list, and now names the suite instead.

```
 9 files changed, 3 insertions(+), 93 deletions(-)
```

All 23 suites pass unchanged, and shellcheck is clean at `style` including a check for `SC2002`, which only CI's older version reports.