### PR TITLE
Fix the power menu's logout and suspend

### DIFF
--- a/.config/rofi/launcher/launcher.sh
+++ b/.config/rofi/launcher/launcher.sh
@@ -5,4 +5,4 @@ theme='launcher/style'
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme "${dir}/${theme}.rasi"

--- a/.config/rofi/powermenu/powermenu.sh
+++ b/.config/rofi/powermenu/powermenu.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
-# Current Theme
+# The rofi power menu, bound to SUPER + ESCAPE and to the waybar power button.
+#
+# Adapted from a widely copied rofi menu that predates this project. Two things
+# it inherited did not survive contact with Hyprland:
+#
+#   Logout branched on $DESKTOP_SESSION for openbox, bspwm, i3 and plasma, and
+#   had no branch for anything else. Here $DESKTOP_SESSION is hyprland-uwsm, so
+#   confirming a logout ran nothing at all.
+#
+#   Suspend ran `mpc -q pause` and `amixer set Master mute` first, for an mpd
+#   and alsa setup this project does not have. mpc is not installed and is in no
+#   package list. The mute worked, measured on a live session as [on] to [off],
+#   and nothing anywhere undid it, so suspending from this menu left the machine
+#   silent after resume.
+
 dir="$HOME/.config/rofi"
 theme='powermenu/style'
 
-# CMDs
-uptime="`uptime -p | sed -e 's/up //g'`"
-host=`hostname`
+uptime="$(uptime -p | sed -e 's/up //g')"
 
 # Options
 shutdown='⏻'
@@ -22,7 +34,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p "Power Menu" \
 		-mesg "Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme "${dir}/${theme}.rasi"
 }
 
 # Confirmation CMD
@@ -30,7 +42,7 @@ confirm_cmd() {
 	rofi -dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/confirm.rasi
+		-theme "${dir}/confirm.rasi"
 }
 
 # Ask for confirmation
@@ -43,50 +55,38 @@ run_rofi() {
 	echo -e "$lock\n$suspend\n$logout\n$reboot\n$shutdown" | rofi_cmd
 }
 
-# Execute Command
+# Confirm, then act. Anything other than yes leaves without doing anything.
 run_cmd() {
+	local selected
 	selected="$(confirm_exit)"
-	if [[ "$selected" == "$yes" ]]; then
-		if [[ $1 == '--shutdown' ]]; then
-            hyprshutdown -t 'Shutting down...' --post-cmd 'shutdown -P 0'
-		elif [[ $1 == '--reboot' ]]; then
-            hyprshutdown -t 'Restarting...' --post-cmd 'reboot'
-		elif [[ $1 == '--suspend' ]]; then
-			mpc -q pause
-			amixer set Master mute
-			systemctl suspend
-		elif [[ $1 == '--logout' ]]; then
-			if [[ "$DESKTOP_SESSION" == 'openbox' ]]; then
-				openbox --exit
-			elif [[ "$DESKTOP_SESSION" == 'bspwm' ]]; then
-				bspc quit
-			elif [[ "$DESKTOP_SESSION" == 'i3' ]]; then
-				i3-msg exit
-			elif [[ "$DESKTOP_SESSION" == 'plasma' ]]; then
-				qdbus org.kde.ksmserver /KSMServer logout 0 0 0
-			fi
-		fi
-	else
-		exit 0
-	fi
+	[[ $selected == "$yes" ]] || exit 0
+
+	case "$1" in
+		--shutdown) hyprshutdown -t 'Shutting down...' --post-cmd 'shutdown -P 0' ;;
+		--reboot) hyprshutdown -t 'Restarting...' --post-cmd 'reboot' ;;
+		--suspend) systemctl suspend ;;
+		# hyprsimple's own logout, the same one SUPER + X runs. It closes windows
+		# so applications shut down cleanly, then stops the uwsm session.
+		--logout) "$HOME/.local/bin/hypr-logout.sh" ;;
+	esac
 }
 
 # Actions
 chosen="$(run_rofi)"
-case ${chosen} in
-    $shutdown)
+case "$chosen" in
+    "$shutdown")
 		run_cmd --shutdown
         ;;
