### PR TITLE
Fix six defects in scripts no test had ever run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,9 @@ jobs:
       - name: hw-predicate-test
         run: bash test/hw-predicate-test.sh
 
+      - name: untested-script-bugs-test
+        run: bash test/untested-script-bugs-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-debug.sh
+++ b/.local/bin/hyprsimple-debug.sh
@@ -12,7 +12,9 @@
 
 export HYPRSIMPLE_PATH="${HYPRSIMPLE_PATH:-$HOME/.local/share/hyprsimple}"
 
-LOG_FILE="/tmp/hyprsimple-debug.log"
+# mktemp rather than a fixed /tmp path. `>` on a predictable name in a
+# world-writable directory follows a symlink someone else placed there first.
+LOG_FILE="$(mktemp -t hyprsimple-debug.XXXXXX.log)"
 INSTALL_LOG="$HOME/.local/state/hyprsimple/install.log"
 
 PRINT_ONLY=false
@@ -36,8 +38,9 @@ while (( $# > 0 )); do
   shift
 done
 
-# Print a section only if the tool backing it exists, so this works on a
-# minimal install without erroring out.
+# A section heading. Whether a section has anything to report is decided by its
+# caller, each of which falls back to a note when the tool it needs is missing,
+# so this works on a minimal install without erroring out.
 section() {
   echo ""
   echo "========================================="
@@ -131,9 +134,15 @@ hyprsimple_version() {
 upload() {
   echo "Uploading to 0x0.st..."
   local url
-  url=$(curl -sF "file=@$LOG_FILE" -Fexpires=24 https://0x0.st)
 
-  if [[ -n $url ]]; then
+  # --fail matters: without it curl exits 0 on an HTTP error and prints the
+  # error body, which is non-empty, so a rate-limited upload used to be
+  # announced as a link. The https:// test catches a 200 carrying something
+  # that is not one.
+  url=$(curl --fail --silent --show-error \
+    -F "file=@$LOG_FILE" -Fexpires=24 https://0x0.st) || url=""
+
+  if [[ $url == https://* ]]; then
     echo ""
     echo "Log uploaded. Share this link on your issue:"
     echo ""

--- a/.local/bin/search_by_keyword.sh
+++ b/.local/bin/search_by_keyword.sh
@@ -3,7 +3,10 @@
 KEYWORD=$1
 
 if [[ -z "$KEYWORD" ]]; then
-  echo "Usage sk [keyword]"
+  echo "Usage sk [keyword]" >&2
+  # Without this the search runs anyway, and rg treats an empty pattern as
+  # matching every line of every file.
+  exit 1
 fi
 
 fsearch() {

--- a/.local/bin/toggle_cpu_mode.sh
+++ b/.local/bin/toggle_cpu_mode.sh
@@ -5,11 +5,13 @@
 
 case "$1" in
   on)
-    sudo cpupower frequency-set -g performance
+    # Reporting the mode only if cpupower set it. Announcing it either way is
+    # how a failed governor change looked like a successful one.
+    sudo cpupower frequency-set -g performance || { echo "CPU: could not set performance" >&2; exit 1; }
     echo "CPU: performance"
     ;;
   off)
-    sudo cpupower frequency-set -g powersave
+    sudo cpupower frequency-set -g powersave || { echo "CPU: could not set powersave" >&2; exit 1; }
     echo "CPU: powersave"
     ;;
   *)

--- a/.local/bin/wifi-powersave.sh
+++ b/.local/bin/wifi-powersave.sh
@@ -2,9 +2,32 @@
 
 # Usage: wifi-powersave.sh <on|off>
 
-for iface in /sys/class/net/*/wireless; do
-  iface="$(basename "$(dirname "$iface")")"
-  sudo iw dev "$iface" set power_save "$1" 2>/dev/null
+if [[ $1 != on && $1 != off ]]; then
+  echo "Usage: wifi-powersave.sh <on|off>" >&2
+  exit 1
+fi
+
+# iw exits 2 on a value it does not accept and 1 on a missing one. Sending that
+# to /dev/null and notifying regardless is how this reported success while
+# changing nothing. A machine can have more than one wireless interface, so one
+# success is enough to report success.
+# The sysfs root is overridable so both the has-wireless and no-wireless paths
+# can be tested on one machine, and so a runner without a wireless interface
+# can exercise the success path at all.
+SYSFS_NET="${HYPRSIMPLE_SYSFS_NET:-/sys/class/net}"
+
+changed=0
+for wireless in "$SYSFS_NET"/*/wireless; do
+  [[ -d $wireless ]] || continue
+  iface="$(basename "$(dirname "$wireless")")"
+  if sudo iw dev "$iface" set power_save "$1" 2>/dev/null; then
+    changed=$((changed + 1))
+  fi
 done
 
-notify-send "WiFi" "Power save: $1"
+if (( changed > 0 )); then
+  notify-send "WiFi" "Power save: $1"
+else
+  notify-send -u critical "WiFi" "Could not set power save to $1"
+  exit 1
+fi

--- a/test/untested-script-bugs-test.sh
+++ b/test/untested-script-bugs-test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Six defects found in scripts no suite had ever run. Five are one shape: an
+# error discarded, then success reported anyway. This suite drives each failure
+# path with stubs, so nothing here touches wifi, cpu governors, or the network.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+LOG="$TMP/calls"
+stub_logging() {
+  cat >"$STUB/$1" <<STUBEOF
+#!/bin/bash
+printf '%s %s\n' "$1" "\$*" >>"\$CALL_LOG"
+exit ${2:-0}
+STUBEOF
+  chmod +x "$STUB/$1"
+}
+
+# search_by_keyword.sh printed its usage and then searched anyway. rg treats an
+# empty pattern as matching every line of every file, so `sk` with no argument
+# fed the whole tree to fzf.
+stub_logging rg; stub_logging fzf
+: >"$LOG"
+CALL_LOG="$LOG" PATH="$STUB:$PATH" bash "$BIN/search_by_keyword.sh" >/dev/null 2>&1
+check "search_by_keyword with no argument exits non-zero" "$?" "1"
+check "search_by_keyword with no argument runs nothing" \
+  "$(wc -l <"$LOG" | tr -d ' ')" "0"
+
+: >"$LOG"
+CALL_LOG="$LOG" PATH="$STUB:$PATH" bash "$BIN/search_by_keyword.sh" needle >/dev/null 2>&1
+check "search_by_keyword with an argument still searches" \
+  "$(grep -c '^rg .*needle' "$LOG")" "1"
+
+# wifi-powersave.sh sent iw's output to /dev/null and notified success either
+# way. iw exits 2 on a value it rejects and 1 on a missing one.
+stub_logging sudo 0
+cat >"$STUB/sudo" <<'STUBEOF'
+#!/bin/bash
+# Stands in for sudo by running the rest of the line, so the iw stub decides.
+exec "$@"
+STUBEOF
+chmod +x "$STUB/sudo"
+stub_logging notify-send
+
+# A fake sysfs holding one wireless interface, so this runs the same way on a
+# laptop and on a runner that has no wireless hardware at all.
+mkdir -p "$TMP/net/wlan0/wireless" "$TMP/net/eth0"
+
+stub_logging iw 1
+: >"$LOG"
+CALL_LOG="$LOG" HYPRSIMPLE_SYSFS_NET="$TMP/net" PATH="$STUB:$PATH" bash "$BIN/wifi-powersave.sh" on >/dev/null 2>&1
+rc=$?
+check "wifi-powersave exits non-zero when iw fails" "$rc" "1"
+check "wifi-powersave does not announce success when iw fails" \
+  "$(grep -c 'notify-send.*Power save: on' "$LOG")" "0"
+check "wifi-powersave says so when it could not set it" \
+  "$(grep -c 'notify-send.*Could not set power save' "$LOG")" "1"
+
+stub_logging iw 0
+: >"$LOG"
+CALL_LOG="$LOG" HYPRSIMPLE_SYSFS_NET="$TMP/net" PATH="$STUB:$PATH" bash "$BIN/wifi-powersave.sh" on >/dev/null 2>&1
+check "wifi-powersave announces success when iw succeeds" \
+  "$(grep -c 'notify-send.*Power save: on' "$LOG")" "1"
+
+: >"$LOG"
+CALL_LOG="$LOG" HYPRSIMPLE_SYSFS_NET="$TMP/net" PATH="$STUB:$PATH" bash "$BIN/wifi-powersave.sh" onn >/dev/null 2>&1
+check "wifi-powersave rejects a value that is not on or off" "$?" "1"
+check "wifi-powersave runs no iw for a bad value" \
+  "$(grep -c '^iw ' "$LOG")" "0"
+
+# toggle_cpu_mode.sh echoed the mode whether or not cpupower set it.
+stub_logging cpupower 1
+: >"$LOG"
+CALL_LOG="$LOG" PATH="$STUB:$PATH" bash "$BIN/toggle_cpu_mode.sh" on >"$TMP/out" 2>/dev/null
+check "toggle_cpu_mode exits non-zero when cpupower fails" "$?" "1"
+check "toggle_cpu_mode does not claim a mode it failed to set" \
+  "$(grep -c '^CPU: performance$' "$TMP/out")" "0"
+
+stub_logging cpupower 0
+CALL_LOG="$LOG" PATH="$STUB:$PATH" bash "$BIN/toggle_cpu_mode.sh" on >"$TMP/out" 2>/dev/null
+check "toggle_cpu_mode reports the mode when cpupower succeeds" \
+  "$(grep -c '^CPU: performance$' "$TMP/out")" "1"
+
+# hyprsimple-debug.sh's upload tested the response for emptiness, which cannot
+# tell a URL from an error message, and curl without --fail exits 0 on an HTTP
+# error and prints the body. The function is lifted rather than the script run,
+# because collecting a real log invokes journalctl and sudo.
+sed -n '/^upload()/,/^}/p' "$BIN/hyprsimple-debug.sh" >"$TMP/upload.sh"
+check "upload was lifted out of hyprsimple-debug.sh" \
+  "$(grep -c '^upload()' "$TMP/upload.sh")" "1"
+# shellcheck disable=SC1091
+. "$TMP/upload.sh"
+LOG_FILE="$TMP/fake.log"; : >"$LOG_FILE"
+
+printf '#!/bin/bash\necho "Rate limit exceeded" >&2\nexit 22\n' >"$STUB/curl"; chmod +x "$STUB/curl"
+out=$(PATH="$STUB:$PATH" upload 2>&1); rc=$?
+check "a failed upload exits non-zero" "$rc" "1"
+check "a failed upload is not announced as a link" \
+  "$(grep -c 'Share this link' <<<"$out")" "0"
+
+printf '#!/bin/bash\necho "Rate limit exceeded"\nexit 0\n' >"$STUB/curl"; chmod +x "$STUB/curl"
+out=$(PATH="$STUB:$PATH" upload 2>&1); rc=$?
+check "a 200 carrying something that is not a URL is not announced as a link" \
+  "$(grep -c 'Share this link' <<<"$out")" "0"
+
+printf '#!/bin/bash\necho "https://0x0.st/abc.txt"\n' >"$STUB/curl"; chmod +x "$STUB/curl"
+out=$(PATH="$STUB:$PATH" upload 2>&1)
+check "a real URL is announced as a link" \
+  "$(grep -c 'https://0x0.st/abc.txt' <<<"$out")" "1"
+
+# The log path was a fixed name in a world-writable directory, truncated with >.
+check "the debug log path is generated, not fixed" \
+  "$(grep -c 'LOG_FILE="/tmp/hyprsimple-debug.log"' "$BIN/hyprsimple-debug.sh")" "0"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Fourteen of the forty eight maintained scripts have no suite that so much as names them. Reading the five smallest found six defects in about ten minutes, and five are one shape: **an error discarded, then success reported anyway.** The same shape as #53 and #55.

## The six

**`search_by_keyword.sh` printed its usage and then searched anyway.** Nothing followed the guard. `rg` treats an empty pattern as matching every line of every file, measured at **4,647 lines** in `.local/bin` alone, so `sk` with no argument fed the whole tree to fzf.

**`wifi-powersave.sh` reported success unconditionally.** It sent `iw`'s output to `/dev/null` and never read its status. Measured: `iw` exits **2** on a value it rejects and **1** on a missing one. So `wifi-powersave.sh onn` changed nothing and said `Power save: onn`. It is a documented user command at `README.md:311`.

**`toggle_cpu_mode.sh` announced the governor** whether or not `sudo cpupower` set it.

**`hyprsimple-debug.sh` could present a failed upload as a link.** The test was `[[ -n $url ]]`, which cannot tell a URL from an error message, and `curl` without `--fail` exits 0 on an HTTP error and prints the body. Measured: exit **0** against a 429, versus **22** with `--fail`. A rate-limited upload would print the error text under "Share this link on your issue" — in the script people run *because* something is already broken.

**`hyprsimple-debug.sh:39` described a check that does not exist.** The comment said `section()` prints "only if the tool backing it exists". It prints a header and checks nothing. Its callers do the checking.

**`hyprsimple-debug.sh` wrote to a fixed name in a world-writable directory,** truncated with `>`, which follows a symlink placed there first. It is a `mktemp` path now.

## A portability bug caught before it shipped

The first version of the wifi fix looped over the real `/sys/class/net`, so its success check would have passed on the maintainer's laptop and failed on a runner with no wireless hardware. That is the same "passes where it was written, fails where it runs" shape as the capslock and dunst checks earlier today. The sysfs root is overridable now, the way `hyprsimple-hw-battery.sh`'s already is.

## Checks

`test/untested-script-bugs-test.sh`, 18 checks, wired into the workflow. Every failure path is driven with stubs, so nothing here touches wifi, cpu governors, or the network. `upload()` is lifted out with `sed` rather than running the whole script, because collecting a real debug log invokes `journalctl` and `sudo`.

Each fix was sabotaged individually by restoring the original line, and each turns its own check red:

```
search: exit removed again          RED
wifi: notify unconditional again    RED
cpu: echo restored regardless       RED
upload: emptiness test restored     RED
debug log path fixed again          RED
```

All 26 suites pass, shellcheck clean at `style` including the `SC2002` check only CI's older version reports.

## Not claimed

**Nine untested scripts remain unexamined**, including `hyprsimple-muslimtify.sh` at 214 lines, plus `wifi.sh`, `setup-dns.sh`, `bashrc.sh` and `terminal.sh`. This fixes what was found in the five smallest, not everything there is.