### PR TITLE
Stop a removed vars key from rejecting the whole config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,9 @@ jobs:
       - name: launched-programs-test
         run: bash test/launched-programs-test.sh
 
+      - name: vars-key-removal-test
+        run: bash test/vars-key-removal-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/default/hypr/vars.lua
+++ b/default/hypr/vars.lua
@@ -19,4 +19,23 @@ if ok and type(user) == "table" then
   end
 end
 
+-- This file is install-owned and reaches every machine on the next update, but
+-- ~/.config/hypr/bindings/applications.lua is user-owned and does not. So
+-- removing a key here breaks any older bindings file that still reads it, and
+-- not in a contained way: exec_cmd raises "expected string, got nil", which
+-- fails the whole config and takes every later binding in the file with it.
+-- Dropping M.notes and M.androidstudio in #62 did exactly that.
+--
+-- An unknown key now answers with a command that says which key is missing and
+-- where to set it, so an out-of-date bindings file loses one key rather than
+-- all of them. This also covers a plain typo in a hand-written binding.
+setmetatable(M, {
+  __index = function(_, key)
+    return "notify-send -u critical 'hyprsimple' "
+      .. "'This key runs vars." .. key .. ", which hyprsimple does not set. "
+      .. "Bind a program directly in ~/.config/hypr/bindings/applications.lua, "
+      .. "or set " .. key .. " in ~/.config/hypr/vars.lua.'"
+  end,
+})
+
 return M

--- a/migrations/1788529166.sh
+++ b/migrations/1788529166.sh
@@ -1,0 +1,46 @@
+echo "Update the application keybindings to match the programs hyprsimple installs"
+
+# #62 removed SUPER + O, SUPER + S and SUPER + E, and removed M.notes and
+# M.androidstudio from default/hypr/vars.lua with them. vars.lua is install
+# owned and arrived on the next update. ~/.config/hypr/bindings/applications.lua
+# is user owned and did not, so an existing install was left with a bindings
+# file reading two keys that no longer existed. exec_cmd raised "expected
+# string, got nil" and the whole config was rejected, not just those two lines.
+#
+# vars.lua now answers an unknown key with a command that explains itself, so
+# nothing crashes either way. This migration is the tidier half: a bindings file
+# that is byte-identical to something this project shipped was never edited, so
+# it is replaced outright and the three dead keys go away instead of turning
+# into a notification. Anything else is left alone and the command to update it
+# is printed instead.
+
+user="$HOME/.config/hypr/bindings/applications.lua"
+shipped="$HYPRSIMPLE_PATH/.config/hypr/bindings/applications.lua"
+
+[[ -f $user && -f $shipped ]] || exit 0
+
+# Already current, which is what makes a re-run a no-op.
+cmp -s "$user" "$shipped" && exit 0
+
+# Every version of this file the project has shipped before the current one,
+# from git history.
+SHIPPED_SUMS=(
+  1122945c51f39e1bc3d832e8209817d1
+  415fd3c8498075c259e2e88040b93c3a
+)
+
+sum=$(md5sum "$user" | cut -d' ' -f1)
+
+for known in "${SHIPPED_SUMS[@]}"; do
+  if [[ $sum == "$known" ]]; then
+    cp -f "$user" "$user.bak"
+    cp -f "$shipped" "$user"
+    echo "  Updated $user (previous version kept at $user.bak)"
+    exit 0
+  fi
+done
+
+echo "  $user has your own edits, so it was left alone."
+echo "  SUPER + O, SUPER + S and SUPER + E now report that they are unset."
+echo "  To take hyprsimple's version and lose your edits:"
+echo "    hyprsimple-refresh-config.sh hypr/bindings/applications.lua"