-    $reboot)
+    "$reboot")
 		run_cmd --reboot
         ;;
-    $lock)
+    "$lock")
         hyprlock
         ;;
-    $suspend)
+    "$suspend")
 		run_cmd --suspend
         ;;
-    $logout)
+    "$logout")
 		run_cmd --logout
         ;;
 esac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,12 @@ jobs:
           # this step locally, add --enable=all and read only the codes this
           # step would have caught.
           shellcheck --version | grep version:
+          # The rofi scripts are shell too, and were not in this list. Nothing
+          # had ever linted them: eleven findings were waiting, including an
+          # SC2034 dead variable, which is the class this step's severity was
+          # raised to catch.
           shellcheck --severity=style --exclude=SC2016 \
-            install.sh bootstrap.sh "${bins[@]}" test/*.sh
+            install.sh bootstrap.sh "${bins[@]}" test/*.sh .config/rofi/*/*.sh
           # Migrations deliberately carry no shebang, so the shell is stated
           # here. They are held to the same threshold, not because the shipped
           # ones will ever run again, since install.sh pre-creates their
@@ -139,6 +143,9 @@ jobs:
 
       - name: confirm-before-delete-test
         run: bash test/confirm-before-delete-test.sh
+
+      - name: powermenu-test
+        run: bash test/powermenu-test.sh
 
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.

--- a/migrations/1788536332.sh
+++ b/migrations/1788536332.sh
@@ -1,0 +1,54 @@
+echo "Repair the power menu's logout and suspend actions"
+
+# The rofi power menu was adapted from a widely copied one written for other
+# window managers, and two of its actions never worked here.
+#
+# Logout branched on $DESKTOP_SESSION for openbox, bspwm, i3 and plasma, with no
+# other branch. $DESKTOP_SESSION is hyprland-uwsm, so confirming a logout ran
+# nothing at all.
+#
+# Suspend ran `mpc -q pause` and `amixer set Master mute` first. mpc is not
+# installed and is in no package list. The mute worked, and nothing undid it, so
+# suspending from the menu left the machine silent after resume.
+#
+# powermenu.sh lives in ~/.config and is never overwritten by an update, so
+# without this the fix reaches nobody who already has hyprsimple installed.
+# A copy byte-identical to something this project shipped was never edited and
+# is replaced. Anything else is left alone and the command to update it printed.
+
+user="$HOME/.config/rofi/powermenu/powermenu.sh"
+shipped="$HYPRSIMPLE_PATH/.config/rofi/powermenu/powermenu.sh"
+
+[[ -f $user && -f $shipped ]] || exit 0
+
+# Already current, which is what makes a re-run a no-op.
+cmp -s "$user" "$shipped" && exit 0
+
+# Every version of this file the project shipped before the current one.
+SHIPPED_SUMS=(
+  3a13e65338adacb0b9e4e40439d9fd29
+  60bb292cbeeef718f399e62d85df0270
+  6baf25fda5829db4a7dd69ee6d723c41
+  9d1dabc852a8eefe4dfb4824515ee9a7
+  d735bfeed77cc80069573b3b2fdc3c3d
+  dea28bfea098a3010931f3799874b4a9
+  f84d2caf5815068ed99efeeb5222a548
+  fe76f1deb8f92579f1f2e66aa5304861
+)
+
+sum=$(md5sum "$user" | cut -d' ' -f1)
+
+for known in "${SHIPPED_SUMS[@]}"; do
+  if [[ $sum == "$known" ]]; then
+    cp -f "$user" "$user.bak"
+    cp -f "$shipped" "$user"
+    echo "  Updated $user (previous version kept at $user.bak)"
+    echo "  Logout now logs out, and suspend no longer mutes your audio."
+    exit 0
+  fi
+done
+
+echo "  $user has your own edits, so it was left alone."
+echo "  Its logout does nothing under Hyprland and its suspend mutes your audio."
+echo "  To take hyprsimple's version and lose your edits:"
+echo "    hyprsimple-refresh-config.sh rofi/powermenu/powermenu.sh"

