### PR TITLE
Remove generated theme files whose template no longer exists

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,9 @@ jobs:
       - name: vars-key-removal-test
         run: bash test/vars-key-removal-test.sh
 
+      - name: generated-cleanup-test
+        run: bash test/generated-cleanup-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/theme-apply-templates.sh
+++ b/.local/bin/theme-apply-templates.sh
@@ -73,11 +73,13 @@ mkdir -p "$THEME_DIR/generated"
 
 # The union of the install and the override directory, so a template added to
 # the repository renders without the user having anything at all.
+rendered=()
 while IFS= read -r name; do
   warn_about_stale "$name"
   tpl=$(template_path "$name")
   [[ -n $tpl ]] || continue
   sed -f "$sed_script" "$tpl" >"$THEME_DIR/generated/${name%.tpl}"
+  rendered+=("${name%.tpl}")
 done < <(
   {
     # Globs rather than `ls | grep`, which splits a template name containing a
@@ -87,6 +89,25 @@ done < <(
     done
   } | sort -u
 )
+
+# Everything under generated/ is written by this script and read by nothing
+# else, so a file here with no template behind it is output from a template
+# that has since been removed. wlogout's colours sat in all sixteen themes
+# after the power menu was dropped, because rendering only ever wrote.
+#
+# Guarded on having rendered something. If TEMPLATES_DIR were missing or empty
+# the loop above would produce no names, and reconciling against an empty set
+# would delete every generated file in every theme.
+if (( ${#rendered[@]} > 0 )); then
+  for existing in "$THEME_DIR/generated"/*; do
+    [[ -f $existing ]] || continue
+    keep=0
+    for name in "${rendered[@]}"; do
+      [[ $(basename "$existing") == "$name" ]] && keep=1 && break
+    done
+    (( keep )) || rm -f "$existing"
+  done
+fi
 
 rm "$sed_script"
 echo "Templates generated in $THEME_DIR/generated/"

--- a/migrations/1788532937.sh
+++ b/migrations/1788532937.sh
@@ -1,0 +1,37 @@
+echo "Remove generated theme files whose template no longer exists"
+
+# Rendering only ever wrote. When a template was removed, its output stayed in
+# every theme forever: dropping the wlogout power menu left wlogout-colors.css
+# in all sixteen. theme-apply-templates.sh now removes an output with no
+# template behind it, but the re-render on update is gated on the template
+# contents changing, and they do not change here. So this runs it once.
+#
+# Nothing is deleted directly. The renderer decides, which means this migration
+# cannot disagree with the rule it is delivering.
+
+RENDERER="$HOME/.local/bin/theme-apply-templates.sh"
+THEMES="$HOME/.config/hypr/themes"
+
+[[ -x $RENDERER && -d $THEMES ]] || exit 0
+
+# Counting names that disappeared, not the change in how many files there are.
+# A render can add a file in the same pass that it removes one, and then the
+# difference in counts is zero while something really was deleted.
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+cleaned=0
+for dir in "$THEMES"/*/; do
+  name=$(basename "$dir")
+  [[ $name == templates || $name == templates.user ]] && continue
+  [[ -f $dir/colors.toml ]] || continue
+  find "$dir/generated" -type f -printf '%f\n' 2>/dev/null | sort >"$work/before"
+  "$RENDERER" "$dir" >/dev/null 2>&1 || continue
+  find "$dir/generated" -type f -printf '%f\n' 2>/dev/null | sort >"$work/after"
+  gone=$(comm -23 "$work/before" "$work/after" | grep -c . || true)
+  cleaned=$((cleaned + gone))
+done
+
+if (( cleaned > 0 )); then
+  echo "  Removed $cleaned stale file(s) from your themes"
+fi

--- a/test/generated-cleanup-test.sh
+++ b/test/generated-cleanup-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Rendering only ever wrote, so an output whose template was removed stayed in
+# every theme forever. Dropping the wlogout power menu left wlogout-colors.css
+# in all sixteen themes with nothing left to read it.
+#
+# The dangerous half of the fix is the deleting, not the rendering, so the
+# guard gets as many checks as the feature: an empty template directory must
+# leave everything alone rather than empty every theme.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RENDERER="$REPO/.local/bin/theme-apply-templates.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+# One fixture install and one theme, rebuilt for each case so no case inherits
+# another's leftovers.
+setup() {
+  INSTALL="$TMP/install"
+  HOMEDIR="$TMP/home"
+  must_be_fixture "$INSTALL"
+  must_be_fixture "$HOMEDIR"
+  rm -rf "$INSTALL" "$HOMEDIR"
+  THEME="$HOMEDIR/.config/hypr/themes/solo"
+  mkdir -p "$INSTALL/.config/hypr/themes/templates" "$THEME/generated"
+  printf 'background = "#2d353b"\n' >"$THEME/colors.toml"
+  printf 'bg {{ background }}\n' >"$INSTALL/.config/hypr/themes/templates/kept.tpl"
+}
+
+render() {
+  HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INSTALL" bash "$RENDERER" "$THEME" >/dev/null 2>&1
+}
+
+# ---- the orphan is removed ----------------------------------------------
+
+setup
+printf 'stale\n' >"$THEME/generated/gone.css"
+render
+check "an output whose template was removed is deleted" \
+  "$([[ -f $THEME/generated/gone.css ]] && echo present || echo removed)" "removed"
+check "and an output that still has a template survives" \
+  "$(grep -c 'bg #2d353b' "$THEME/generated/kept" 2>/dev/null)" "1"
+
+# ---- a user's own template counts as a template --------------------------
+
+setup
+mkdir -p "$HOMEDIR/.config/hypr/themes/templates.user"
+printf 'mine {{ background }}\n' >"$HOMEDIR/.config/hypr/themes/templates.user/mine.conf.tpl"
+render
+check "an output from the user's own template is not treated as an orphan" \
+  "$(grep -c 'mine #2d353b' "$THEME/generated/mine.conf" 2>/dev/null)" "1"
+
+# ---- the guard -----------------------------------------------------------
+#
+# This is the case that decides whether the feature is safe. With no templates
+# to render, the expected set is empty, and reconciling against an empty set
+# would delete every generated file in the theme.
+
+setup
+rm -f "$INSTALL/.config/hypr/themes/templates"/*.tpl
+printf 'precious\n' >"$THEME/generated/kept"
+printf 'precious\n' >"$THEME/generated/gone.css"
+render
+check "an empty template directory deletes nothing" \
+  "$(find "$THEME/generated" -type f | wc -l)" "2"
+
+setup
+rm -rf "$INSTALL/.config/hypr/themes/templates"
+printf 'precious\n' >"$THEME/generated/kept"
+render
+check "a missing template directory deletes nothing" \
+  "$(find "$THEME/generated" -type f | wc -l)" "1"
+
+# ---- a theme with no colors.toml is never touched -------------------------
+
+setup
+rm -f "$THEME/colors.toml"
+printf 'precious\n' >"$THEME/generated/gone.css"
+render
+check "a theme with no colors.toml keeps its generated files" \
+  "$([[ -f $THEME/generated/gone.css ]] && echo present || echo removed)" "present"
+
+# ---- idempotent ----------------------------------------------------------
+
+setup
+printf 'stale\n' >"$THEME/generated/gone.css"
+render
+first="$(find "$THEME/generated" -type f | sort | tr '\n' ' ')"
+render
+check "a second render changes nothing" \
+  "$(find "$THEME/generated" -type f | sort | tr '\n' ' ')" "$first"
+
+# ---- the migration delivers it -------------------------------------------
+
+# Pinned by name, not "the newest", which points somewhere else the moment
+# another migration lands.
+MIGRATION="$REPO/migrations/1788532937.sh"
+if [[ -f $MIGRATION ]]; then
+  pass "the migration this suite tests exists"
+else
+  fail "$MIGRATION is missing, so every check below is testing nothing"
+fi
+
+setup
+mkdir -p "$HOMEDIR/.local/bin"
+cp "$RENDERER" "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+chmod +x "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+printf 'stale\n' >"$THEME/generated/gone.css"
+out="$(HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INSTALL" bash "$MIGRATION" 2>&1)"
+check "the migration removes the orphan" \
+  "$([[ -f $THEME/generated/gone.css ]] && echo present || echo removed)" "removed"
+check "the migration says how many it removed" \
+  "$(printf '%s' "$out" | grep -c 'Removed 1 stale')" "1"
+
+# A second run has nothing left to remove and must say nothing about it.
+out="$(HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INSTALL" bash "$MIGRATION" 2>&1)"
+check "re-running the migration reports no removals" \
+  "$(printf '%s' "$out" | grep -c 'stale file')" "0"
+
+# The migration must delegate every deletion to the renderer, so that it cannot
+# disagree with the rule it is delivering. Pointing it at a renderer that does
+# nothing is what proves that: if the migration deletes anything of its own,
+# the orphan disappears here.
+#
+# An earlier version of this block removed the renderer entirely instead. That
+# passed with the migration's guard deleted, because a renderer that is not
+# there fails and the loop skips the theme either way, so it was testing
+# nothing.
+setup
+mkdir -p "$HOMEDIR/.local/bin"
+printf '#!/bin/sh\nexit 0\n' >"$HOMEDIR/.local/bin/theme-apply-templates.sh"
+chmod +x "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+printf 'stale\n' >"$THEME/generated/gone.css"
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INSTALL" bash "$MIGRATION" >/dev/null 2>&1
+check "the migration deletes nothing itself, only what the renderer removed" \
+  "$([[ -f $THEME/generated/gone.css ]] && echo present || echo removed)" "present"
+
+setup
+printf 'stale\n' >"$THEME/generated/gone.css"
+HOME="$HOMEDIR" HYPRSIMPLE_PATH="$INSTALL" bash "$MIGRATION" >/dev/null 2>&1
+rc=$?
+check "with no renderer installed the migration exits 0 and leaves the theme alone" \
+  "$rc:$([[ -f $THEME/generated/gone.css ]] && echo present || echo removed)" "0:present"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/vars-key-removal-test.sh
+++ b/test/vars-key-removal-test.sh
@@ -82,11 +82,10 @@ done
 
 # ---- the migration ------------------------------------------------------
 
-# A glob rather than parsing ls, which is the finding class this project has
-# actually shipped as a bug. Migrations are named after a unix timestamp, so
-# the glob's own sort is chronological.
-migrations=("$REPO/migrations"/*.sh)
-MIGRATION="${migrations[-1]}"
+# Pinned by name. Taking the newest migration instead made this suite point at
+# whatever landed last, and the next migration after it aimed all six checks
+# below at an unrelated file.
+MIGRATION="$REPO/migrations/1788529166.sh"
 if grep -q 'applications.lua' "$MIGRATION"; then
   pass "the newest migration is the applications.lua one"
 else


### PR DESCRIPTION
Closes the loose end from #64.

## The leak

Rendering only ever wrote. When a template was removed its output stayed in every theme forever, so dropping the wlogout power menu left `wlogout-colors.css` in all sixteen themes with nothing left to read it.

`themes/*/generated` is written by `theme-apply-templates.sh` and read by nothing else, so a file there with no template behind it has no other explanation. The renderer now removes those as part of rendering, which fixes the class rather than this one instance.

## The guard is the risky part

With `TEMPLATES_DIR` missing or empty the render loop produces no names, and reconciling against an empty set would delete **every** generated file in **every** theme. The cleanup is gated on having rendered something first, and two checks cover that:

| case | expected |
|---|---|
| empty template directory | deletes nothing |
| missing template directory | deletes nothing |
| theme with no `colors.toml` | never touched |
| a `templates.user` file | counts as a template, its output is not an orphan |

## The migration

The re-render on update is gated on template *contents* changing, and they do not change here, so a migration delivers it. It deletes nothing itself, it runs the renderer, so it cannot disagree with the rule it is delivering.

Verified on the live install:

```
before: 144 generated files, 16 named wlogout-colors.css
Removed 16 stale file(s) from your themes
after:  128 generated files, 0 named wlogout-colors.css
remaining names: btop.theme dunst-colors ghostty.conf hyprland-colors.lua
                 hyprlock.conf rofi-colors.rasi theme-clock.jsonc waybar-colors.css
```

Eight names left, eight shipped templates. Theme re-applied afterwards with no config errors, waybar and dunst still up, 83 binds.

## Three defects in my own work, all caught by checks rather than review

**The migration counted the wrong thing.** It measured the change in how many files exist, which is not how many were removed: a render can add a file in the same pass that it removes one, and then the difference is zero while something really was deleted. It counts names that disappeared now.

**A check was vacuous.** "With no renderer installed the migration deletes nothing" stayed green with the migration's guard deleted, because a renderer that is not there fails and the loop skips the theme either way. It now points at a renderer that exists and does nothing, which is what actually proves the migration does no deleting of its own. Adding an `rm` to the migration turns it red.

**Both new suites chased "the newest migration".** The moment this one landed, `vars-key-removal-test.sh` aimed all six of its checks at it and failed. Its own guard is what reported that. Both now pin their migration by filename, the way the older suites already did.

Six sabotages turn the new suite red, including removing the cleanup, removing the guard, ignoring `templates.user`, breaking the count, and making the migration delete on its own.

28 suites pass, shellcheck clean at `style`.