--- a/test/fixtures/applications.lua.pre-62
+++ b/test/fixtures/applications.lua.pre-62
@@ -1,0 +1,18 @@
+local vars = require("default.hypr.vars")
+local home = os.getenv("HOME")
+
+hl.bind("SUPER + SHIFT + T", hl.dsp.exec_cmd(home .. "/.local/bin/theme-switcher.sh"),                 { description = "Theme Switcher" })
+hl.bind("SUPER + SHIFT + W", hl.dsp.exec_cmd(home .. "/.local/bin/wallpaper-switcher.sh pick"),        { description = "Wallpaper Picker" })
+hl.bind("SUPER + ALT + W",   hl.dsp.exec_cmd(home .. "/.local/bin/wallpaper-switcher.sh next"),        { description = "Next Wallpaper" })
+hl.bind("SUPER + CTRL + W",  hl.dsp.exec_cmd(home .. "/.local/bin/live-wallpaper-toggle.sh"),          { description = "Toggle Live Wallpaper" })
+
+hl.bind("SUPER + T", hl.dsp.exec_cmd(vars.terminal),       { description = "Terminal" })
+hl.bind("SUPER + B", hl.dsp.exec_cmd(vars.browser),        { description = "Browser" })
+hl.bind("SUPER + O", hl.dsp.exec_cmd(vars.notes),          { description = "Notes" })
+hl.bind("SUPER + S", hl.dsp.exec_cmd(vars.androidstudio),  { description = "Android Studio" })
+hl.bind("SUPER + F", hl.dsp.exec_cmd(vars.fileManager),    { description = "File Manager" })
+hl.bind("SUPER + A", hl.dsp.exec_cmd(vars.menu),           { description = "App Launcher" })
+
+hl.bind("SUPER + E", hl.dsp.exec_cmd("sh -c 'jome -d | wl-copy'"),                                              { description = "Emoji Picker" })
+hl.bind("SUPER + V", hl.dsp.exec_cmd("sh -c 'cliphist list | rofi --show dmenu | cliphist decode | wl-copy'"),  { description = "Clipboard Manager" })
+hl.bind("SUPER + M", hl.dsp.exec_cmd("sh -c '" .. vars.colorPicker .. " | wl-copy'"),                           { description = "Color Picker" })

