### PR TITLE
Stop shipping another user's systemd symlinks

### DIFF
--- a/.config/systemd/user/default.target.wants/battery-monitor.service
+++ b/.config/systemd/user/default.target.wants/battery-monitor.service
@@ -1,1 +1,0 @@
-/home/rizki/.config/systemd/user/battery-monitor.service

--- a/.config/systemd/user/default.target.wants/pipewire-pulse.service
+++ b/.config/systemd/user/default.target.wants/pipewire-pulse.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/user/pipewire-pulse.service

--- a/.config/systemd/user/default.target.wants/pipewire.service
+++ b/.config/systemd/user/default.target.wants/pipewire.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/user/pipewire.service

--- a/.config/systemd/user/pipewire-session-manager.service
+++ b/.config/systemd/user/pipewire-session-manager.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/user/wireplumber.service

--- a/.config/systemd/user/pipewire.service.wants/wireplumber.service
+++ b/.config/systemd/user/pipewire.service.wants/wireplumber.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/user/wireplumber.service

--- a/.config/systemd/user/sockets.target.wants/pipewire-pulse.socket
+++ b/.config/systemd/user/sockets.target.wants/pipewire-pulse.socket
@@ -1,1 +1,0 @@
-/usr/lib/systemd/user/pipewire-pulse.socket

--- a/.config/systemd/user/sockets.target.wants/pipewire.socket
+++ b/.config/systemd/user/sockets.target.wants/pipewire.socket
@@ -1,1 +1,0 @@
-/usr/lib/systemd/user/pipewire.socket

--- a/.config/systemd/user/timers.target.wants/battery-monitor.timer
+++ b/.config/systemd/user/timers.target.wants/battery-monitor.timer
@@ -1,1 +1,0 @@
-/home/rizki/.config/systemd/user/battery-monitor.timer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,9 @@ jobs:
       - name: generated-cleanup-test
         run: bash test/generated-cleanup-test.sh
 
