### PR TITLE
Stop wifi.sh refusing to run before it asks NetworkManager

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,6 +154,9 @@ jobs:
       - name: shell-init-test
         run: bash test/shell-init-test.sh
 
+      - name: wifi-test
+        run: bash test/wifi-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/wifi-powersave.sh
+++ b/.local/bin/wifi-powersave.sh
@@ -16,10 +16,22 @@ fi
 # can exercise the success path at all.
 SYSFS_NET="${HYPRSIMPLE_SYSFS_NET:-/sys/class/net}"
 
+# phy80211 first: cfg80211 creates it for every wireless netdev,
+# unconditionally. The wireless directory beside it is the WEXT compatibility
+# layer, which is a kernel option and can be absent on a machine whose WiFi
+# works. Looking only at that one missed the interface entirely.
+#
+# Sorted unique, because an interface usually has both markers and this loop
+# acts on every interface rather than stopping at the first. Without that it
+# would run iw twice per interface and count each one twice.
+mapfile -t ifaces < <(
+  for marker in "$SYSFS_NET"/*/phy80211 "$SYSFS_NET"/*/wireless; do
+    [[ -e $marker ]] && basename "$(dirname "$marker")"
+  done | LC_ALL=C sort -u
+)
+
 changed=0
-for wireless in "$SYSFS_NET"/*/wireless; do
-  [[ -d $wireless ]] || continue
-  iface="$(basename "$(dirname "$wireless")")"
+for iface in "${ifaces[@]}"; do
   if sudo iw dev "$iface" set power_save "$1" 2>/dev/null; then
     changed=$((changed + 1))
   fi

--- a/.local/bin/wifi.sh
+++ b/.local/bin/wifi.sh
@@ -7,17 +7,22 @@
 
 # Auto-detect WiFi interface. A glob rather than parsing ls output, so the
 # shell splits the paths instead of a newline doing it.
+#
+# phy80211 first: cfg80211 creates it for every wireless netdev, unconditionally.
+# The wireless directory next to it is the WEXT compatibility layer, which is a
+# kernel option (CONFIG_CFG80211_WEXT) and can simply be absent on a machine
+# whose WiFi works perfectly well. Looking only at that one was the bug.
+#
+# The sysfs root is overridable so both the has-wireless and no-wireless paths
+# can be tested on one machine, matching wifi-powersave.sh.
+SYSFS_NET="${HYPRSIMPLE_SYSFS_NET:-/sys/class/net}"
+
 IFACE=""
-for wireless in /sys/class/net/*/wireless; do
-  [[ -d $wireless ]] || continue
-  IFACE=$(basename "$(dirname "$wireless")")
+for marker in "$SYSFS_NET"/*/phy80211 "$SYSFS_NET"/*/wireless; do
+  [[ -e $marker ]] || continue
+  IFACE=$(basename "$(dirname "$marker")")
   break
 done
-
-if [[ -z $IFACE ]]; then
-  echo "No WiFi interface found"
-  exit 1
-fi
 
 # Detect the active WiFi backend. Prefer whichever service is actually
 # running so we never run iwctl on a NetworkManager/wpa_supplicant host
@@ -43,6 +48,10 @@ PASS=$2
 
 case "$BACKEND" in
 nmcli)
+  # No interface check here on purpose. NetworkManager finds its own device,
+  # and nothing in this branch uses $IFACE. Requiring one meant that a machine
+  # where the interface is not visible in sysfs was told "No WiFi interface
+  # found" without nmcli ever being asked, when nmcli would have worked.
   nmcli device wifi rescan 2>/dev/null
   if [[ -z $SSID ]]; then
     nmcli --fields IN-USE,SSID,SIGNAL,SECURITY device wifi list
@@ -55,6 +64,11 @@ nmcli)
   fi
   ;;
 iwd)
+  # iwctl needs the interface by name, so this is where the check belongs.
+  if [[ -z $IFACE ]]; then
+    echo "No WiFi interface found" >&2
+    exit 1
+  fi
   iwctl station "$IFACE" scan
   if [[ -z $SSID ]]; then
     iwctl station "$IFACE" get-networks

