### PR TITLE
Install the programs the config launches

### DIFF
--- a/.config/hypr/bindings/applications.lua
+++ b/.config/hypr/bindings/applications.lua
@@ -6,13 +6,17 @@ hl.bind("SUPER + SHIFT + W", hl.dsp.exec_cmd(home .. "/.local/bin/wallpaper-swit
 hl.bind("SUPER + ALT + W",   hl.dsp.exec_cmd(home .. "/.local/bin/wallpaper-switcher.sh next"),        { description = "Next Wallpaper" })
 hl.bind("SUPER + CTRL + W",  hl.dsp.exec_cmd(home .. "/.local/bin/live-wallpaper-toggle.sh"),          { description = "Toggle Live Wallpaper" })
 
-hl.bind("SUPER + T", hl.dsp.exec_cmd(vars.terminal),       { description = "Terminal" })
-hl.bind("SUPER + B", hl.dsp.exec_cmd(vars.browser),        { description = "Browser" })
-hl.bind("SUPER + O", hl.dsp.exec_cmd(vars.notes),          { description = "Notes" })
-hl.bind("SUPER + S", hl.dsp.exec_cmd(vars.androidstudio),  { description = "Android Studio" })
-hl.bind("SUPER + F", hl.dsp.exec_cmd(vars.fileManager),    { description = "File Manager" })
-hl.bind("SUPER + A", hl.dsp.exec_cmd(vars.menu),           { description = "App Launcher" })
+hl.bind("SUPER + T", hl.dsp.exec_cmd(vars.terminal),    { description = "Terminal" })
+hl.bind("SUPER + B", hl.dsp.exec_cmd(vars.browser),     { description = "Browser" })
+hl.bind("SUPER + F", hl.dsp.exec_cmd(vars.fileManager), { description = "File Manager" })
+hl.bind("SUPER + A", hl.dsp.exec_cmd(vars.menu),        { description = "App Launcher" })
 
-hl.bind("SUPER + E", hl.dsp.exec_cmd("sh -c 'jome -d | wl-copy'"),                                              { description = "Emoji Picker" })
+-- Bind your own programs here. hyprsimple only ships keys for software it
+-- installs, because a key bound to something absent does nothing at all and
+-- says nothing about why:
+--
+--   hl.bind("SUPER + O", hl.dsp.exec_cmd("obsidian"),       { description = "Notes" })
+--   hl.bind("SUPER + S", hl.dsp.exec_cmd("android-studio"), { description = "Android Studio" })
+
 hl.bind("SUPER + V", hl.dsp.exec_cmd("sh -c 'cliphist list | rofi --show dmenu | cliphist decode | wl-copy'"),  { description = "Clipboard Manager" })
 hl.bind("SUPER + M", hl.dsp.exec_cmd("sh -c '" .. vars.colorPicker .. " | wl-copy'"),                           { description = "Color Picker" })

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,6 +128,9 @@ jobs:
       - name: muslimtify-and-dns-test
         run: bash test/muslimtify-and-dns-test.sh
 
+      - name: launched-programs-test
+        run: bash test/launched-programs-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/README.md
+++ b/README.md
@@ -181,9 +181,6 @@ Press **`SUPER + /`** for interactive viewer with fuzzy search.
 | `SUPER + B` | Open browser (Brave) |
 | `SUPER + A` | App launcher (Rofi) |
 | `SUPER + F` | File manager (Nautilus) |
-| `SUPER + O` | Notes (Obsidian) |
-| `SUPER + S` | Android Studio |
-| `SUPER + E` | Emoji picker |
 | `SUPER + V` | Clipboard history |
 | `SUPER + M` | Color picker |
 

--- a/aur-packages.txt
+++ b/aur-packages.txt
@@ -1,7 +1,6 @@
 # AUR Packages
 wlogout
 wl-mirror
-nwg-look
 wl-screenrec-git
 muslimtify
 imagemagick

--- a/default/hypr/vars.lua
+++ b/default/hypr/vars.lua
@@ -7,9 +7,7 @@ M.fileManager = "nautilus"
 M.menu = os.getenv("HOME") .. "/.config/rofi/launcher/launcher.sh"
 M.powermenu = os.getenv("HOME") .. "/.config/rofi/powermenu/powermenu.sh"
 M.browser = "brave --enable-features=UseOzonePlatform --ozone-platform=wayland"
-M.notes = "obsidian"
 M.colorPicker = "hyprpicker"
-M.androidstudio = "android-studio"
 
 -- pcall so a syntax error in the user's file degrades to these defaults rather
 -- than killing the session. hypr.vars and default.hypr.vars are distinct module

--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,6 @@
 # Core Hyprland
 hyprland
+uwsm
 hyprpaper
 hyprlock
 hypridle
@@ -36,6 +37,7 @@ zip
 cpupower
 btop
 power-profiles-daemon
+upower
 qt5-wayland
 qt6-wayland
 kvantum

--- a/test/launched-programs-test.sh
+++ b/test/launched-programs-test.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Every program the shipped config launches has to be a program the installer
+# installs. Nothing enforced that, and three things had drifted apart from it:
+# uwsm, which runs every autostart entry, was never in a package list at all,
+# and two keys were bound to software the installer had never heard of.
+#
+# A missing program is the quietest failure hyprsimple has. Hyprland execs it,
+# the exec fails, and no window, message or log line says so. The whole point
+# of this suite is that the list is checked by something other than a person
+# remembering to check it.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+LUA_FILES=(
+  "$REPO/default/hypr/autostart.lua"
+  "$REPO/default/hypr/bindings"/*.lua
+  "$REPO/.config/hypr/bindings"/*.lua
+)
+
+# Commands hyprsimple never installs because they arrive with the base system
+# or with the toolchain any Arch machine already has. Each one is here because
+# it was checked, not because it looked familiar.
+BASE_COMMANDS=(
+  sh              # bash provides it, and bash is not optional on Arch
+  systemctl       # systemd
+  dbus-update-activation-environment  # dbus, a dependency of hyprland
+  cut env         # coreutils
+  killall         # psmisc, which base depends on
+)
+
+# Where the command name and the package name differ. A command absent from
+# this table has to be its own package name.
+package_of() {
+  case "$1" in
+    wl-copy | wl-paste) echo wl-clipboard ;;
+    wpctl) echo wireplumber ;;
+    killall) echo psmisc ;;
+    brave) echo brave-bin ;;
+    nvim) echo neovim ;;
+    wl-screenrec) echo wl-screenrec-git ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# Every command string the shipped lua hands to Hyprland, comment lines dropped
+# first so an example in a comment is not read as a binding.
+cmd_strings() {
+  grep -hv '^[[:space:]]*--' "${LUA_FILES[@]}" |
+    grep -oE 'exec_cmd\(\[\[[^]]*\]\]|exec_cmd\("[^"]*"' |
+    sed -E 's/^exec_cmd\(\[\[//; s/\]\]$//; s/^exec_cmd\("//; s/"$//'
+}
+
+# The quoted defaults in vars.lua. The two that are built by concatenating
+# os.getenv("HOME") are paths into this repository rather than programs, and do
+# not match the quoted form on purpose.
+vars_values() {
+  grep -oE '^M\.[a-zA-Z]+ = "[^"]*"' "$REPO/default/hypr/vars.lua" |
+    sed -E 's/^[^"]*"//; s/"$//'
+}
+
+# One command string in, the program names it runs out. uwsm is a launcher and
+# sh -c is a wrapper, so both are peeled off to reach what actually runs, and
+# then each pipeline or list segment contributes its first word.
+programs_in() {
+  local s="$1"
+  # uwsm is itself a program that has to be installed, and peeling it off is
+  # what hid it: it never appeared in its own output.
+  [[ $s == *"uwsm app -- "* ]] && printf 'uwsm\n'
+  s="${s//uwsm app -- /}"
+  s="${s//sh -c /}"
+  # The quotes around an sh -c argument survive the lua string and would
+  # otherwise ride along on the first and last program name.
+  s="${s#\'}"
+  s="${s%\'}"
+  printf '%s\n' "$s" | tr '|&;' '\n' | sed -E "s/^[[:space:]']+//" | awk 'NF {print $1}'
+}
+
+mapfile -t launched < <(
+  {
+    cmd_strings
+    vars_values
+  } | while IFS= read -r line; do programs_in "$line"; done |
+    # A path is a file in this repository, which the copy step covers and the
+    # missing-script check in another suite already pins. A lua fragment is an
+    # artefact of concatenation, not a program.
+    grep -vE '^/|^\$|^"|\.lua|os\.getenv|vars\.' |
+    sort -u
+)
+
+check "the extractor found the programs the config launches" \
+  "$([[ ${#launched[@]} -ge 8 ]] && echo enough || echo "only ${#launched[@]}")" "enough"
+
+# uwsm is the one this suite exists for, so name it rather than trusting the
+# extractor to have kept finding it.
+check "uwsm is among the launched programs" \
+  "$(printf '%s\n' "${launched[@]}" | grep -cx uwsm)" "1"
+
+packages="$(grep -hv '^[[:space:]]*#' "$REPO/packages.txt" "$REPO/aur-packages.txt" | grep -v '^[[:space:]]*$')"
+
+for prog in "${launched[@]}"; do
+  skip=0
+  for base in "${BASE_COMMANDS[@]}"; do
+    [[ $prog == "$base" ]] && skip=1 && break
+  done
+  (( skip )) && continue
+
+  pkg="$(package_of "$prog")"
+  if printf '%s\n' "$packages" | grep -qx "$pkg"; then
+    pass "$prog is installed by hyprsimple (package $pkg)"
+  else
+    fail "$prog is launched by the shipped config but no package list installs it"
+  fi
+done
+
+# Scripts have runtime dependencies that no lua file mentions. Only the ones
+# with no fallback belong here: a script that checks with command -v and says
+# something useful is not a silent failure.
+#
+# battery-monitor.sh reads the charge and the charging state through upower and
+# through nothing else. Without it the script still exits 0, every 30 seconds,
+# for as long as the timer is enabled, having done nothing.
+HARD_SCRIPT_DEPS=(
+  "battery-monitor.sh upower upower"
+)
+
+for entry in "${HARD_SCRIPT_DEPS[@]}"; do
+  read -r script prog pkg <<<"$entry"
+  if [[ $(grep -c "\\b$prog\\b" "$REPO/.local/bin/$script") -eq 0 ]]; then
+    fail "$script no longer calls $prog, so remove it from HARD_SCRIPT_DEPS"
+  elif printf '%s\n' "$packages" | grep -qx "$pkg"; then
+    pass "$prog is installed by hyprsimple, so $script can run (package $pkg)"
+  else
+    fail "$script depends on $prog with no fallback but no package list installs it"
+  fi
+done
+
+# A package named twice is installed twice, once from the repositories and once
+# through the AUR helper, and the second one is a build nobody asked for.
+dupes="$(printf '%s\n' "$packages" | sort | uniq -d | tr '\n' ' ')"
+check "no package is listed in both packages.txt and aur-packages.txt" "${dupes:-none}" "none"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Three programs the shipped config runs were in no package list, and nothing checked that they were.

## uwsm

Every entry in `default/hypr/autostart.lua` runs as `uwsm app -- ...`, and so do `hyprsimple-restart-dunst.sh`, `hyprsimple-restart-waybar.sh`, `toggle-idle.sh`, `toggle-nightlight.sh` and `hypr-logout.sh`.

```
$ pacman -Si hyprland | grep uwsm
   uwsm: an advanced way to start desktop compositors as systemd units
```

That is under **Optional Deps**, which pacman never installs, and `git log -S'uwsm' -- packages.txt aur-packages.txt` returns nothing, so it has never been listed. On a fresh install waybar, hypridle and both cliphist watchers never start. Measured with uwsm off PATH:

```
dunst before: 1
restart exit=0
dunst after: 0
```

dunst came back only because D-Bus activates it on demand. Nothing else in that list has such a fallback.

## upower

`battery-monitor.sh` reads both the charge and the charging state through `upower` and through nothing else.

```
$ env PATH=<no upower> bash .local/bin/battery-monitor.sh
battery-monitor.sh: line 13: upower: command not found
...
exit=0
```

Exit 0, no notification, no brightness drop, every 30 seconds for as long as the timer is enabled.

## Three keys bound to nothing

`SUPER + O` to obsidian, `SUPER + S` to android-studio, `SUPER + E` to jome. None in a package list, two of them documented in the README keybindings table.

They are removed rather than installed. android-studio is a 1.5 GB AUR build and jome is an AUR emoji picker with two votes, and neither belongs in a default desktop install. A key that does nothing and says nothing is worse than no key. `applications.lua` carries a commented example instead, so binding your own is one uncommented line.

Existing users keep their own `applications.lua`, and `hyprsimple-update.sh` will name it in the config-drift notice with the `hyprsimple-refresh-config.sh` command for it.

## Also

`nwg-look` was listed in both `packages.txt` and `aur-packages.txt`, which meant an AUR build of something already installed from the repositories.

## The check that lasts

`test/launched-programs-test.sh` reads every command string the shipped lua hands to Hyprland, peels off the `uwsm` and `sh -c` wrappers, splits pipelines and lists, resolves the quoted defaults in `vars.lua`, and asserts that every program left is installed by a package list. Base-system commands are allowed by name with the reason each is safe, and the binary-to-package differences are an explicit table.

Six sabotages, all of which turn it red:

| sabotage | result |
|---|---|
| drop `uwsm` from packages.txt | `not ok - uwsm is launched by the shipped config but no package list installs it` |
| drop `upower` | `not ok - battery-monitor.sh depends on upower with no fallback but no package list installs it` |
| re-add the obsidian binding | `not ok - obsidian is launched by the shipped config but no package list installs it` |
| re-add the jome binding | `not ok - jome is launched by the shipped config but no package list installs it` |
| re-add duplicate `nwg-look` | `not ok - no package is listed in both packages.txt and aur-packages.txt` |
| make battery-monitor.sh call `acpi` instead | `not ok - battery-monitor.sh no longer calls upower, so remove it from HARD_SCRIPT_DEPS` |

The commented obsidian example in `applications.lua` leaves it green, which is the comment handling proven rather than assumed.

## Not changed

`python3` is called unguarded by `hyprsimple-muslimtify.sh` and is deliberately not added. `ufw` is already in `packages.txt` and depends on `python`, so it arrives either way.

`killall` is used by a shipped binding and comes from `psmisc`, which `base` depends on. Allowed by name in the suite with that reason.

All 27 suites pass, shellcheck clean at `style`.