+      - name: committed-symlinks-test
+        run: bash test/committed-symlinks-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/migrations/1788533893.sh
+++ b/migrations/1788533893.sh
@@ -1,0 +1,39 @@
+echo "Remove the battery monitor's broken autostart link"
+
+# The repository committed systemd's enable state, not just its units, and two
+# of those symlinks had another user's home path baked into them:
+#
+#   default.target.wants/battery-monitor.service -> /home/rizki/...
+#   timers.target.wants/battery-monitor.timer    -> /home/rizki/...
+#
+# install.sh runs `systemctl --user enable --now battery-monitor.timer`, which
+# rewrote the timer one, so it points where it should. Nothing ever enabled the
+# service, so its link is still broken on every install.
+#
+# It is not inert. systemd resolves a .wants symlink by its filename rather than
+# its target, so default.target pulls in battery-monitor.service anyway and the
+# check runs once at login on top of the timer that already runs it every 30
+# seconds. The timer is the only thing that was meant to start it.
+#
+# Only a link that does not resolve is removed. One that does was enabled by
+# someone on purpose, and this leaves it alone.
+
+LINK="$HOME/.config/systemd/user/default.target.wants/battery-monitor.service"
+
+[[ -L $LINK ]] || exit 0
+[[ -e $LINK ]] && exit 0
+
+target=$(readlink "$LINK")
+case "$target" in
+  "$HOME"/*) exit 0 ;;
+esac
+
+rm -f "$LINK"
+echo "  Removed $LINK"
+echo "  It pointed at $target, which does not exist here."
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl --user daemon-reload 2>/dev/null || true
+fi
+
+echo "  The battery monitor still runs, on its timer, every 30 seconds."

--- a/test/committed-symlinks-test.sh
+++ b/test/committed-symlinks-test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# The repository committed systemd's enable state alongside its units, and two
+# of those symlinks pointed into /home/rizki, a home directory that exists on
+# nobody's machine. cp -r copies a broken symlink happily, exit 0, so every
+# install since has planted one and nothing said so.
+#
+# It is the second time this class has shipped. migrations/1787389156.sh repairs
+# a hardcoded /home/rizki path in hyprpaper.conf. That fix was made to the one
+# file somebody noticed, and two more instances sat in the systemd tree.
+#
+# So the rule is checked rather than remembered: nothing this repository tracks
+# may carry a path into a particular person's home.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+cd "$REPO" || exit 1
+
+# ---- no committed symlink escapes the repository -------------------------
+#
+# Every symlink here was systemd enable state, which belongs to a machine
+# rather than to a configuration, and which install.sh recreates correctly with
+# systemctl --user enable. A relative symlink inside the tree would be fine, an
+# absolute one never is: it names a path on whoever's machine made it.
+
+mapfile -t symlinks < <(git ls-files -s | awk '$1=="120000"{print $4}')
+
+escaping=()
+for link in "${symlinks[@]}"; do
+  target="$(readlink "$link")"
+  [[ $target == /* ]] && escaping+=("$link -> $target")
+done
+
+# printf runs once with no arguments when the array is empty, so the format
+# string prints on its own and a clean result reads as "; " rather than "".
+escaping_str=""
+(( ${#escaping[@]} > 0 )) && escaping_str="$(printf '%s; ' "${escaping[@]}")"
+
+check "no tracked symlink points at an absolute path" "$escaping_str" ""
+
+# ---- no tracked file carries somebody's home directory -------------------
+#
+# Migrations are excluded because they exist to repair exactly this, so the
+# path has to appear in them. Everything else has no reason to name one.
+
+mapfile -t hardcoded < <(
+  git grep -lI -E '/home/[a-z][a-z0-9_-]*/' -- . \
+    ':!migrations' ':!docs' ':!external' ':!test/committed-symlinks-test.sh' 2>/dev/null
+)
+
+hardcoded_str=""
+(( ${#hardcoded[@]} > 0 )) && hardcoded_str="$(printf '%s; ' "${hardcoded[@]}")"
+
+check "no tracked file outside migrations names a specific home directory" \
+  "$hardcoded_str" ""
+
+# ---- what should still be shipped ----------------------------------------
+
+for unit in battery-monitor.service battery-monitor.timer; do
+  if [[ -f $REPO/.config/systemd/user/$unit ]]; then
+    pass "$unit is still shipped, because a unit is configuration"
+  else
+    fail "$unit is missing, and the battery monitor cannot run without it"
+  fi
+done
+
+check "no .wants or .target.wants directory is tracked, that is enable state" \
+  "$(git ls-files '.config/systemd/*wants*' | wc -l)" "0"
+
+# ---- install.sh still enables everything the symlinks used to encode -----
+#
+# Deleting them is only safe because these two lines put them back, correctly
+# and under the right home. pipewire.service carries Also=pipewire.socket and
+# WantedBy=default.target, and wireplumber.service carries
+# Alias=pipewire-session-manager.service and WantedBy=pipewire.service, so
+# enabling those three recreates all six of the pipewire links.
+
+check "install.sh enables the pipewire units" \
+  "$(grep -c 'systemctl --user enable --now pipewire pipewire-pulse wireplumber' "$REPO/install.sh")" "1"
+check "install.sh enables the battery monitor timer" \
+  "$(grep -c 'systemctl --user enable --now battery-monitor.timer' "$REPO/install.sh")" "1"
+
+# ---- the migration --------------------------------------------------------
+
+MIGRATION="$REPO/migrations/1788533893.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if [[ -f $MIGRATION ]]; then
+  pass "the migration this suite tests exists"
+else
+  fail "$MIGRATION is missing, so every check below is testing nothing"
+fi
+
+wants_dir() { printf '%s' "$1/.config/systemd/user/default.target.wants"; }
+
+setup_home() {
+  local home="$TMP/$1"
+  rm -rf "$home"
+  mkdir -p "$(wants_dir "$home")" "$home/.config/systemd/user"
+  printf '[Unit]\n' >"$home/.config/systemd/user/battery-monitor.service"
+  printf '%s' "$home"
+}
+
+run_migration() {
+  # systemctl is stubbed out: the migration must not depend on a running user
+  # bus, and CI has none.
+  local home="$1" stub="$TMP/stub"
+  mkdir -p "$stub"
+  printf '#!/bin/sh\nexit 0\n' >"$stub/systemctl"
+  chmod +x "$stub/systemctl"
+  HOME="$home" PATH="$stub:$PATH" bash "$MIGRATION" 2>&1
+}
+
+# the broken link, which is what this is for
+home="$(setup_home broken)"
+ln -s /home/someone-else/.config/systemd/user/battery-monitor.service \
+  "$(wants_dir "$home")/battery-monitor.service"
+out="$(run_migration "$home")"
+check "a link pointing at another home is removed" \
+  "$([[ -L $(wants_dir "$home")/battery-monitor.service ]] && echo present || echo removed)" "removed"
+check "and the removal is reported" \
+  "$(printf '%s' "$out" | grep -c 'Removed')" "1"
+check "and the unit file itself is untouched" \
+  "$([[ -f $home/.config/systemd/user/battery-monitor.service ]] && echo kept || echo deleted)" "kept"
+
+# a link this user enabled on purpose
+home="$(setup_home deliberate)"
+ln -s "$home/.config/systemd/user/battery-monitor.service" \
+  "$(wants_dir "$home")/battery-monitor.service"
+run_migration "$home" >/dev/null
+check "a link the user enabled themselves is left alone" \
+  "$([[ -L $(wants_dir "$home")/battery-monitor.service ]] && echo present || echo removed)" "present"
+
+# A link that resolves but points outside this home. This is the case the
+# "does it resolve" guard exists for: the home check alone would delete it,
+# because its target is not under $HOME, and it is a working link.
+home="$(setup_home elsewhere)"
+mkdir -p "$TMP/systemwide"
+printf '[Unit]\n' >"$TMP/systemwide/battery-monitor.service"
+ln -s "$TMP/systemwide/battery-monitor.service" \
+  "$(wants_dir "$home")/battery-monitor.service"
+run_migration "$home" >/dev/null
+check "a working link is left alone even when its target is outside the home" \
+  "$([[ -L $(wants_dir "$home")/battery-monitor.service ]] && echo present || echo removed)" "present"
+
+# a broken link that still points inside this user's home, which is their
+# problem to fix and not this migration's to guess at
+home="$(setup_home ownbroken)"
+ln -s "$home/.config/systemd/user/nonexistent.service" \
+  "$(wants_dir "$home")/battery-monitor.service"
+run_migration "$home" >/dev/null
+check "a broken link inside the user's own home is left alone" \
+  "$([[ -L $(wants_dir "$home")/battery-monitor.service ]] && echo present || echo removed)" "present"
+
+# nothing there at all
+home="$(setup_home absent)"
+out="$(run_migration "$home")"
+check "with no link at all the migration says nothing and exits 0" \
+  "$(printf '%s' "$out" | grep -c 'Removed')" "0"
+
+# re-running after a removal
+home="$(setup_home rerun)"
+ln -s /home/someone-else/.config/systemd/user/battery-monitor.service \
+  "$(wants_dir "$home")/battery-monitor.service"
+run_migration "$home" >/dev/null
+out="$(run_migration "$home")"
+check "re-running the migration reports nothing" \
+  "$(printf '%s' "$out" | grep -c 'Removed')" "0"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
The repository tracked systemd's **enable state** alongside its unit files, eight symlinks in all, and two had a stranger's home path baked in.

```
default.target.wants/battery-monitor.service -> /home/rizki/...
timers.target.wants/battery-monitor.timer    -> /home/rizki/...
```

`cp -r` copies a broken symlink happily and exits 0, so every install has planted one and nothing ever said so. `install.sh` enables the timer, which rewrote that link under the correct home. Nothing ever enabled the service, so on this machine it still reads:

```
$ ls -l ~/.config/systemd/user/default.target.wants/battery-monitor.service
-> /home/rizki/.config/systemd/user/battery-monitor.service
```

**It is not inert.** systemd resolves a `.wants` symlink by its *filename*, not its target, so `default.target` pulls the unit in regardless and the battery check runs once at login on top of the timer that already runs it every 30 seconds. Asked systemd rather than reasoned about:

```
before:  systemctl --user show default.target -p Wants | grep -c battery-monitor.service  ->  1
after:                                                                                    ->  0
```

**The other six are redundant, not wrong.** `install.sh` already runs `systemctl --user enable --now pipewire pipewire-pulse wireplumber`, and the unit files put every one of them back under the right home:

| unit | `[Install]` | recreates |
|---|---|---|
| `pipewire.service` | `Also=pipewire.socket`, `WantedBy=default.target` | 2 links |
| `pipewire-pulse.service` | `Also=pipewire-pulse.socket`, `WantedBy=default.target` | 2 links |
| `wireplumber.service` | `Alias=pipewire-session-manager.service`, `WantedBy=pipewire.service` | 2 links |

All eight are deleted. Both unit files stay, because a unit is configuration and enable state is not.

## Second time for this class

`migrations/1787389156.sh` already repairs a hardcoded `/home/rizki` path in `hyprpaper.conf`. That fix went to the one file somebody noticed, and two more instances sat in the systemd tree the whole time. So it is checked now instead of remembered: no tracked symlink may point at an absolute path, and no tracked file outside `migrations/` may name a specific home directory.

## The migration

Removes the link only when it does **not** resolve **and** points outside the user's home. Verified on the live install:

```
Removed ~/.config/systemd/user/default.target.wants/battery-monitor.service
  It pointed at /home/rizki/..., which does not exist here.
  The battery monitor still runs, on its timer, every 30 seconds.
```

`muslimtify.service`, both pipewire links and `psd.service` in the same directory were untouched, the timer is still active, and its last run reported `Result=success`.

## Two defects in my own work

**`printf` on an empty array.** `printf '%s; ' "${arr[@]}"` prints the format string once when the array is empty, so both "nothing found" checks compared `"; "` against `""` and failed on a clean tree. That exact trap is already written up in `hyprsimple-muslimtify.sh`, and I walked into it anyway.

**A sabotage contaminated the four that followed it.** It staged its edit with `git add`, so `git checkout --` restored the broken version from the index, and the next three sabotages plus the control all failed for that reason rather than their own. Re-run after a proper `git restore --staged --worktree`, one turned out to be **green**: deleting the migration's resolve guard changed nothing, because every fixture reaching it pointed inside the home and a later check caught those. The case the guard actually exists for, a working link whose target is outside the home, had no fixture. It has one now, and removing the guard turns it red.

29 suites pass, shellcheck clean at `style`.