--- a/packages.txt
+++ b/packages.txt
@@ -47,6 +47,7 @@ dnsmasq
 iptables
 hostapd
 haveged
+iw
 ufw
 
 # Applications

--- a/test/launched-programs-test.sh
+++ b/test/launched-programs-test.sh
@@ -131,11 +131,34 @@ done
 # for as long as the timer is enabled, having done nothing.
 HARD_SCRIPT_DEPS=(
   "battery-monitor.sh upower upower"
+
+  # iw is how both of these find and configure a wireless interface, and
+  # neither has another way. It was in no package list and nothing hyprsimple
+  # installs depends on it, so it was present here only because CachyOS pulls
+  # it in through cachyos-settings and wireless-regdb. On a plain Arch machine
+  # with exactly this list, it would not have been there.
+  "wifi-powersave.sh iw iw"
+
+  # hotspot.sh is vendored create_ap and excluded from the lint step, but the
+  # feature is aliased as `hotspot` and documented, and its dependencies are
+  # this project's problem. Four of the five below are in packages.txt already
+  # and are there for nothing else, which is what made the missing one stand
+  # out: the access point, its DHCP, its NAT and its entropy were all provided,
+  # and the tool that finds the interface was not.
+  "hotspot.sh iw iw"
+  "hotspot.sh hostapd hostapd"
+  "hotspot.sh dnsmasq dnsmasq"
+  "hotspot.sh iptables iptables"
+  "hotspot.sh haveged haveged"
 )
 
 for entry in "${HARD_SCRIPT_DEPS[@]}"; do
   read -r script prog pkg <<<"$entry"
-  if [[ $(grep -c "\\b$prog\\b" "$REPO/.local/bin/$script") -eq 0 ]]; then
+  # Comment lines are stripped first. These scripts explain in prose why they
+  # call what they call, so counting every mention meant an entry stayed
+  # "current" after the script had stopped using the command entirely.
+  uses=$(grep -v '^[[:space:]]*#' "$REPO/.local/bin/$script" | grep -c "\\b$prog\\b")
+  if (( uses == 0 )); then
     fail "$script no longer calls $prog, so remove it from HARD_SCRIPT_DEPS"
   elif printf '%s\n' "$packages" | grep -qx "$pkg"; then
     pass "$prog is installed by hyprsimple, so $script can run (package $pkg)"

