### PR TITLE
Fix four more defects in scripts nothing had ever run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,9 @@ jobs:
       - name: untested-script-bugs-test
         run: bash test/untested-script-bugs-test.sh
 
+      - name: muslimtify-and-dns-test
+        run: bash test/muslimtify-and-dns-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/bashrc.sh
+++ b/.local/bin/bashrc.sh
@@ -29,8 +29,16 @@ y() {
     local cwd
     yazi "$@" --cwd-file="$tmp"
     IFS= read -r -d '' cwd <"$tmp"
-    [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && builtin cd -- "$cwd" || return
+    # Clean up unconditionally, and still report a failed cd. The old form
+    # ended the chain with `|| return`, which fired on every exit that did not
+    # change directory and skipped the cleanup, leaving a yazi-cwd file behind
+    # in /tmp each time.
+    local rc=0
+    if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+      builtin cd -- "$cwd" || rc=$?
+    fi
     rm -f -- "$tmp"
+    return "$rc"
   fi
 }
 

--- a/.local/bin/hyprsimple-muslimtify.sh
+++ b/.local/bin/hyprsimple-muslimtify.sh
@@ -7,7 +7,9 @@
 #   hyprsimple-muslimtify.sh remove   # strip waybar module + uninstall package
 #
 # Edits ~/.config/waybar/config.jsonc and ~/.config/waybar/style.css.
-# Backups are written next to the originals with a .bak suffix.
+# The first edit of each writes a .bak next to the original, and later edits
+# leave it alone, so the backup always holds the file as it was before
+# hyprsimple first touched it.
 
 set -u
 
@@ -40,7 +42,11 @@ reload_waybar() {
   ok "waybar reloaded"
 }
 
+# Keeps the first backup rather than the most recent one. add saves the user's
+# original, and a later remove used to overwrite that with the add-patched
+# version, so the thing the backup existed to preserve was the thing it lost.
 backup() {
+  [[ -f "$1.bak" ]] && return 0
   cp -f "$1" "$1.bak"
 }
 
@@ -52,12 +58,19 @@ pkg_installed() {
   pacman -Qi muslimtify >/dev/null 2>&1
 }
 
-# Returns the list of installed muslimtify-related packages (main + debug).
+# Returns the list of installed muslimtify-related packages (main + debug), or
+# nothing at all when none are installed.
+#
+# The guard matters. `printf '%s\n'` with no arguments still prints one empty
+# line, so an empty list reached mapfile as an array of length one holding "",
+# the caller's `(( ${#pkgs[@]} > 0 ))` was true, and remove tried to uninstall a
+# package with no name.
 installed_pkgs() {
   local p list=()
   for p in muslimtify muslimtify-debug; do
     pacman -Qi "$p" >/dev/null 2>&1 && list+=("$p")
   done
+  (( ${#list[@]} > 0 )) || return 0
   printf '%s\n' "${list[@]}"
 }
 

--- a/.local/bin/setup-dns.sh
+++ b/.local/bin/setup-dns.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# systemd-resolved is not in packages.txt, so it is not guaranteed to be the
+# resolver on this machine. Writing resolved.conf.d on a host that does not use
+# it changes nothing, and the script used to report success anyway.
+if ! systemctl is-active --quiet systemd-resolved; then
+  echo "systemd-resolved is not running, so this script cannot set your DNS." >&2
+  echo "Check what manages /etc/resolv.conf on this machine." >&2
+  exit 1
+fi
+
 echo "Select DNS provider:"
 echo "1) Cloudflare (1.1.1.1)"
 echo "2) Google (8.8.8.8)"
@@ -18,7 +27,8 @@ case $choice in
   3)
     echo "Using DHCP defaults"
     sudo rm -f /etc/systemd/resolved.conf.d/dns.conf
-    sudo systemctl restart systemd-resolved
+    sudo systemctl restart systemd-resolved ||
+      { echo "Could not restart systemd-resolved" >&2; exit 1; }
     echo "DNS reset to DHCP"
     exit 0
     ;;
@@ -35,5 +45,9 @@ DNS=$DNS
 DNSOverTLS=opportunistic
 EOF
 
-sudo systemctl restart systemd-resolved
+# Announcing the change only if the restart took. systemctl exits 5 on a unit
+# that does not exist and non-zero on one that fails to start, and this used to
+# print success either way, on a machine whose DNS was then broken.
+sudo systemctl restart systemd-resolved ||
+  { echo "Could not restart systemd-resolved, DNS unchanged" >&2; exit 1; }
 echo "DNS set to $DNS_NAME ($DNS)"

--- a/test/muslimtify-and-dns-test.sh
+++ b/test/muslimtify-and-dns-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Four defects in scripts that had never been run by anything. The muslimtify
+# one is the worst: with the package absent, remove took the uninstall branch,
+# tried to remove a package with no name, and died before cleaning the waybar
+# config it exists to clean.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+
+# installed_pkgs is lifted rather than the script run, because running it
+# invokes an AUR helper and edits waybar's config.
+sed -n '/^installed_pkgs()/,/^}/p' "$BIN/hyprsimple-muslimtify.sh" >"$TMP/pkgs.sh"
+check "installed_pkgs was lifted out" "$(grep -c '^installed_pkgs()' "$TMP/pkgs.sh")" "1"
+# shellcheck disable=SC1091
+. "$TMP/pkgs.sh"
+
+printf '#!/bin/bash\nexit 1\n' >"$STUB/pacman"; chmod +x "$STUB/pacman"
+mapfile -t pkgs < <(PATH="$STUB:$PATH" installed_pkgs)
+check "nothing installed yields an empty package list" "${#pkgs[@]}" "0"
+
+printf '#!/bin/bash\n[[ $2 == muslimtify ]] && exit 0\nexit 1\n' >"$STUB/pacman"; chmod +x "$STUB/pacman"
+mapfile -t pkgs < <(PATH="$STUB:$PATH" installed_pkgs)
+check "one installed package yields one entry" "${#pkgs[@]}" "1"
+check "and it is the right one" "${pkgs[0]}" "muslimtify"
+
+# The consequence, stated as the caller sees it. An empty list must not take
+# the uninstall branch, or remove dies before cleaning waybar.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/pacman"; chmod +x "$STUB/pacman"
+mapfile -t pkgs < <(PATH="$STUB:$PATH" installed_pkgs)
+if (( ${#pkgs[@]} > 0 )); then branch=uninstall; else branch=skip; fi
+check "with nothing installed, remove skips the uninstall branch" "$branch" "skip"
+
+# backup kept the most recent copy, so add then remove destroyed the original.
+sed -n '/^backup()/,/^}/p' "$BIN/hyprsimple-muslimtify.sh" >"$TMP/backup.sh"
+# shellcheck disable=SC1091
+. "$TMP/backup.sh"
+f="$TMP/config.jsonc"
+printf 'ORIGINAL\n' >"$f"
+backup "$f"; printf 'PATCHED BY ADD\n' >"$f"
+backup "$f"; printf 'CLEANED BY REMOVE\n' >"$f"
+check "the backup still holds the file as it was before hyprsimple touched it" \
+  "$(cat "$f.bak")" "ORIGINAL"
+
+# setup-dns.sh announced success whatever systemctl did, on a machine whose
+# DNS was then broken.
+check "setup-dns checks that systemd-resolved is running" \
+  "$(grep -c 'systemctl is-active --quiet systemd-resolved' "$BIN/setup-dns.sh")" "1"
+check "every systemd-resolved restart is checked" \
+  "$(grep -c 'systemctl restart systemd-resolved ||' "$BIN/setup-dns.sh")" "2"
+check "no restart is left unchecked" \
+  "$(grep -cE 'systemctl restart systemd-resolved$' "$BIN/setup-dns.sh")" "0"
+
+# The yazi wrapper skipped its own cleanup on every exit that did not change
+# directory, leaving a temp file behind each time.
+sed -n '/^y() {/,/^}/p' "$BIN/bashrc.sh" >"$TMP/y.sh"
+check "the yazi wrapper was lifted out" "$(grep -c '^y() {' "$TMP/y.sh")" "1"
+printf '#!/bin/bash\nfor a in "$@"; do case $a in --cwd-file=*) printf "%%s" "$PWD" > "${a#--cwd-file=}";; esac; done\n' >"$STUB/yazi"
+chmod +x "$STUB/yazi"
+# shellcheck disable=SC1091
+. "$TMP/y.sh"
+before=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'yazi-cwd.*' 2>/dev/null | wc -l)
+PATH="$STUB:$PATH" y >/dev/null 2>&1
+after=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'yazi-cwd.*' 2>/dev/null | wc -l)
+check "exiting yazi without changing directory leaves no temp file" "$after" "$before"
+
+# And a cd that fails must still clean up, while reporting the failure. The
+# first fix for the leak dropped the failure signal entirely, which shellcheck
+# caught as SC2164 before it was pushed.
+printf '#!/bin/bash\nfor a in "$@"; do case $a in --cwd-file=*) printf "%%s" "/nonexistent-xyz" > "${a#--cwd-file=}";; esac; done\n' >"$STUB/yazi"
+chmod +x "$STUB/yazi"
+before=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'yazi-cwd.*' 2>/dev/null | wc -l)
+PATH="$STUB:$PATH" y >/dev/null 2>&1
+check "a failed cd is reported" "$?" "1"
+after=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'yazi-cwd.*' 2>/dev/null | wc -l)
+check "a failed cd still cleans up its temp file" "$after" "$before"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
The five largest untested scripts, read for the first time. Four defects, and the muslimtify one breaks the command outright.

## `hyprsimple-muslimtify.sh remove` was broken whenever the package was absent

```bash
installed_pkgs() {
  ...
  printf '%s\n' "${list[@]}"      # no arguments still prints ONE EMPTY LINE
}
```

So with nothing installed, `mapfile -t pkgs` produced an array of **length 1** holding `""`, the caller's `(( ${#pkgs[@]} > 0 ))` was true, and remove ran the AUR helper against a package with no name. That fails, `die` exits 1, and **the waybar config and style the command exists to clean were never touched.**

Two of the three branches — the "not installed via pacman" note and "already absent" — were unreachable.

Measured directly with a stubbed `pacman`:

```
with nothing installed: pkgs length = 1, first = []
BRANCH TAKEN: uninstall   <- wrong
```

## `backup()` destroyed the thing it existed to preserve

It kept the most recent copy, not the first. `add` saved the user's original, then a later `remove` overwrote that with the add-patched version:

```
after add:    .bak holds [ORIGINAL USER CONFIG]
after remove: .bak holds [PATCHED BY ADD]      <- the original is gone
```

## `setup-dns.sh` announced success whatever systemctl did

`systemctl` exits **5** on a unit that does not exist, and `systemd-resolved` is **not in `packages.txt`**. So on a host that resolves some other way, the script wrote a file that changes nothing, failed to restart a unit that may not exist, and printed `DNS set to Cloudflare (1.1.1.1 1.0.0.1)` — on a machine whose DNS was then not what it said.

It now checks the resolver is actually running, and checks both restarts.

## The yazi wrapper leaked a temp file per session

```bash
[ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && builtin cd -- "$cwd" || return
rm -f -- "$tmp"      # skipped whenever you did not change directory
```

Reproduced: 0 files before, 1 after a single exit that ended where it started.

## Two mistakes of mine, both caught before pushing

**The first fix for the leak dropped the failure signal from `cd`.** shellcheck flagged it as `SC2164` locally, before CI. Cleanup is now unconditional and the status still propagates. All three paths verified from a clean start: same directory, failed cd, real cd — zero temp files, correct exit codes.

**The first sabotage of the `installed_pkgs` fix silently failed**, because the pattern passed to `sed` contained `||` while `|` was the delimiter. It reported "NOTHING FAILED, vacuous", which would have sent me rewriting a check that was fine. Re-run with a verified edit, it turns **two** checks red. A tool that did not run is not a negative result.

## Checks

`test/muslimtify-and-dns-test.sh`, 13 checks, wired into the workflow. Functions are lifted with `sed` rather than the scripts run, because running them invokes an AUR helper, edits waybar's config, and restarts system services.

All four fixes sabotaged individually, each turning its own checks red.

All 27 suites pass, shellcheck clean at `style`.

## Not claimed

`terminal.sh` and `wifi.sh` were read and nothing was found. That is weaker evidence than a test, and neither has one.