### PR TITLE
Install iw, which the hotspot needs to find the interface

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -47,6 +47,7 @@ dnsmasq
 iptables
 hostapd
 haveged
+iw
 ufw
 
 # Applications

--- a/test/launched-programs-test.sh
+++ b/test/launched-programs-test.sh
@@ -131,11 +131,34 @@ done
 # for as long as the timer is enabled, having done nothing.
 HARD_SCRIPT_DEPS=(
   "battery-monitor.sh upower upower"
+
+  # iw is how both of these find and configure a wireless interface, and
+  # neither has another way. It was in no package list and nothing hyprsimple
+  # installs depends on it, so it was present here only because CachyOS pulls
+  # it in through cachyos-settings and wireless-regdb. On a plain Arch machine
+  # with exactly this list, it would not have been there.
+  "wifi-powersave.sh iw iw"
+
+  # hotspot.sh is vendored create_ap and excluded from the lint step, but the
+  # feature is aliased as `hotspot` and documented, and its dependencies are
+  # this project's problem. Four of the five below are in packages.txt already
+  # and are there for nothing else, which is what made the missing one stand
+  # out: the access point, its DHCP, its NAT and its entropy were all provided,
+  # and the tool that finds the interface was not.
+  "hotspot.sh iw iw"
+  "hotspot.sh hostapd hostapd"
+  "hotspot.sh dnsmasq dnsmasq"
+  "hotspot.sh iptables iptables"
+  "hotspot.sh haveged haveged"
 )
 
 for entry in "${HARD_SCRIPT_DEPS[@]}"; do
   read -r script prog pkg <<<"$entry"
-  if [[ $(grep -c "\\b$prog\\b" "$REPO/.local/bin/$script") -eq 0 ]]; then
+  # Comment lines are stripped first. These scripts explain in prose why they
+  # call what they call, so counting every mention meant an entry stayed
+  # "current" after the script had stopped using the command entirely.
+  uses=$(grep -v '^[[:space:]]*#' "$REPO/.local/bin/$script" | grep -c "\\b$prog\\b")
+  if (( uses == 0 )); then
     fail "$script no longer calls $prog, so remove it from HARD_SCRIPT_DEPS"
   elif printf '%s\n' "$packages" | grep -qx "$pkg"; then
     pass "$prog is installed by hyprsimple, so $script can run (package $pkg)"


### PR DESCRIPTION
hyprsimple installs four packages for the hotspot, and nothing else in the project uses any of them:

| package | what the hotspot uses it for | uses in `hotspot.sh` |
|---|---|---|
| `hostapd` | the access point | 31 |
| `dnsmasq` | its DHCP | 23 |
| `iptables` | its NAT | 27 |
| `haveged` | its entropy | 10 |
| **`iw`** | **finding and configuring the interface** | **not installed** |

`iw` is also how `wifi-powersave.sh` sets power saving. Neither script has another way.

Nothing hyprsimple installs depends on it either:

```
$ pacman -Qi iw | grep 'Required By'
Required By     : cachyos-settings  wireless-regdb
```

Both CachyOS packages. A plain Arch machine following this package list would not have had it, and `hotspot` is an aliased, documented command.

## The check that existed and missed it

`launched-programs-test.sh` reads the programs the lua config launches, and neither of these is launched from lua. Everything beyond that was a hand-maintained list of script dependencies with **exactly one entry**. It now covers both wireless scripts and all five of the hotspot's, so the four already installed are pinned too.

**Its staleness check was also broken, and I only found that by sabotaging it.** It counted every mention of a command in a script, comments included, and both scripts explain in prose why they call what they call:

```bash
# iw exits 2 on a value it does not accept and 1 on a missing one. Sending that
```

So replacing `wifi-powersave.sh`'s only real `iw` call left the suite green. Comments are stripped now, and the same sabotage turns it red.

## Sabotages

| sabotage | result |
|---|---|
| `iw` removed again | `not ok - wifi-powersave.sh depends on iw with no fallback but no package list installs it` |
| `haveged` removed | `not ok - hotspot.sh depends on haveged with no fallback but no package list installs it` |
| `wifi-powersave.sh` stops calling `iw` | `not ok - wifi-powersave.sh no longer calls iw, so remove it from HARD_SCRIPT_DEPS` |
| `battery-monitor.sh` stops calling `upower` | `not ok - battery-monitor.sh no longer calls upower, ...` |

## A correction

I have repeatedly listed "four themes ship one wallpaper, so the picker is dead on them" as an open defect. **It is not a defect.** `wallpaper-switcher.sh` checks the count and exits 0 with `Only one wallpaper in this theme`. Run against the active theme, which is one of the four:

```
$ wallpaper-switcher.sh pick
exit=0
notification said: Only one wallpaper in this theme
```

Deliberate, and it says so. The four themes shipping a single wallpaper is a content choice. I had been repeating an inherited claim without checking it.

32 suites pass, shellcheck clean at `style`.
