### PR TITLE
Stop the notification timing checks failing when nobody is at the keyboard

### DIFF
--- a/test/notification-idiom-test.sh
+++ b/test/notification-idiom-test.sh
@@ -175,21 +175,29 @@ if dunstctl count displayed >/dev/null 2>&1; then
   check "the same pair without an id displays as two" \
     "$(dunstctl count displayed)" "2"
 
-  # screen-record.sh sends critical notifications with -t 3000, and dunst's
-  # documented default for critical urgency is never to expire. It does expire
-  # here, because hyprsimple's own dunst config sets a global timeout and the
-  # urgency_critical section overrides only colours. Measured rather than
-  # assumed: a critical notification with -t 1000 is gone after 2.5s, and one
-  # with no -t survives that long. Asserting it so a drop-in that sets
-  # urgency_critical timeout cannot change it invisibly.
+  # screen-record.sh sends critical notifications with -t 3000, and dunst
+  # documents critical urgency as never expiring by default. It does expire
+  # here, because default/dunst/10-hyprsimple.conf sets a global timeout and
+  # the urgency_critical sections override only colours.
+  #
+  # Both probes are --transient, and that is not incidental. The same file sets
+  # idle_threshold = 120, which stops notifications timing out at all once the
+  # user has been idle that long. An automated run is idle by definition, so
+  # without --transient these checks pass when someone is at the keyboard and
+  # fail when nobody is, which is how they were written and how they flaked.
+  # dunst documents transient as the client-side bypass for exactly this.
+  #
+  # Measured in the failing state rather than reasoned about: with the machine
+  # idle, an ordinary -t 1000 notification was still displayed after 2 seconds
+  # and a transient one was gone, at both critical and low urgency.
   dunstctl close-all
-  notify-send -u critical -t 1000 "probe" "critical honours -t"
+  notify-send -u critical -t 1000 --transient "probe" "critical honours -t"
   sleep 2.5
   check "a critical notification honours its own -t" \
     "$(dunstctl count displayed)" "0"
 
   dunstctl close-all
-  notify-send -u critical "probe" "critical without -t outlives it"
+  notify-send -u critical --transient "probe" "critical without -t outlives it"
   sleep 2.5
   check "a critical notification without -t outlives that window" \
     "$(dunstctl count displayed)" "1"


### PR DESCRIPTION
These flaked on main, discovered by running the suites straight after merging #57. One run in twelve, and only on a live desktop, so CI could never see it: CI skips those checks for want of a running dunst.

## The cause is hyprsimple's own config

`default/dunst/10-hyprsimple.conf:20` sets:

```
idle_threshold = 120
```

which dunst documents as *"Don't timeout notifications if user is idle longer than this time."*

An automated test run is idle by definition. Past two minutes, no notification expires at all, whatever `-t` says, and a check asserting expiry fails.

That is deliberate product behaviour and this PR does not change it. A low battery warning that vanishes while you are away from the machine is worse than one that waits.

## The fix

dunst documents `transient` as the client-side bypass for exactly this, and `notify-send` exposes it as `--transient`. Both timing probes now use it.

```
before, tight loop, machine idle:   25 failures in 25 runs
after,  same state:                  0 failures in 10 runs
```

Both checks still discriminate. Dropping the `-t` so only the global timeout applies turns the first red. Giving the second probe a short `-t` turns it red.

## Two corrections to the record

The claim that critical urgency honours `-t`, made when this suite was written in #54, holds **only while someone is at the machine**. It was measured while active and stated without that qualification.

An earlier attempt to test the idle threshold slept past it and saw both forms expire, and I reported that as ruling the cause out. It was **inconclusive, not negative**. The A/B that settled it was run in the failing state, where an ordinary notification stayed up and a transient one did not, at both critical and low urgency:

```
ordinary  critical -t 1000 after 2.0s: 1
transient critical -t 1000 after 2.0s: 0
ordinary  low      -t 1000 after 2.0s: 1
transient low      -t 1000 after 2.0s: 0
```

Treating an inconclusive result as a refutation is the same error as treating a passing check as evidence, which is the failure mode this suite exists to guard against.