--- a/test/fixtures/rofi/powermenu.pre-fix.sh
+++ b/test/fixtures/rofi/powermenu.pre-fix.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Current Theme
+dir="$HOME/.config/rofi"
+theme='powermenu/style'
+
+# CMDs
+uptime="`uptime -p | sed -e 's/up //g'`"
+host=`hostname`
+
+# Options
+shutdown='⏻'
+reboot='󰑐'
+lock=''
+suspend='󰒲'
+logout=''
+yes=''
+no='󰜺'
+
+# Rofi CMD
+rofi_cmd() {
+	rofi -dmenu \
+		-p "Power Menu" \
+		-mesg "Uptime: $uptime" \
+		-theme ${dir}/${theme}.rasi
+}
+
+# Confirmation CMD
+confirm_cmd() {
+	rofi -dmenu \
+		-p 'Confirmation' \
+		-mesg 'Are you Sure?' \
+		-theme ${dir}/confirm.rasi
+}
+
+# Ask for confirmation
+confirm_exit() {
+	echo -e "$yes\n$no" | confirm_cmd
+}
+
+# Pass variables to rofi dmenu
+run_rofi() {
+	echo -e "$lock\n$suspend\n$logout\n$reboot\n$shutdown" | rofi_cmd
+}
+
+# Execute Command
+run_cmd() {
+	selected="$(confirm_exit)"
+	if [[ "$selected" == "$yes" ]]; then
+		if [[ $1 == '--shutdown' ]]; then
+            hyprshutdown -t 'Shutting down...' --post-cmd 'shutdown -P 0'
+		elif [[ $1 == '--reboot' ]]; then
+            hyprshutdown -t 'Restarting...' --post-cmd 'reboot'
+		elif [[ $1 == '--suspend' ]]; then
+			mpc -q pause
+			amixer set Master mute
+			systemctl suspend
+		elif [[ $1 == '--logout' ]]; then
+			if [[ "$DESKTOP_SESSION" == 'openbox' ]]; then
+				openbox --exit
+			elif [[ "$DESKTOP_SESSION" == 'bspwm' ]]; then
+				bspc quit
+			elif [[ "$DESKTOP_SESSION" == 'i3' ]]; then
+				i3-msg exit
+			elif [[ "$DESKTOP_SESSION" == 'plasma' ]]; then
+				qdbus org.kde.ksmserver /KSMServer logout 0 0 0
+			fi
+		fi
+	else
+		exit 0
+	fi
+}
+
+# Actions
+chosen="$(run_rofi)"
+case ${chosen} in
+    $shutdown)
+		run_cmd --shutdown
+        ;;
+    $reboot)
+		run_cmd --reboot
+        ;;
+    $lock)
+        hyprlock
+        ;;
+    $suspend)
+		run_cmd --suspend
+        ;;
+    $logout)
+		run_cmd --logout
+        ;;
+esac