--- a/test/wifi-test.sh
+++ b/test/wifi-test.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# wifi.sh had no test at all, and the reason was structural: it read
+# /sys/class/net directly, so neither answer could be arranged on a machine
+# whose own wireless hardware is fixed. Its sibling wifi-powersave.sh was given
+# an overridable root for exactly that reason and has six checks. This one had
+# none, and two bugs.
+#
+# It found the interface by looking for the `wireless` directory, which is the
+# WEXT compatibility layer and a kernel option (CONFIG_CFG80211_WEXT). cfg80211
+# creates phy80211 for every wireless netdev unconditionally, so a machine
+# built without WEXT has working WiFi and no `wireless` directory.
+#
+# And the interface was required before the backend was chosen, though only the
+# iwd branch uses it. NetworkManager finds its own device. Measured before the
+# fix, inside a namespace with /sys/class/net masked: "No WiFi interface found",
+# exit 1, and nmcli never called once.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WIFI="$REPO/.local/bin/wifi.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"
+LOG="$TMP/calls.log"
+mkdir -p "$STUB"
+
+cat >"$STUB/nmcli" <<'STUBEOF'
+#!/bin/bash
+printf 'nmcli %s\n' "$*" >>"$CALL_LOG"
+exit "${NMCLI_RC:-0}"
+STUBEOF
+cat >"$STUB/iwctl" <<'STUBEOF'
+#!/bin/bash
+printf 'iwctl %s\n' "$*" >>"$CALL_LOG"
+STUBEOF
+# is-active answers for whichever service the test says is running.
+cat >"$STUB/systemctl" <<'STUBEOF'
+#!/bin/bash
+for arg in "$@"; do
+  [[ $arg == "${RUNNING_SERVICE:-}" ]] && exit 0
+done
+exit 3
+STUBEOF
+chmod +x "$STUB"/*
+
+# Three sysfs shapes: a modern interface with both markers, one with only
+# phy80211 as a WEXT-less kernel gives, and nothing at all.
+mk_sysfs() {
+  local root="$TMP/sysfs-$1"
+  rm -rf "$root"
+  mkdir -p "$root"
+  case "$1" in
+    both) mkdir -p "$root/wlan0/wireless"; : >"$root/wlan0/phy80211" ;;
+    phy-only) mkdir -p "$root/wlan0"; : >"$root/wlan0/phy80211" ;;
+    none) mkdir -p "$root/enp4s0" ;;
+  esac
+  printf '%s' "$root"
+}
+
+run() {
+  local sysfs="$1" service="$2"
+  shift 2
+  : >"$LOG"
+  CALL_LOG="$LOG" NMCLI_RC="${NMCLI_RC:-0}" RUNNING_SERVICE="$service" \
+    HYPRSIMPLE_SYSFS_NET="$sysfs" PATH="$STUB:/usr/bin:/bin" \
+    bash "$WIFI" "$@" >"$TMP/out" 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+rc() { cat "$TMP/rc"; }
+calls() { cat "$LOG" 2>/dev/null; }
+
+# ---- the override works at all -------------------------------------------
+#
+# Asserted before anything is read from it. If the script ignored
+# HYPRSIMPLE_SYSFS_NET it would read the real machine's sysfs, every case below
+# would see whatever hardware the runner happens to have, and this suite would
+# be testing that instead.
+
+check "wifi.sh honours HYPRSIMPLE_SYSFS_NET" \
+  "$(grep -c 'HYPRSIMPLE_SYSFS_NET' "$WIFI")" "1"
+
+# ---- NetworkManager does not need the interface to be visible -------------
+
+run "$(mk_sysfs none)" NetworkManager MyNet
+check "nmcli connects even with no interface visible in sysfs" \
+  "$(calls | grep -c 'nmcli device wifi connect MyNet')" "1"
+check "and does not refuse before asking nmcli" "$(rc)" "0"
+
+run "$(mk_sysfs both)" NetworkManager
+check "no argument lists networks" \
+  "$(calls | grep -c 'device wifi list')" "1"
+check "and rescans first" \
+  "$(calls | grep -c 'device wifi rescan')" "1"
+
+run "$(mk_sysfs both)" NetworkManager MyNet hunter2
+check "a passphrase is passed through" \
+  "$(calls | grep -c 'connect MyNet password hunter2')" "1"
+
+NMCLI_RC=4 run "$(mk_sysfs both)" NetworkManager MyNet
+check "a failed connect is not reported as success" "$(rc)" "4"
+unset NMCLI_RC
+
+# ---- iwd is the branch that genuinely needs the interface -----------------
+
+run "$(mk_sysfs both)" iwd MyNet
+check "iwd connects using the detected interface" \
+  "$(calls | grep -c 'iwctl station wlan0 connect MyNet')" "1"
+
+run "$(mk_sysfs none)" iwd MyNet
+check "iwd with no interface says so" \
+  "$(grep -c 'No WiFi interface found' "$TMP/out")" "1"
+check "and exits non-zero" "$(rc)" "1"
+check "and runs no iwctl" "$(calls | grep -c iwctl)" "0"
+
+# ---- a kernel with no WEXT compatibility layer ---------------------------
+#
+# The case the old detection missed entirely: phy80211 present, no `wireless`.
+
+run "$(mk_sysfs phy-only)" iwd MyNet
+check "an interface with only phy80211 is still found" \
+  "$(calls | grep -c 'iwctl station wlan0 connect MyNet')" "1"
+
+# ---- neither backend installed -------------------------------------------
+
+# A PATH holding only what the script needs and neither backend. Keeping
+# /usr/bin on it would have found this machine's real nmcli, which is exactly
+# what happened the first time this check was written: it failed because the
+# case it claimed to set up had not been set up.
+NOBACKEND="$TMP/nobackend"
+mkdir -p "$NOBACKEND"
+# bash included: with PATH replaced, the shell resolves the interpreter with
+# the new PATH too, so leaving it out made every run exit 127 with no output
+# and the check failed against a script that had never started.
+for c in bash basename dirname; do ln -sf "$(command -v "$c")" "$NOBACKEND/$c"; done
+cp "$STUB/systemctl" "$NOBACKEND/systemctl"
+
+check "the no-backend fixture really has no backend" \
+  "$(PATH="$NOBACKEND" command -v nmcli iwctl 2>/dev/null | grep -c .)" "0"
+
+: >"$TMP/none.log"
+CALL_LOG="$TMP/none.log" RUNNING_SERVICE=none \
+  HYPRSIMPLE_SYSFS_NET="$(mk_sysfs both)" PATH="$NOBACKEND" \
+  bash "$WIFI" MyNet >"$TMP/out" 2>&1
+check "with no backend installed it says which ones it needs" \
+  "$(grep -c 'need NetworkManager/nmcli or iwd/iwctl' "$TMP/out")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Two bugs in `wifi.sh`'s interface detection, both worse for a NetworkManager user than an iwd one.

## It refused before asking nmcli

`wifi.sh` required a wireless interface **before** choosing a backend, and exited 1 if it did not find one. The nmcli branch never uses that interface — NetworkManager finds its own device.

Measured before the fix, in a namespace with `/sys/class/net` masked:

```
$ unshare -rm ... wifi.sh MyNet
No WiFi interface found
  exit=1
  calls made:
```

The call log is empty. nmcli was never asked. The check now lives in the iwd branch, which is the only thing that needs an interface name, because `iwctl station <iface>` takes one as an argument.

## It looked for an optional kernel feature

Detection was `/sys/class/net/*/wireless`. That directory is the **WEXT compatibility layer**, and it is a kernel option:

```
$ zgrep CFG80211_WEXT /proc/config.gz
CONFIG_CFG80211_WEXT=y      # on this machine, but it does not have to be
```

`cfg80211` creates `phy80211` for every wireless netdev unconditionally. A machine built without WEXT has working WiFi, an `nmcli` that lists networks fine, and no `wireless` directory anywhere — and this script would have told its owner they had no WiFi hardware.

Both markers are checked now, `phy80211` first. `wifi-powersave.sh` had the same detection and gets the same fix, with the interface list deduplicated because it acts on *every* interface rather than the first, and an interface usually has both markers.

## Why there was no test

Not an oversight, a structural block. `wifi.sh` read `/sys/class/net` directly, so neither answer could be arranged on a machine whose wireless hardware is fixed. Its sibling `wifi-powersave.sh` was given `HYPRSIMPLE_SYSFS_NET` for exactly that reason and has six checks. `wifi.sh` had none. It has the override now, and thirteen checks.

| sabotage | result |
|---|---|
| the original `wifi.sh` | `not ok - wifi.sh honours HYPRSIMPLE_SYSFS_NET` |
| detect via the WEXT dir only | `not ok - an interface with only phy80211 is still found` |
| gate restored before backend detection | `not ok - nmcli connects even with no interface visible in sysfs` |
| iwd stops checking for an interface | `not ok - iwd with no interface says so` |

## Two mistakes while writing the suite

Both caught by the suite failing, not by review.

The no-backend case kept `/usr/bin` on `PATH` and found this machine's **real** nmcli, so the case it claimed to set up was never set up. With `PATH` replaced properly it then exited 127, because the shell resolves the interpreter with the new `PATH` too and `bash` was not on it — so the check was failing against a script that had never started.

Both fixtures now assert their own shape before anything is concluded from them:

```
ok - the no-backend fixture really has no backend
ok - wifi.sh honours HYPRSIMPLE_SYSFS_NET
```

Verified live on this NetworkManager machine: `wifi` still lists networks and still detects `wlan0`.

33 suites pass, shellcheck clean at `style`.
