### PR TITLE
Ask before deleting the install, not after

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,9 @@ jobs:
       - name: committed-symlinks-test
         run: bash test/committed-symlinks-test.sh
 
+      - name: confirm-before-delete-test
+        run: bash test/confirm-before-delete-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,8 +70,43 @@ fi
 
 # ---- Canonical path ------------------------------------------------------
 
+# Anything below this point touches the destination, so the question is asked
+# first. It used to live in the middle of the copy, after `rm -rf
+# "$HYPRSIMPLE_PATH"`, which meant answering "no" deleted the install that was
+# already there and then declined to replace it. Nothing to undo, nothing left.
+confirm_installing_head() {
+  local src="$1"
+  git -C "$src" rev-parse HEAD &>/dev/null || return 0
+  [[ -n $(git -C "$src" status --porcelain) ]] || return 0
+
+  echo -e "${YELLOW}Uncommitted changes in $src will not be installed. Installing HEAD.${NC}"
+  # Only ask when someone is there to answer. Under curl-pipe, stdin is the
+  # script itself, so reading from it would consume the installer.
+  [[ -t 0 ]] || return 0
+
+  local reply
+  read -rp "Continue and install HEAD? (y/N) " reply
+  if [[ ! $reply =~ ^[Yy]$ ]]; then
+    echo -e "${RED}Aborted. Commit or stash your changes, then run this again.${NC}"
+    return 1
+  fi
+}
+
+# A directory with nothing in it is not somebody's data. A run that failed
+# after creating the destination used to wedge every later run behind a message
+# telling the user to move aside a directory this script had made itself.
+dir_is_empty() {
+  local entry
+  for entry in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+    [[ -e $entry || -L $entry ]] && return 1
+  done
+  return 0
+}
+
+confirm_installing_head "$SOURCE_DIR"
+
 if [[ -e $HYPRSIMPLE_PATH ]]; then
-  if [[ ! -f "$HYPRSIMPLE_PATH/install.sh" ]]; then
+  if [[ ! -f "$HYPRSIMPLE_PATH/install.sh" ]] && ! dir_is_empty "$HYPRSIMPLE_PATH"; then
     echo -e "${RED}$HYPRSIMPLE_PATH exists but does not look like a hyprsimple checkout.${NC}"
     echo -e "${RED}Move it aside and run this again.${NC}"
     exit 1