--- a/test/powermenu-test.sh
+++ b/test/powermenu-test.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# The rofi power menu is bound to SUPER + ESCAPE and to the waybar power
+# button, and it was adapted from a widely copied menu written for other window
+# managers. Two things it inherited did not work here, and nothing had ever run
+# it to find out.
+#
+#   Logout branched on $DESKTOP_SESSION for openbox, bspwm, i3 and plasma, with
+#   no other branch. $DESKTOP_SESSION is hyprland-uwsm, so confirming a logout
+#   ran nothing.
+#
+#   Suspend ran `mpc -q pause` and `amixer set Master mute` first. mpc is not
+#   installed and is in no package list. The mute worked, measured on a live
+#   session as [on] to [off], and nothing undid it, so the machine came back
+#   from suspend silent.
+#
+# The menu is driven here with rofi stubbed, so each selection is exercised for
+# what it actually runs.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MENU="$REPO/.config/rofi/powermenu/powermenu.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"
+LOG="$TMP/ran.log"
+mkdir -p "$STUB"
+
+# Everything the menu can invoke is stubbed and records its own name and
+# arguments. A command that is stubbed but never called leaves no line, which
+# is how "the suspend path no longer mutes" is checked.
+for cmd in hyprshutdown hyprlock systemctl mpc amixer uptime; do
+  cat >"$STUB/$cmd" <<STUBEOF
+#!/bin/bash
+printf '%s %s\n' "$cmd" "\$*" >>"$LOG"
+STUBEOF
+  chmod +x "$STUB/$cmd"
+done
+# uptime is read for the menu header, so it has to say something.
+printf '#!/bin/bash\necho "up 1 hour"\n' >"$STUB/uptime"
+chmod +x "$STUB/uptime"
+
+# hyprsimple's logout script, stubbed where the menu looks for it.
+FAKE_HOME="$TMP/home"
+mkdir -p "$FAKE_HOME/.local/bin" "$FAKE_HOME/.config/rofi"
+cat >"$FAKE_HOME/.local/bin/hypr-logout.sh" <<STUBEOF
+#!/bin/bash
+printf 'hypr-logout.sh\n' >>"$LOG"
+STUBEOF
+chmod +x "$FAKE_HOME/.local/bin/hypr-logout.sh"
+
+# rofi is called twice: once for the menu, once to confirm. The first call
+# answers with the glyph under test and the second with the confirmation.
+make_rofi() {
+  local choice="$1" confirm="$2"
+  cat >"$STUB/rofi" <<STUBEOF
+#!/bin/bash
+state="$TMP/rofi.state"
+if [[ ! -f \$state ]]; then
+  printf '1\n' >"\$state"
+  printf '%s\n' "$choice"
+else
+  printf '%s\n' "$confirm"
+fi
+STUBEOF
+  chmod +x "$STUB/rofi"
+  rm -f "$TMP/rofi.state"
+}
+
+# The glyphs are read out of the menu itself rather than retyped, so a suite
+# that drifts from the script fails instead of silently testing nothing.
+glyph() { sed -n "s/^$1='\(.*\)'$/\1/p" "$MENU"; }
+
+for name in shutdown reboot lock suspend logout yes no; do
+  if [[ -n $(glyph "$name") ]]; then
+    pass "the '$name' glyph was read out of the menu"
+  else
+    fail "could not read the '$name' glyph from the menu, so every check below is testing nothing"
+    exit 1
+  fi
+done
+
+# Three of these are BMP private use area codepoints, which do not survive
+# every editor and every pipeline. Two of them going empty would put two empty
+# patterns in the menu's final case, the first would win, and choosing logout
+# would silently lock the screen instead. An empty glyph for yes is worse: the
+# confirmation would match anything.
+# LC_ALL=C, so sort compares bytes. Under a UTF-8 locale these private use
+# codepoints have no collation weight and compare equal to each other, so
+# `sort -u` reduced seven distinct glyphs to three and this check failed
+# against a file that was perfectly correct.
+distinct=$(for name in shutdown reboot lock suspend logout yes no; do glyph "$name"; done |
+  LC_ALL=C sort -u | grep -c .)
+check "all seven glyphs are distinct, so no two menu entries collide" "$distinct" "7"
+
+run_menu() {
+  : >"$LOG"
+  make_rofi "$1" "$2"
+  HOME="$FAKE_HOME" PATH="$STUB:$PATH" DESKTOP_SESSION=hyprland-uwsm \
+    bash "$MENU" >/dev/null 2>&1
+  cat "$LOG" 2>/dev/null
+}
+
+# ---- logout actually logs out --------------------------------------------
+
+out="$(run_menu "$(glyph logout)" "$(glyph yes)")"
+check "confirming a logout runs hyprsimple's logout script" \
+  "$(printf '%s' "$out" | grep -c 'hypr-logout.sh')" "1"
+check "and it is the only thing it runs" \
+  "$(printf '%s' "$out" | grep -vc 'hypr-logout.sh\|^uptime')" "0"
+
+out="$(run_menu "$(glyph logout)" "$(glyph no)")"
+check "declining a logout runs nothing" \
+  "$(printf '%s' "$out" | grep -c 'hypr-logout.sh')" "0"
+
+# ---- suspend suspends and nothing else -----------------------------------
+
+out="$(run_menu "$(glyph suspend)" "$(glyph yes)")"
+check "confirming a suspend suspends" \
+  "$(printf '%s' "$out" | grep -c '^systemctl suspend')" "1"
+check "and does not mute the audio" \
+  "$(printf '%s' "$out" | grep -c '^amixer')" "0"
+check "and does not reach for mpd, which is not installed" \
+  "$(printf '%s' "$out" | grep -c '^mpc')" "0"
+
+# ---- the rest still work --------------------------------------------------
+
+out="$(run_menu "$(glyph shutdown)" "$(glyph yes)")"
+check "confirming a shutdown shuts down" \
+  "$(printf '%s' "$out" | grep -c 'hyprshutdown.*Shutting down')" "1"
+
+out="$(run_menu "$(glyph reboot)" "$(glyph yes)")"
+check "confirming a reboot reboots" \
+  "$(printf '%s' "$out" | grep -c 'hyprshutdown.*Restarting')" "1"
+
+out="$(run_menu "$(glyph shutdown)" "$(glyph no)")"
+check "declining a shutdown does nothing" \
+  "$(printf '%s' "$out" | grep -c 'hyprshutdown')" "0"
+
+# lock is the one entry that does not confirm, by design
+out="$(run_menu "$(glyph lock)" "$(glyph no)")"
+check "lock locks without asking for confirmation" \
+  "$(printf '%s' "$out" | grep -c '^hyprlock')" "1"
+
+# ---- no branch on a window manager this project does not run -------------
+
+# Comment lines are stripped first: the header documents the branches that were
+# removed, and naming them there is the point.
+check "the menu no longer branches on DESKTOP_SESSION" \
+  "$(grep -v '^[[:space:]]*#' "$MENU" | grep -cE 'openbox|bspwm|i3-msg|ksmserver')" "0"
+
+# ---- the migration delivers it to existing installs -----------------------
+#
+# powermenu.sh lives in ~/.config and is never overwritten by an update, so
+# without a migration the fix reaches nobody who already has hyprsimple.
+
+MIGRATION="$REPO/migrations/1788536332.sh"
+if [[ -f $MIGRATION ]]; then
+  pass "the migration this suite tests exists"
+else
+  fail "$MIGRATION is missing, so every check below is testing nothing"
+fi
+
+# The fixture is a version the project really shipped, kept as a file rather
+# than read from git history, because CI checks out shallow and the commit is
+# not there. Checked against the migration's own list so it cannot rot into
+# bytes no user ever had. Retyping it was never an option: three of its glyphs
+# are private use codepoints that do not survive a round trip through an editor.
+PREVIOUS="$REPO/test/fixtures/rofi/powermenu.pre-fix.sh"
+previous_sum="$(md5sum "$PREVIOUS" 2>/dev/null | cut -d' ' -f1)"
+
+check "the fixture is a version the migration claims to handle" \
+  "$(grep -c "$previous_sum" "$MIGRATION")" "1"
+
+run_migration() {
+  HOME="$1" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" 2>&1
+}
+seed() {
+  local home="$TMP/$1"
+  rm -rf "$home"
+  mkdir -p "$home/.config/rofi/powermenu"
+  cp "$PREVIOUS" "$home/.config/rofi/powermenu/powermenu.sh"
+  printf '%s' "$home"
+}
+
+home="$(seed pristine)"
+run_migration "$home" >/dev/null
+check "a never-edited power menu is replaced" \
+  "$(cmp -s "$home/.config/rofi/powermenu/powermenu.sh" "$MENU" && echo replaced || echo unchanged)" \
+  "replaced"
+check "and the old one is kept as a backup" \
+  "$(cmp -s "$home/.config/rofi/powermenu/powermenu.sh.bak" "$PREVIOUS" && echo kept || echo lost)" "kept"
+
+home="$(seed edited)"
+printf '\n# MY OWN EDIT\n' >>"$home/.config/rofi/powermenu/powermenu.sh"
+out="$(run_migration "$home")"
+check "an edited power menu is left alone" \
+  "$(grep -c 'MY OWN EDIT' "$home/.config/rofi/powermenu/powermenu.sh")" "1"
+check "and the user is told how to update it" \
+  "$(printf '%s' "$out" | grep -c 'hyprsimple-refresh-config.sh rofi/powermenu/powermenu.sh')" "1"
+
+home="$(seed current)"
+cp "$MENU" "$home/.config/rofi/powermenu/powermenu.sh"
+out="$(run_migration "$home")"
+check "an already-current power menu is a no-op" \
+  "$([[ -f $home/.config/rofi/powermenu/powermenu.sh.bak ]] && echo backed-up || echo untouched)" "untouched"
+check "and is not accused of having edits" \
+  "$(printf '%s' "$out" | grep -c 'your own edits')" "0"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
The rofi power menu on `SUPER + ESCAPE`, and on the waybar power button, was adapted from a widely copied menu written for other window managers. **Two of its five actions never worked here**, and nothing had ever run it.

