### PR TITLE
Measure the notification timing check instead of guessing at it

### DIFF
--- a/test/notification-idiom-test.sh
+++ b/test/notification-idiom-test.sh
@@ -190,17 +190,41 @@ if dunstctl count displayed >/dev/null 2>&1; then
   # Measured in the failing state rather than reasoned about: with the machine
   # idle, an ordinary -t 1000 notification was still displayed after 2 seconds
   # and a transient one was gone, at both critical and low urgency.
+  # These two race a wall clock against dunst's global timeout, so they report
+  # how long they actually took. "critical without -t outlives that window"
+  # failed once during a full sweep and could not be reproduced afterwards in
+  # twelve isolated runs or four more full sweeps. Neither theory survived
+  # testing: no suite restarts the live dunst, and the check held under load.
+  #
+  # Rather than guess at a fix for something that would not reproduce, the
+  # window is now measured. If the elapsed time reaches the timeout the check
+  # could not have concluded anything, and it says so instead of reporting the
+  # product as broken. The sleep is also 1s rather than 2.5s, which leaves four
+  # seconds of headroom in a five second window instead of two and a half.
+  global_timeout_ms=5000
+
+  elapsed_ms() { printf '%s' "$(( $(date +%s%3N) - $1 ))"; }
+
   dunstctl close-all
   notify-send -u critical -t 1000 --transient "probe" "critical honours -t"
-  sleep 2.5
+  sleep 1.5
   check "a critical notification honours its own -t" \
     "$(dunstctl count displayed)" "0"
 
   dunstctl close-all
+  started=$(date +%s%3N)
   notify-send -u critical --transient "probe" "critical without -t outlives it"
-  sleep 2.5
-  check "a critical notification without -t outlives that window" \
-    "$(dunstctl count displayed)" "1"
+  sleep 1
+  displayed=$(dunstctl count displayed)
+  took=$(elapsed_ms "$started")
+  if (( took >= global_timeout_ms )); then
+    printf 'not ok - inconclusive: reading the count took %sms, past the %sms timeout\n' \
+      "$took" "$global_timeout_ms" >&2
+    failures=$((failures + 1))
+  else
+    check "a critical notification without -t outlives that window ($((took))ms of ${global_timeout_ms}ms)" \
+      "$displayed" "1"
+  fi
   dunstctl close-all
 else
   printf 'skip - dunst not running, replacement behaviour not exercised\n'


### PR DESCRIPTION
Not a product bug. A test flake I could not reproduce, made diagnosable instead of guessed at.

## What happened

During a full sweep after merging #71, one check failed:

```
not ok - a critical notification without -t outlives that window (want 1, got 0)
```

It then would not reproduce. **Twelve isolated runs and four more full sweeps all passed.**

## Two theories, both tested, both wrong

**A suite restarting the live dunst mid-check.** Measured dunst's pid across the six suites that touch it or send notifications:

```
dunst pid before: 164396
  ok muslimtify-and-dns-test.sh
  ok theme-picker-test.sh
  ok theme-refresh-test.sh
  ok dunst-split-test.sh
  ok screenshot-and-battery-test.sh
  ok launched-programs-test.sh
dunst pid after: 164396
```

**Machine load stretching the sleep past the timeout.** Ran the check with four suites running concurrently. Still reported one displayed.

So the cause is unknown, and I am not going to change the thing I guess is wrong and call it fixed.

## What the check can do instead

It raced a 2.5 second sleep against dunst's 5 second global timeout and asserted purely on the count, so **a slow read was indistinguishable from a broken product**. It now records how long the read actually took. If that reaches the timeout, the run is reported as inconclusive rather than as a failure of the notification:

```
not ok - inconclusive: reading the count took 1011ms, past the 1ms timeout
```

and the passing line carries the number, so the headroom is visible rather than assumed:

```
ok - a critical notification without -t outlives that window (1012ms of 5000ms)
```

The sleep is 1 second rather than 2.5, leaving four seconds of headroom in a five second window instead of two and a half. **That is a wider margin, not a fix, and it is not claimed as one.** If the flake returns, the output will say whether timing was involved.

Ten runs of the changed suite and two full sweeps, no failures. The inconclusive branch was exercised by setting the timeout to 1ms.