--- a/test/vars-key-removal-test.sh
+++ b/test/vars-key-removal-test.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# default/hypr/vars.lua is install-owned and arrives on the next update.
+# ~/.config/hypr/bindings/applications.lua is user-owned and does not. Removing
+# a key from the first while the second still reads it is therefore a breaking
+# change, and #62 shipped one: exec_cmd raised "expected string, got nil" and
+# Hyprland rejected the entire config rather than the two offending lines.
+#
+# Two things are pinned here. An unknown key answers with a command instead of
+# nil, so an out-of-date bindings file loses one key rather than all of them.
+# And the migration replaces a bindings file that was never edited, so the
+# common case gets the real fix rather than the fallback.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+VARS="$REPO/default/hypr/vars.lua"
+
+# ---- the fallback -------------------------------------------------------
+
+check "a key vars.lua does set returns its value" \
+  "$(lua -e "io.write(dofile('$VARS').terminal)")" "ghostty"
+
+check "a key vars.lua does not set returns a string, not nil" \
+  "$(lua -e "io.write(type(dofile('$VARS').notAKeyAnyoneShips))")" "string"
+
+# The string has to be a command, because that is what exec_cmd will run. A
+# fallback that returns a bare message would be handed to the shell as one.
+fallback="$(lua -e "io.write(dofile('$VARS').notes)")"
+check "the fallback names the missing key" \
+  "$(printf '%s' "$fallback" | grep -c 'vars\.notes')" "1"
+
+# Running it under a stub, rather than asking whether it parses. Every string
+# parses as a shell command, including a bare message, so a parse check passes
+# on a fallback that only prints "command not found" at the user.
+STUB="$TMP/bin"
+mkdir -p "$STUB"
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$@" >>"$NOTIFY_LOG"
+STUBEOF
+chmod +x "$STUB/notify-send"
+
+NOTIFY_LOG="$TMP/notify.log"
+: >"$NOTIFY_LOG"
+NOTIFY_LOG="$NOTIFY_LOG" PATH="$STUB:$PATH" sh -c "$fallback"
+check "the fallback actually notifies when run" \
+  "$(grep -c 'vars\.notes' "$NOTIFY_LOG")" "1"
+check "the notification says where to set it" \
+  "$(grep -c 'applications\.lua' "$NOTIFY_LOG")" "1"
+
+# ---- every vars key the shipped config reads is actually set -------------
+
+mapfile -t referenced < <(
+  grep -rhoE '\bvars\.[a-zA-Z][a-zA-Z0-9]*' \
+    "$REPO/.config/hypr/bindings"/*.lua \
+    "$REPO/default/hypr/autostart.lua" \
+    "$REPO/default/hypr/bindings"/*.lua 2>/dev/null |
+    sed 's/^vars\.//' | sort -u
+)
+
+check "the extractor found vars keys in the shipped config" \
+  "$([[ ${#referenced[@]} -ge 3 ]] && echo enough || echo "only ${#referenced[@]}")" "enough"
+
+for key in "${referenced[@]}"; do
+  if grep -qE "^M\.$key = " "$VARS"; then
+    pass "vars.$key is set in default/hypr/vars.lua"
+  else
+    fail "vars.$key is read by the shipped config but default/hypr/vars.lua does not set it"
+  fi
+done
+
+# ---- the migration ------------------------------------------------------
+
+# A glob rather than parsing ls, which is the finding class this project has
+# actually shipped as a bug. Migrations are named after a unix timestamp, so
+# the glob's own sort is chronological.
+migrations=("$REPO/migrations"/*.sh)
+MIGRATION="${migrations[-1]}"
+if grep -q 'applications.lua' "$MIGRATION"; then
+  pass "the newest migration is the applications.lua one"
+else
+  fail "the newest migration does not mention applications.lua, so this suite is aimed at the wrong file"
+fi
+
+SHIPPED="$REPO/.config/hypr/bindings/applications.lua"
+
+# The version users had before #62, kept as a fixture rather than read from git
+# history, because CI checks out shallow and the commit is not there.
+#
+# A fixture can rot into something no user ever had, so it is checked against
+# the migration's own checksum list rather than trusted. If those disagree,
+# every case below is testing bytes that do not matter.
+PREVIOUS="$REPO/test/fixtures/applications.lua.pre-62"
+previous_sum="$(md5sum "$PREVIOUS" | cut -d' ' -f1)"
+check "the fixture is a version the migration claims to handle" \
+  "$(grep -c "$previous_sum" "$MIGRATION")" "1"
+
+if [[ ! -s $PREVIOUS ]]; then
+  fail "the pre-#62 applications.lua fixture is missing"
+else
+  run_migration() {
+    local home="$1"
+    HOME="$home" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" 2>&1
+  }
+
+  # pristine: replaced, with a backup
+  home_pristine="$TMP/pristine"
+  mkdir -p "$home_pristine/.config/hypr/bindings"
+  cp "$PREVIOUS" "$home_pristine/.config/hypr/bindings/applications.lua"
+  run_migration "$home_pristine" >/dev/null
+  check "a never-edited bindings file is replaced with the shipped one" \
+    "$(cmp -s "$home_pristine/.config/hypr/bindings/applications.lua" "$SHIPPED" && echo replaced || echo unchanged)" \
+    "replaced"
+  check "the replaced file is backed up" \
+    "$(cmp -s "$home_pristine/.config/hypr/bindings/applications.lua.bak" "$PREVIOUS" && echo kept || echo lost)" \
+    "kept"
+
+  # edited: untouched
+  home_edited="$TMP/edited"
+  mkdir -p "$home_edited/.config/hypr/bindings"
+  { cat "$PREVIOUS"; printf '\n-- MY OWN BINDING MARKER\n'; } >"$home_edited/.config/hypr/bindings/applications.lua"
+  out="$(run_migration "$home_edited")"
+  check "an edited bindings file is left alone" \
+    "$(grep -c 'MY OWN BINDING MARKER' "$home_edited/.config/hypr/bindings/applications.lua")" "1"
+  check "an edited bindings file gets no backup, because nothing was replaced" \
+    "$([[ -f $home_edited/.config/hypr/bindings/applications.lua.bak ]] && echo yes || echo no)" "no"
+  check "the user is told how to take hyprsimple's version" \
+    "$(printf '%s' "$out" | grep -c 'hyprsimple-refresh-config.sh hypr/bindings/applications.lua')" "1"
+
+  # already current: no-op, and no stray backup
+  home_current="$TMP/current"
+  mkdir -p "$home_current/.config/hypr/bindings"
+  cp "$SHIPPED" "$home_current/.config/hypr/bindings/applications.lua"
+  out_current="$(run_migration "$home_current")"
+  check "an already-current bindings file is a no-op" \
+    "$([[ -f $home_current/.config/hypr/bindings/applications.lua.bak ]] && echo backed-up || echo untouched)" \
+    "untouched"
+  # Without the early cmp, a file that is already current falls through to the
+  # unknown-checksum branch and every future update tells the user they have
+  # edits they do not have.
+  check "an already-current bindings file is not accused of having edits" \
+    "$(printf '%s' "$out_current" | grep -c 'your own edits')" "0"
+
+  # re-running the migration must not undo the first run
+  run_migration "$home_pristine" >/dev/null
+  check "re-running the migration changes nothing" \
+    "$(cmp -s "$home_pristine/.config/hypr/bindings/applications.lua" "$SHIPPED" && echo still-current || echo drifted)" \
+    "still-current"
+fi
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Fixes the error #62 caused.

```
=[C]:-1: exec_cmd: bad argument 1: expected string, got nil
/home/USER/.config/hypr/bindings/applications.lua:11: hl.bind: dispatcher must be a dispatcher
=[C]:-1: exec_cmd: bad argument 1: expected string, got nil
/home/USER/.config/hypr/bindings/applications.lua:12: hl.bind: dispatcher must be a dispatcher
```

## What I got wrong

#62 removed `M.notes` and `M.androidstudio` from `default/hypr/vars.lua` in the same change that removed the two keys reading them. Those two files are not delivered the same way:

| file | owner | reaches an existing install |
|---|---|---|
| `default/hypr/vars.lua` | install | on the next `hyprsimple-update` |
| `.config/hypr/bindings/applications.lua` | user | never, by design |

So the removal arrived and the bindings did not. I wrote in that PR that existing users "keep their own `applications.lua`" as though that made it safe. It made it break: the file was left reading two keys that no longer exist.

And the failure is not contained to those two lines. `exec_cmd` raises on nil, `hl.bind` rejects the result, and Hyprland reports the whole config as bad.

Reproduced on a live session by restoring the pre-#62 bindings file against the current installed `vars.lua`, which printed exactly the two errors reported.

## Two halves, for two different users

**The fallback.** `vars.lua` answers an unknown key with a command that names the key and says where to set it, instead of nil. An out-of-date bindings file now loses one key rather than all of them. This also covers a plain typo in a hand-written binding, which failed the same way for the same reason.

**The migration.** A bindings file byte-identical to something this project shipped was never edited, so it is replaced outright and the three dead keys go away with no notification at all. Anything else is left alone and told how to update.

Verified live, in order: the pre-#62 file reproduces both errors, the fallback alone clears them (86 binds, no config errors), the migration then replaces the file (`415fd3c8` to `993b9948`, backup kept), and a re-run is a no-op.

## The check that would have caught it

`test/vars-key-removal-test.sh` pins the fallback, the migration's three cases, and the rule itself: every `vars.` key the shipped config reads has to be set in `vars.lua`.

**It took two rounds of sabotage.** The first round left two checks green:

| weak check | why it passed anyway | now |
|---|---|---|
| "the fallback parses as a shell command" | every string parses, including a bare message | runs it under a `notify-send` stub and asserts what arrived |
| "an already-current file is unchanged" | the unknown-checksum branch also leaves it alone | asserts the user is not told they have edits they do not have |

Six sabotages now turn it red, including removing the metatable, dropping the migration's backup, and making the migration replace an edited file.

`test/suite-hygiene-test.sh` caught a third problem before CI did: the suite read the pre-#62 file with `git show`, and CI checks out shallow. It is a fixture now, checked against the migration's own checksum list so it cannot rot into bytes no user ever had.

All 28 suites pass, shellcheck clean at `style`.