## Logout did nothing

```bash
if [[ "$DESKTOP_SESSION" == 'openbox' ]]; then ...
elif [[ "$DESKTOP_SESSION" == 'bspwm' ]]; then ...
elif [[ "$DESKTOP_SESSION" == 'i3' ]]; then ...
elif [[ "$DESKTOP_SESSION" == 'plasma' ]]; then ...
fi
```

```
$ echo "$DESKTOP_SESSION"
hyprland-uwsm
```

No branch matched. Selecting Logout and confirming it ran nothing at all. It now runs hyprsimple's own `hypr-logout.sh`, the same script `SUPER + X` uses.

## Suspend muted your audio permanently

```bash
mpc -q pause
amixer set Master mute
systemctl suspend
```

`mpc` is not installed and is in no package list. The mute worked, measured on the live session:

```
before:  alsa: [on]    wpctl: Volume: 0.66
after:   alsa: [off]   wpctl: Volume: 0.66 [MUTED]
```

Nothing anywhere undid it, so suspending from this menu left the machine silent after resume. Both lines are gone.

## The rofi scripts were never linted

The shellcheck step covered `install.sh`, `bootstrap.sh`, `.local/bin`, the suites and the migrations, and stopped there. Eleven findings were waiting in these two files, including an `SC2034` unused variable, which is the class this step's severity was raised to catch. They are in the list now and both files are clean.