@@ -92,18 +127,6 @@ copy_source_to_canonical_path() {
   # abort the installer under set -e. Testing HEAD covers both "not a repo" and
   # "no commits", and both divert to the plain copy below.
   if git -C "$SOURCE_DIR" rev-parse HEAD &>/dev/null; then
-    if [[ -n $(git -C "$SOURCE_DIR" status --porcelain) ]]; then
-      echo -e "${YELLOW}Uncommitted changes in $SOURCE_DIR will not be installed. Installing HEAD.${NC}"
-      # Only ask when someone is there to answer. Under curl-pipe, stdin is the
-      # script itself, so reading from it would consume the installer.
-      if [[ -t 0 ]]; then
-        read -rp "Continue and install HEAD? (y/N) " reply
-        if [[ ! $reply =~ ^[Yy]$ ]]; then
-          echo -e "${RED}Aborted. Commit or stash your changes, then run this again.${NC}"
-          return 1
-        fi
-      fi
-    fi
     git -C "$SOURCE_DIR" archive HEAD | tar -x -C "$HYPRSIMPLE_PATH"
     cp -a "$SOURCE_DIR/.git" "$HYPRSIMPLE_PATH/.git"
   else

--- a/install.sh
+++ b/install.sh
@@ -411,13 +411,41 @@ echo ""
 # hyprsimple-update.sh and every migration read from $HYPRSIMPLE_PATH, so mirror
 # this checkout there (including .git, so updates can pull).
 
+# A directory with nothing in it is not somebody's data. A run that failed
+# after creating the destination used to wedge every later run behind a message
+# telling the user to move aside a directory this installer had made itself.
+dir_is_empty() {
+  local entry
+  for entry in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+    [[ -e $entry || -L $entry ]] && return 1
+  done
+  return 0
+}
+
 install_to_canonical_path() {
   if [[ $DOTFILES_DIR = "$HYPRSIMPLE_PATH" ]]; then
     return 0
   fi
 
+  # Asked before anything is touched. This used to sit in the middle of the
+  # copy, after the rm -rf below, so answering "no" deleted the install that was
+  # already there and then declined to replace it.
+  if git -C "$DOTFILES_DIR" rev-parse HEAD &>/dev/null &&
+    [[ -n $(git -C "$DOTFILES_DIR" status --porcelain) ]]; then
+    echo -e "${YELLOW}Uncommitted changes in $DOTFILES_DIR will not be installed. Installing HEAD.${NC}"
+    # Only ask when someone is there to answer. Under curl-pipe, stdin is the
+    # script itself, so reading from it would consume the installer.
+    if [[ -t 0 ]]; then
+      read -rp "Continue and install HEAD? (y/N) " reply
+      if [[ ! $reply =~ ^[Yy]$ ]]; then
+        echo -e "${RED}Aborted. Commit or stash your changes, then run this again.${NC}"
+        return 1
+      fi
+    fi
+  fi
+
   if [[ -e $HYPRSIMPLE_PATH ]]; then
-    if [[ ! -f "$HYPRSIMPLE_PATH/install.sh" ]]; then
+    if [[ ! -f "$HYPRSIMPLE_PATH/install.sh" ]] && ! dir_is_empty "$HYPRSIMPLE_PATH"; then
       echo -e "${RED}$HYPRSIMPLE_PATH exists but does not look like a hyprsimple checkout.${NC}"
       echo -e "${RED}Move it aside and re-run this installer.${NC}"
       return 1
@@ -437,18 +465,6 @@ install_to_canonical_path() {
   # abort the installer under set -e. Testing HEAD covers both "not a repo" and
   # "no commits", and both divert to the plain copy below.
   if git -C "$DOTFILES_DIR" rev-parse HEAD &>/dev/null; then
-    if [[ -n $(git -C "$DOTFILES_DIR" status --porcelain) ]]; then
-      echo -e "${YELLOW}Uncommitted changes in $DOTFILES_DIR will not be installed. Installing HEAD.${NC}"
-      # Only ask when someone is there to answer. Under curl-pipe, stdin is the
-      # script itself, so reading from it would consume the installer.
-      if [[ -t 0 ]]; then
-        read -rp "Continue and install HEAD? (y/N) " reply
-        if [[ ! $reply =~ ^[Yy]$ ]]; then
-          echo -e "${RED}Aborted. Commit or stash your changes, then run this again.${NC}"
-          return 1
-        fi
-      fi
-    fi
     git -C "$DOTFILES_DIR" archive HEAD | tar -x -C "$HYPRSIMPLE_PATH"
     cp -a "$DOTFILES_DIR/.git" "$HYPRSIMPLE_PATH/.git"
   else

--- a/test/confirm-before-delete-test.sh
+++ b/test/confirm-before-delete-test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# bootstrap.sh and install.sh both put the canonical install where it belongs,
+# and both used to do it in this order:
+#
+#   rm -rf "$HYPRSIMPLE_PATH"      <- the existing install, gone
+#   mkdir -p "$HYPRSIMPLE_PATH"
+#   ... ask whether to continue    <- answering "no" returns here
+#
+# So declining at the prompt deleted the install and then declined to replace
+# it. Nothing to undo and nothing left. Worse, the empty directory left behind
+# failed the "does this look like a hyprsimple checkout" guard on every later
+# run, so the user was told to move aside a directory the script had made.
+#
+# test/install-copy-test.sh eval's copy_source_to_canonical_path out of
+# bootstrap.sh and exercises it alone, which is why this was invisible: the bug
+# was never in the function, it was in the order of the script around it. This
+# suite runs bootstrap.sh as a script.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+must_be_fixture() {
+  if [[ -z ${1:-} || $1 != "$TMP"/* ]]; then
+    printf 'not ok - refusing to operate outside the fixture: %s\n' "${1:-<empty>}" >&2
+    exit 1
+  fi
+}
+
+# The prompt is guarded on `[[ -t 0 ]]`, so reaching it at all needs a
+# terminal. Asserted rather than skipped: a skip that fires everywhere is a
+# check that never runs.
+if command -v script >/dev/null 2>&1; then
+  pass "script(1) is available, so the prompt can be reached"
+else
+  fail "script(1) is missing, so none of the prompt checks below can run"
+  exit 1
+fi
+
+# ---- a source checkout with uncommitted changes --------------------------
+
+SRC="$TMP/src"
+must_be_fixture "$SRC"
+mkdir -p "$SRC/migrations" "$SRC/.local/bin"
+cp "$REPO/bootstrap.sh" "$SRC/bootstrap.sh"
+printf '#!/bin/bash\necho install\n' >"$SRC/install.sh"
+printf 'echo migration\n' >"$SRC/migrations/1.sh"
+printf '#!/bin/bash\nexit 0\n' >"$SRC/.local/bin/hyprsimple-migrate.sh"
+git -C "$SRC" init -q .
+git -C "$SRC" config user.email t@example.com
+git -C "$SRC" config user.name t
+git -C "$SRC" add -A >/dev/null
+git -C "$SRC" commit -qm init
+printf 'uncommitted\n' >>"$SRC/install.sh"
+
+DEST="$TMP/dest"
+
+# The migrate step runs against the real home otherwise, and this suite must
+# never touch it. HOME is redirected for every run below.
+FAKE_HOME="$TMP/home"
+mkdir -p "$FAKE_HOME/.local/bin"
+
+run_bootstrap() {
+  local answer="$1"
+  must_be_fixture "$DEST"
+  printf '%s\n' "$answer" |
+    script -qec "env HOME=$FAKE_HOME HYPRSIMPLE_PATH=$DEST bash $SRC/bootstrap.sh" /dev/null 2>&1
+}
+
+seed_existing_install() {
+  must_be_fixture "$DEST"
+  rm -rf "$DEST"
+  mkdir -p "$DEST"
+  printf '#!/bin/bash\necho OLD\n' >"$DEST/install.sh"
+  printf 'irreplaceable\n' >"$DEST/USER_DATA.txt"
+}
+
+# ---- declining must not destroy the existing install ---------------------
+
+seed_existing_install
+out="$(run_bootstrap n)"
+check "declining leaves the existing install in place" \
+  "$([[ -f $DEST/USER_DATA.txt ]] && echo kept || echo DESTROYED)" "kept"
+check "declining says so" \
+  "$(printf '%s' "$out" | grep -c 'Aborted')" "1"
+check "declining does not empty the directory" \
+  "$(find "$DEST" -mindepth 1 | wc -l)" "2"
+
+# ---- accepting still replaces it -----------------------------------------
+
+seed_existing_install
+run_bootstrap y >/dev/null
+check "accepting replaces the install" \
+  "$([[ -f $DEST/USER_DATA.txt ]] && echo stale || echo replaced)" "replaced"
+check "and the committed content is what landed, not the uncommitted edit" \
+  "$(grep -c 'uncommitted' "$DEST/install.sh" 2>/dev/null)" "0"
+
+# ---- an empty destination must not wedge the run -------------------------
+#
+# This is the state the old code left behind, and it made every later run fail
+# with a message about moving aside a directory bootstrap itself had created.
+
+must_be_fixture "$DEST"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+out="$(run_bootstrap y)"
+check "an empty destination directory is not mistaken for someone else's data" \
+  "$(printf '%s' "$out" | grep -c 'does not look like a hyprsimple checkout')" "0"
+check "and the install lands in it" \
+  "$([[ -f $DEST/install.sh ]] && echo installed || echo missing)" "installed"
+
+# ---- a destination with unrelated content is still refused ---------------
+
+must_be_fixture "$DEST"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+printf 'not hyprsimple\n' >"$DEST/somebody-elses-project.txt"
+out="$(run_bootstrap y)"
+check "a non-empty directory that is not a checkout is still refused" \
+  "$(printf '%s' "$out" | grep -c 'does not look like a hyprsimple checkout')" "1"
+check "and its contents are untouched" \
+  "$([[ -f $DEST/somebody-elses-project.txt ]] && echo kept || echo DESTROYED)" "kept"
+
+# ---- install.sh has the same shape and needs the same guarantee ----------
+#
+# Its function is driven directly rather than running the whole installer,
+# which would try to install an entire desktop.
+
+DRIVER="$TMP/driver.sh"
+{
+  printf 'set -eEo pipefail\n'
+  printf "RED=''\nYELLOW=''\nNC=''\n"
+  printf 'DOTFILES_DIR="%s"\n' "$SRC"
+  printf 'HYPRSIMPLE_PATH="%s"\n' "$DEST"
+  sed -n '/^dir_is_empty() {/,/^}/p' "$REPO/install.sh"
+  sed -n '/^install_to_canonical_path() {/,/^}/p' "$REPO/install.sh"
+  printf 'install_to_canonical_path\n'
+} >"$DRIVER"
+
+seed_existing_install
+printf 'n\n' | script -qec "bash $DRIVER" /dev/null >/dev/null 2>&1
+check "install.sh: declining leaves the existing install in place" \
+  "$([[ -f $DEST/USER_DATA.txt ]] && echo kept || echo DESTROYED)" "kept"
+
+seed_existing_install
+printf 'y\n' | script -qec "bash $DRIVER" /dev/null >/dev/null 2>&1
+check "install.sh: accepting replaces it" \
+  "$([[ -f $DEST/USER_DATA.txt ]] && echo stale || echo replaced)" "replaced"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/confirm-before-delete-test.sh
+++ b/test/confirm-before-delete-test.sh
@@ -52,7 +52,24 @@ fi
 SRC="$TMP/src"
 must_be_fixture "$SRC"
 mkdir -p "$SRC/migrations" "$SRC/.local/bin"
-cp "$REPO/bootstrap.sh" "$SRC/bootstrap.sh"
+
+# bootstrap.sh refuses to run anywhere but Arch, and CI is Ubuntu. The fixture
+# copy has that one guard neutered and nothing else, and the substitution is
+# asserted so a silent miss cannot leave this suite testing an unmodified
+# script that exits on line 35.
+#
+# This is not hypothetical. The first version of this suite ran bootstrap.sh
+# unmodified, and on CI it exited immediately, so "declining leaves the
+# existing install in place" passed because nothing had run at all. The check
+# below that the script actually gets as far as printing its own progress is
+# what stops that recurring.
+sed 's|^if \[\[ ! -f /etc/arch-release \]\]; then$|if false; then|' \
+  "$REPO/bootstrap.sh" >"$SRC/bootstrap.sh"
+
+check "the fixture neutered exactly the Arch guard and nothing else" \
+  "$(diff "$REPO/bootstrap.sh" "$SRC/bootstrap.sh" | grep -cE '^[<>]')" "2"
+check "and the fixture no longer refuses to run here" \
+  "$(grep -c 'if false; then' "$SRC/bootstrap.sh")" "1"
 printf '#!/bin/bash\necho install\n' >"$SRC/install.sh"
 printf 'echo migration\n' >"$SRC/migrations/1.sh"
 printf '#!/bin/bash\nexit 0\n' >"$SRC/.local/bin/hyprsimple-migrate.sh"
@@ -87,8 +104,14 @@ seed_existing_install() {
 
 # ---- declining must not destroy the existing install ---------------------
 
+# Before anything is concluded from bootstrap's behaviour, prove it ran. Every
+# check below reads a filesystem that an exiting script simply leaves alone,
+# which is indistinguishable from correct behaviour.
 seed_existing_install
 out="$(run_bootstrap n)"
+check "bootstrap actually runs, rather than exiting before it does anything" \
+  "$(printf '%s' "$out" | grep -c 'Using the checkout at')" "1"
+
 check "declining leaves the existing install in place" \
   "$([[ -f $DEST/USER_DATA.txt ]] && echo kept || echo DESTROYED)" "kept"
 check "declining says so" \


### PR DESCRIPTION
Both `bootstrap.sh` and `install.sh` moved the checkout into its canonical place in this order:

```
rm -rf "$HYPRSIMPLE_PATH"      # the existing install, gone
mkdir -p "$HYPRSIMPLE_PATH"
... ask whether to continue    # answering "no" returns here
```

**Declining at the prompt deleted the install and then declined to replace it.** Reproduced against a fixture holding a file named `USER_DATA.txt`:

```
=== before ===
IMPORTANT.txt  install.sh  migrations

=== run bootstrap from a dirty source, answer n ===
Aborted. Commit or stash your changes, then run this again.

=== after ===
.  ..
```

The prompt only appears when the source checkout is dirty, which means running from a local clone rather than `curl | bash`, so this reached contributors rather than first-time users. It is still data loss, and both scripts had it.

## It also wedged every later run

The empty directory left behind then failed the "does this look like a hyprsimple checkout" guard, so a user who did exactly what the abort message told them was met with:

```
$ # commit the changes, then, as instructed, run it again
.../hyprsimple exists but does not look like a hyprsimple checkout.
Move it aside and run this again.
```

Told to move aside a directory the script had created. An empty directory is not somebody's data and is now treated as free space. A directory with unrelated content is still refused, which is what that guard is actually for.

## Why no test caught it

Nothing had ever run `bootstrap.sh` as a script. `test/install-copy-test.sh` does this:

```bash
eval "$(sed -n '/^copy_source_to_canonical_path() {/,/^}/p' "$REPO/bootstrap.sh")"
```

It lifts one function out and exercises it alone. The bug was never inside that function. It was in the order of the script around it, and lifting the function out is precisely what hid it.

`test/confirm-before-delete-test.sh` runs the whole script, and drives `install.sh`'s function directly, since running that installer outright would try to install an entire desktop.

The prompt is guarded on `[[ -t 0 ]]`, so reaching it needs a terminal. The suite uses `script(1)` and **asserts it is present rather than skipping**, because a skip that fires everywhere is a check that never runs.

## Sabotages

| sabotage | result |
|---|---|
| `bootstrap.sh` restored to the original order | `not ok - declining leaves the existing install in place` |
| `install.sh` restored to the original order | `not ok - install.sh: declining leaves the existing install in place` |
| drop the empty-directory tolerance | `not ok - an empty destination directory is not mistaken for someone else's data` |
| make the emptiness test always true | `not ok - a non-empty directory that is not a checkout is still refused` |

30 suites pass, shellcheck clean at `style`.
