### PR TITLE
Ask the two duplicated hardware questions in one place each

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,9 @@ jobs:
       - name: screenshot-and-battery-test
         run: bash test/screenshot-and-battery-test.sh
 
+      - name: hw-predicate-test
+        run: bash test/hw-predicate-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-hw-battery.sh
+++ b/.local/bin/hyprsimple-hw-battery.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Exit 0 if this machine has a battery, which is how hyprsimple decides it is a
+# laptop. Used as a condition, not run for output:
+#
+#   if hyprsimple-hw-battery.sh; then ...
+#
+# The sysfs root is overridable so both answers can be tested on a machine
+# whose own battery presence is fixed.
+
+SYSFS_POWER="${HYPRSIMPLE_SYSFS_POWER:-/sys/class/power_supply}"
+
+compgen -G "$SYSFS_POWER/BAT*" >/dev/null

--- a/.local/bin/hyprsimple-hw-intel-laptop.sh
+++ b/.local/bin/hyprsimple-hw-intel-laptop.sh
@@ -17,6 +17,6 @@ cpu_model=$(grep -m1 '^model[[:space:]]*:' /proc/cpuinfo | cut -d: -f2 | tr -d '
 (( cpu_model >= 42 )) || exit 1
 
 # Has a battery, i.e. is a laptop
-compgen -G "/sys/class/power_supply/BAT*" >/dev/null || exit 1
+"$(dirname "${BASH_SOURCE[0]}")/hyprsimple-hw-battery.sh" || exit 1
 
 exit 0

--- a/.local/bin/hyprsimple-hw-nvidia.sh
+++ b/.local/bin/hyprsimple-hw-nvidia.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Exit 0 if this machine has an NVIDIA GPU. Used as a condition, not run for
+# output:
+#
+#   if hyprsimple-hw-nvidia.sh; then ...
+#
+# Answers only the yes or no. install.sh keeps its own capture of the model
+# string, because it regex-matches that string to decide which driver a card
+# needs, and a boolean cannot carry it.
+
+lspci 2>/dev/null | grep -qi 'nvidia'

--- a/.local/bin/screen-record.sh
+++ b/.local/bin/screen-record.sh
@@ -18,7 +18,7 @@ start_screenrecording() {
 
   # Detect whether wf-recorder or wl-screenrec will be used
   local is_nvidia=false
-  if lspci | grep -qi 'nvidia'; then
+  if "$HOME/.local/bin/hyprsimple-hw-nvidia.sh"; then
     is_nvidia=true
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -103,12 +103,16 @@ echo ""
 
 detect_and_install_nvidia() {
   echo -e "${YELLOW}Detecting NVIDIA GPU...${NC}"
-  NVIDIA="$(lspci | grep -i 'nvidia' || true)"
 
-  if [[ -z $NVIDIA ]]; then
+  # The predicate answers the yes or no, and the capture below supplies the
+  # model string that the driver regexes need. Asking twice costs a second
+  # lspci on NVIDIA machines only, which is nothing in a script that installs a
+  # desktop, and it keeps one definition of what counts as an NVIDIA GPU.
+  if ! bash "$DOTFILES_DIR/.local/bin/hyprsimple-hw-nvidia.sh"; then
     echo -e "${GREEN}No NVIDIA GPU detected, skipping${NC}"
     return 0
   fi
+  NVIDIA="$(lspci | grep -i 'nvidia' || true)"
 
   echo -e "${GREEN}NVIDIA GPU detected: $NVIDIA${NC}"
 
@@ -383,7 +387,7 @@ setup_firewall() {
 
 setup_battery() {
   echo -e "${YELLOW}Detecting battery...${NC}"
-  if ls /sys/class/power_supply/BAT* &>/dev/null; then
+  if bash "$DOTFILES_DIR/.local/bin/hyprsimple-hw-battery.sh"; then
     echo -e "${GREEN}Battery detected, setting balanced power profile${NC}"
     command -v powerprofilesctl &>/dev/null && powerprofilesctl set balanced
   else
@@ -650,7 +654,7 @@ systemctl --user enable --now hyprpolkitagent.service || true
 muslimtify daemon install || true
 muslimtify daemon status || true
 # thermald is Intel-only and pointless on AMD or on a desktop, so gate it
-if bash "$HOME/.local/bin/hyprsimple-hw-intel-laptop.sh"; then
+if bash "$DOTFILES_DIR/.local/bin/hyprsimple-hw-intel-laptop.sh"; then
   install_packages sudo pacman -S --noconfirm -- thermald
   sudo systemctl enable --now thermald || true
   echo -e "${GREEN}thermald enabled (Intel laptop detected)${NC}"

--- a/test/hw-predicate-test.sh
+++ b/test/hw-predicate-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# The hardware predicates answer by exit status and print nothing, so a caller
+# can use one as a condition. Both answers of both predicates are exercised
+# here without depending on what hardware this machine actually has, because a
+# check that only ever sees one answer has only ever tested half of it.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+
+# lspci is a command, so a stub on PATH decides what the NVIDIA predicate sees.
+with_nvidia() {
+  cat >"$STUB/lspci" <<'STUBEOF'
+#!/bin/bash
+echo "00:02.0 VGA compatible controller: Intel Corporation Raptor Lake-P [UHD Graphics]"
+echo "01:00.0 VGA compatible controller: NVIDIA Corporation AD107M [GeForce RTX 4050]"
+STUBEOF
+  chmod +x "$STUB/lspci"
+}
+without_nvidia() {
+  cat >"$STUB/lspci" <<'STUBEOF'
+#!/bin/bash
+echo "00:02.0 VGA compatible controller: Intel Corporation Raptor Lake-P [UHD Graphics]"
+STUBEOF
+  chmod +x "$STUB/lspci"
+}
+
+with_nvidia
+PATH="$STUB:$PATH" bash "$BIN/hyprsimple-hw-nvidia.sh"
+check "nvidia predicate exits 0 when lspci reports one" "$?" "0"
+
+out=$(PATH="$STUB:$PATH" bash "$BIN/hyprsimple-hw-nvidia.sh" 2>/dev/null)
+check "nvidia predicate prints nothing when it says yes" "$out" ""
+
+without_nvidia
+PATH="$STUB:$PATH" bash "$BIN/hyprsimple-hw-nvidia.sh"
+check "nvidia predicate exits non-zero when lspci reports none" "$?" "1"
+
+out=$(PATH="$STUB:$PATH" bash "$BIN/hyprsimple-hw-nvidia.sh" 2>/dev/null)
+check "nvidia predicate prints nothing when it says no" "$out" ""
+
+# The battery predicate reads sysfs, which no PATH stub can replace, so it
+# takes its root from the environment. That override exists for this test and
+# is the only reason both answers are reachable on one machine.
+mkdir -p "$TMP/power-with/BAT0" "$TMP/power-without/AC"
+
+HYPRSIMPLE_SYSFS_POWER="$TMP/power-with" bash "$BIN/hyprsimple-hw-battery.sh"
+check "battery predicate exits 0 when a BAT entry exists" "$?" "0"
+
+out=$(HYPRSIMPLE_SYSFS_POWER="$TMP/power-with" bash "$BIN/hyprsimple-hw-battery.sh" 2>/dev/null)
+check "battery predicate prints nothing when it says yes" "$out" ""
+
+HYPRSIMPLE_SYSFS_POWER="$TMP/power-without" bash "$BIN/hyprsimple-hw-battery.sh"
+check "battery predicate exits non-zero with no BAT entry" "$?" "1"
+
+out=$(HYPRSIMPLE_SYSFS_POWER="$TMP/power-without" bash "$BIN/hyprsimple-hw-battery.sh" 2>/dev/null)
+check "battery predicate prints nothing when it says no" "$out" ""
+
+# The duplication this change exists to remove. One definition of the battery
+# question, and no caller deciding NVIDIA presence by testing a captured string
+# for emptiness. install.sh still runs lspci to read the model name, which the
+# driver regexes need and a boolean cannot carry.
+check "the battery question is asked in one place" \
+  "$(grep -rl 'power_supply' "$BIN"/*.sh "$REPO/install.sh" | wc -l | tr -d ' ')" "1"
+check "no caller answers the nvidia question from a captured string" \
+  "$(grep -c 'if \[\[ -z \$NVIDIA \]\]' "$REPO/install.sh")" "0"
+check "hw-intel-laptop defers to the battery predicate" \
+  "$(grep -c 'hyprsimple-hw-battery.sh' "$BIN/hyprsimple-hw-intel-laptop.sh")" "1"
+
+# install.sh populates ~/.local/bin at line 538, but calls setup_battery at
+# 404. A predicate invoked from the home directory does not exist yet at that
+# point, bash exits 127, and the `if` reads that as "no battery", which would
+# set a performance power profile on a laptop. Calling the repo copy has no
+# such ordering dependency, because install.sh runs from the repo.
+check "install.sh calls predicates from the repo, not the home directory" \
+  "$(grep -c 'bash "\$HOME/.local/bin/hyprsimple-hw-' "$REPO/install.sh")" "0"
+check "install.sh calls all three predicates from DOTFILES_DIR" \
+  "$(grep -c 'bash "\$DOTFILES_DIR/.local/bin/hyprsimple-hw-' "$REPO/install.sh")" "3"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Two hardware questions were asked in more than one place, each with its own spelling, and nothing kept either pair in agreement.

**Is there an NVIDIA GPU.** `screen-record.sh:21` ran `lspci | grep -qi 'nvidia'` to pick between `wf-recorder` and `wl-screenrec`. `install.sh:106` captured `lspci | grep -i 'nvidia'` and tested it for emptiness.

**Is there a battery.** `install.sh:386` used `ls /sys/class/power_supply/BAT* &>/dev/null`. `hyprsimple-hw-intel-laptop.sh:20` used `compgen -G` on the same glob.

## What was built

```
hyprsimple-hw-nvidia.sh    exit status only, no output
hyprsimple-hw-battery.sh   exit status only, no output
```

Both follow the shape `hyprsimple-hw-intel-laptop.sh` already set, so a caller uses one directly as a condition.

`install.sh` keeps its own `lspci` afterwards, because it regex-matches the model name at `:133` to choose a driver and a boolean cannot carry a string. The predicate answers the yes or no, the capture supplies the name. That costs one extra `lspci` on NVIDIA machines, in a script that installs an entire desktop.

The battery predicate takes its sysfs root from `HYPRSIMPLE_SYSFS_POWER`. That override is the only way to reach both answers on a machine whose battery presence is fixed, and testing only the answer this laptop gives would be testing half of it.

## Five of the seven predicates were not built

The roadmap asked for seven. Measured against the tree:

| | |
|---|---|
| `hw-match` (generic DMI matcher) | **Nothing in the repository reads DMI.** Zero consumers |
| `hw-nvidia-gsp` | No caller. The GSP question is a regex over the model string, not a boolean |
| `hw-amd-gpu`, `hw-intel-gpu`, `hw-hybrid-gpu` | One caller each, all three inside `detect_and_setup_multi_gpu`, which needs a PCI address rather than a yes or no |

The roadmap also says to fix "the duplicate `lspci` probes in `screen-record.sh:19` and `hyprsimple-debug.sh:90`". Those are not duplicates of each other: one is a boolean NVIDIA test, the other prints every GPU for a debug report.

Of the seven `lspci` sites, only two are predicates. Three capture PCI addresses, one captures a model description, one is display output.

## A bug introduced and caught before it shipped

`install.sh` populates `~/.local/bin` at line 538 but calls `setup_battery` at line 404. A predicate invoked from the home directory would not exist yet at that point, `bash` would exit 127, and the `if` would read that as "no battery" and set a **performance** power profile on a laptop.

All three predicate calls now read the repo copy, which `install.sh` always has because it runs from there, and a check pins it. Reverting one call to `$HOME` turns two checks red.

## Checks

`test/hw-predicate-test.sh`, 13 checks, wired into the workflow. Both answers of both predicates, neither depending on this machine's hardware: a stubbed `lspci` for one, a temporary sysfs root for the other. Each predicate is also asserted to print nothing on both paths, since stray output would land in the middle of installer messages.

Every invariant sabotaged individually. Inverting the NVIDIA grep, making the battery predicate ignore its override, and undoing the deferral in `hw-intel-laptop` each turn their own checks red.

All 25 suites pass, shellcheck clean at `style` including the `SC2002` check only CI's older version reports.