## Delivery

`powermenu.sh` lives in `~/.config` and an update never overwrites it, so a migration replaces a copy byte-identical to any of the eight versions this project shipped, keeping a backup. Anything else is left alone and told how to update.

## One bad defect of my own

Rewriting the file wholesale **silently emptied three of its seven glyphs**:

```
        before          after my rewrite
lock    U+F023          '' (0 bytes)
logout  U+EA6E          ''
yes     U+F058          ''
```

They are BMP private use codepoints and did not survive being retyped. An empty `yes` matches any confirmation, and an empty `lock` and `logout` collide as two identical patterns in the final `case`, so the first wins: **choosing Logout would have locked the screen.** Redone as targeted edits that never re-emit a glyph line. The assignments are now byte-identical to what they were, checked by md5.

The suite reads the glyphs out of the menu rather than repeating them, and checks all seven are distinct. That check needed `LC_ALL=C`: under a UTF-8 locale these codepoints have no collation weight and compare **equal**, so `sort -u` reduced seven distinct glyphs to three and reported a correct file as broken.

## Sabotages

| sabotage | result |
|---|---|
| the original menu restored | `not ok - confirming a logout runs hyprsimple's logout script` |
| put the mute back on suspend | `not ok - and does not mute the audio` |
| logout stops calling the script | `not ok - confirming a logout runs hyprsimple's logout script` |
| blank the `yes` glyph, as my rewrite did | `not ok - could not read the 'yes' glyph from the menu` |
| migration replaces an edited file | `not ok - an edited power menu is left alone` |
| migration keeps no backup | `not ok - and the old one is kept as a backup` |
| migration loses idempotency | `not ok - and is not accused of having edits` |
| fixture drifts from the migration's list | `not ok - the fixture is a version the migration claims to handle` |

31 suites pass, shellcheck clean at `style`.
