### PR TITLE
Fix two toggles that read hyprctl output with patterns it does not emit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,9 @@ jobs:
       - name: theme-picker-test
         run: bash test/theme-picker-test.sh
 
+      - name: toggle-scripts-test
+        run: bash test/toggle-scripts-test.sh
+
       - name: update-channel-test
         run: bash test/update-channel-test.sh
 

--- a/.local/bin/audio-switch.sh
+++ b/.local/bin/audio-switch.sh
@@ -33,8 +33,13 @@ fi
 
 [[ -z $next_sink_description ]] && next_sink_description="$next_sink_name"
 
-if [[ $next_sink_name != "$current_sink_name" ]]; then
-  pactl set-default-sink "$next_sink_name"
+# With a single sink the cycle lands back on the one already selected. That set
+# no default and still reported "Switched to", so the only machine where this
+# key does nothing was also the only one where it always claimed success.
+if [[ $next_sink_name == "$current_sink_name" ]]; then
+  notify-send "Audio Output" "Only one audio output: $next_sink_description"
+  exit 0
 fi
 
+pactl set-default-sink "$next_sink_name"
 notify-send "Audio Output" "Switched to: $next_sink_description"

--- a/.local/bin/live-wallpaper-toggle.sh
+++ b/.local/bin/live-wallpaper-toggle.sh
@@ -24,10 +24,11 @@ ACTION="$1"
 turn_off() {
   # Try to get current wallpaper from hyprpaper IPC
   ACTIVE=$(hyprctl hyprpaper listactive 2>/dev/null | head -1)
-  # Parse: output format is "monitor = /path/to/wallpaper"
-  # shellcheck disable=SC2001  # the run of spaces is variable width, which
-  # parameter expansion cannot match
-  RESOLVED=$(echo "$ACTIVE" | sed 's/.*= *//')
+  # Parse: hyprpaper answers "monitor: /path/to/wallpaper". It was read here as
+  # "monitor = /path", so the strip matched nothing, the path kept its "eDP-1: "
+  # prefix, the -f check below rejected it, and every disable fell back to the
+  # cached wallpaper. That is the exact staleness this lookup exists to avoid.
+  RESOLVED="${ACTIVE#*: }"
 
   # Validate resolved path exists and is inside the theme backgrounds dir
   if [[ ! -f "$RESOLVED" || "$RESOLVED" != "$BG_DIR"/* ]]; then

--- a/.local/bin/monitor-mirror-toggle.sh
+++ b/.local/bin/monitor-mirror-toggle.sh
@@ -46,7 +46,13 @@ mirror_off() {
 }
 
 is_mirrored() {
-  hyprctl monitors | grep -A 5 "$EXTERNAL" | grep -q "mirror of $PRIMARY"
+  # hyprctl reports this as a mirrorOf field, not the prose "mirror of", and it
+  # sits 23 lines into the block, so the old `grep -A 5` could not have reached
+  # it even with the right pattern. Read the field by name instead.
+  local mirror
+  mirror=$(hyprctl monitors -j |
+    jq -r --arg external "$EXTERNAL" '.[] | select(.name == $external) | .mirrorOf')
+  [[ $mirror == "$PRIMARY" ]]
 }
 
 case "$MODE" in

--- a/.local/bin/virtual-mirror-toggle.sh
+++ b/.local/bin/virtual-mirror-toggle.sh
@@ -3,10 +3,18 @@
 # Toggle virtual mirror using wl-mirror
 # Auto-detects primary monitor
 
+# wl-mirror is an AUR package, so an install that skipped the AUR list has the
+# keybind without the program. Without this the notification below announced a
+# mirror that never started.
+if ! command -v wl-mirror >/dev/null; then
+  notify-send "Virtual Mirror" "wl-mirror is not installed"
+  exit 1
+fi
+
 PRIMARY=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
 
 if pgrep -x wl-mirror >/dev/null; then
-  pkill wl-mirror
+  pkill -x wl-mirror
   notify-send "Virtual Mirror" "Stopped"
 else
   wl-mirror "$PRIMARY" &

--- a/test/fixtures/hyprctl/listactive.txt
+++ b/test/fixtures/hyprctl/listactive.txt
@@ -1,0 +1,1 @@
+eDP-1: /path/to/theme/backgrounds/0-with-you.jpg

--- a/test/fixtures/hyprctl/monitors-extended.json
+++ b/test/fixtures/hyprctl/monitors-extended.json
@@ -1,0 +1,4 @@
+[
+  { "name": "eDP-1", "focused": true, "mirrorOf": "none" },
+  { "name": "HDMI-A-1", "focused": false, "mirrorOf": "none" }
+]

--- a/test/fixtures/hyprctl/monitors-mirrored.json
+++ b/test/fixtures/hyprctl/monitors-mirrored.json
@@ -1,0 +1,4 @@
+[
+  { "name": "eDP-1", "focused": true, "mirrorOf": "none" },
+  { "name": "HDMI-A-1", "focused": false, "mirrorOf": "eDP-1" }
+]

--- a/test/fixtures/hyprctl/monitors-mirrored.txt
+++ b/test/fixtures/hyprctl/monitors-mirrored.txt
@@ -1,0 +1,25 @@
+Monitor eDP-1 (ID 0):
+	1920x1080@144.00200 at 0x0
+	description: LG Display 0x074D
+	focused: yes
+	dpmsStatus: 1
+	vrr: false
+	solitary: 0
+	activelyTearing: false
+	disabled: false
+	currentFormat: XRGB8888
+	mirrorOf: none
+	availableModes: 1920x1080@144.00Hz
+
+Monitor HDMI-A-1 (ID 1):
+	1920x1080@60.00000 at 0x0
+	description: Acme Projector
+	focused: no
+	dpmsStatus: 1
+	vrr: false
+	solitary: 0
+	activelyTearing: false
+	disabled: false
+	currentFormat: XRGB8888
+	mirrorOf: eDP-1
+	availableModes: 1920x1080@60.00Hz

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Four keybound toggles that no suite had ever run. Two of them parsed hyprctl
+# output with a pattern hyprctl does not emit, and both failures were silent.
+#
+# monitor-mirror-toggle.sh asked whether the external display was already
+# mirroring by grepping for "mirror of eDP-1". hyprctl writes "mirrorOf: eDP-1",
+# 23 lines into the block, so `grep -A 5` could not have reached it even with
+# the right words. is_mirrored was therefore always false and SUPER+SHIFT+M
+# only ever turned mirroring on, never off.
+#
+# live-wallpaper-toggle.sh asked hyprpaper which wallpaper was on screen so
+# that switching live mode off would freeze on that one. hyprpaper answers
+# "eDP-1: /path"; the script stripped up to an "=" that is not there, kept the
+# "eDP-1: " prefix, failed its own -f check and fell back to the stale cache.
+# The freeze-on-what-you-see behaviour never once happened.
+#
+# The fixtures under fixtures/hyprctl are captured from a live Hyprland session
+# rather than written from memory. monitors-mirrored.txt is trimmed to keep it
+# short, so mirrorOf sits 10 lines into the block there instead of 23; that is
+# still past the `grep -A 5` window the old code used.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+FIX="$REPO/test/fixtures/hyprctl"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+LOG="$TMP/calls"
+
+# One hyprctl stub for every script here. It answers from files the test names,
+# so a case is set up by pointing at a fixture rather than by editing the stub.
+cat >"$STUB/hyprctl" <<'STUBEOF'
+#!/bin/bash
+printf 'hyprctl %s\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  "monitors -j") cat "$MONITORS_JSON" ;;
+  "monitors") cat "$MONITORS_TXT" ;;
+  "hyprpaper listactive") cat "$LISTACTIVE" ;;
+  *) exit 0 ;;
+esac
+STUBEOF
+for tool in notify-send systemctl pactl wpctl pgrep pkill wl-mirror; do
+  cat >"$STUB/$tool" <<STUBEOF
+#!/bin/bash
+printf '%s %s\n' "$tool" "\$*" >>"\$CALL_LOG"
+exit "\${${tool//-/_}_RC:-0}"
+STUBEOF
+done
+chmod +x "$STUB"/*
+
+run() { CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" bash "$@"; }
+
+# --- monitor-mirror-toggle.sh -----------------------------------------------
+
+: >"$LOG"
+MONITORS_JSON="$FIX/monitors-mirrored.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
+  run "$BIN/monitor-mirror-toggle.sh" toggle >/dev/null 2>&1
+check "an already mirrored display toggles back to extended" \
+  "$(grep -c 'keyword monitor HDMI-A-1,preferred,auto,1$' "$LOG")" "1"
+check "and does not re-issue the mirror keyword" \
+  "$(grep -c 'mirror,eDP-1' "$LOG")" "0"
+
+: >"$LOG"
+MONITORS_JSON="$FIX/monitors-extended.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
+  run "$BIN/monitor-mirror-toggle.sh" toggle >/dev/null 2>&1
+check "an extended display toggles into mirror" \
+  "$(grep -c 'keyword monitor HDMI-A-1,preferred,auto,1,mirror,eDP-1' "$LOG")" "1"
+
+# The two forced modes must ignore the current state entirely.
+: >"$LOG"
+MONITORS_JSON="$FIX/monitors-mirrored.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
+  run "$BIN/monitor-mirror-toggle.sh" on >/dev/null 2>&1
+check "on forces mirror even when already mirrored" \
+  "$(grep -c 'mirror,eDP-1' "$LOG")" "1"
+
+# --- live-wallpaper-toggle.sh -----------------------------------------------
+
+# A theme with two backgrounds, the cache pointing at the first, hyprpaper
+# showing the second. Turning live mode off must keep the one on screen.
+HOME_DIR="$TMP/home"
+THEME="$HOME_DIR/.config/hypr/themes/rosepine"
+mkdir -p "$THEME/backgrounds" "$HOME_DIR/.cache" "$HOME_DIR/.local/bin"
+cp "$BIN/hypr-helpers.sh" "$HOME_DIR/.local/bin/"
+printf 'first\n' >"$THEME/backgrounds/0-with-you.jpg"
+printf 'second\n' >"$THEME/backgrounds/1-elsewhere.jpg"
+printf '%s\n' "$THEME/backgrounds/0-with-you.jpg" >"$HOME_DIR/.cache/current_wallpaper_path"
+touch "$HOME_DIR/.cache/live_wallpaper_enabled"
+
+printf 'eDP-1: %s\n' "$THEME/backgrounds/1-elsewhere.jpg" >"$TMP/listactive.txt"
+
+: >"$LOG"
+HOME="$HOME_DIR" LISTACTIVE="$TMP/listactive.txt" \
+  MONITORS_JSON="$FIX/monitors-extended.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
+  run "$BIN/live-wallpaper-toggle.sh" off >/dev/null 2>&1
+check "turning live wallpaper off keeps the one hyprpaper is showing" \
+  "$(cat "$HOME_DIR/.cache/current_wallpaper_path")" "$THEME/backgrounds/1-elsewhere.jpg"
+check "and copies that same file into the cache" \
+  "$(cat "$HOME_DIR/.cache/current_wallpaper")" "second"
+check "and clears the enabled flag" \
+  "$([[ -e $HOME_DIR/.cache/live_wallpaper_enabled ]] && echo present || echo gone)" "gone"
+
+# A path outside the theme is still rejected, so the parse fix did not remove
+# the validation that keeps a stray answer from being cached.
+printf 'eDP-1: /etc/passwd\n' >"$TMP/listactive.txt"
+printf '%s\n' "$THEME/backgrounds/0-with-you.jpg" >"$HOME_DIR/.cache/current_wallpaper_path"
+touch "$HOME_DIR/.cache/live_wallpaper_enabled"
+: >"$LOG"
+HOME="$HOME_DIR" LISTACTIVE="$TMP/listactive.txt" \
+  MONITORS_JSON="$FIX/monitors-extended.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
+  run "$BIN/live-wallpaper-toggle.sh" off >/dev/null 2>&1
+check "a path outside the theme falls back to the cached wallpaper" \
+  "$(cat "$HOME_DIR/.cache/current_wallpaper_path")" "$THEME/backgrounds/0-with-you.jpg"
+
+# --- audio-switch.sh --------------------------------------------------------
+
+one_sink='[{"name":"alsa_output.analog-stereo","description":"Built-in Audio","ports":[]}]'
+two_sinks='[{"name":"alsa_output.analog-stereo","description":"Built-in Audio","ports":[]},{"name":"bluez_output.AA","description":"Headphones","ports":[]}]'
+
+cat >"$STUB/pactl" <<'STUBEOF'
+#!/bin/bash
+printf 'pactl %s\n' "$*" >>"$CALL_LOG"
+case "$1" in
+  get-default-sink) printf '%s\n' "$DEFAULT_SINK" ;;
+  -f) printf '%s\n' "$SINKS_JSON" ;;
+esac
+STUBEOF
+chmod +x "$STUB/pactl"
+
+: >"$LOG"
+SINKS_JSON="$one_sink" DEFAULT_SINK="alsa_output.analog-stereo" \
+  run "$BIN/audio-switch.sh" >/dev/null 2>&1
+check "a single sink sets no default" "$(grep -c 'set-default-sink' "$LOG")" "0"
+check "and says so instead of claiming a switch" \
+  "$(grep -c 'Only one audio output' "$LOG")" "1"
+check "and never says Switched to" "$(grep -c 'Switched to' "$LOG")" "0"
+
+: >"$LOG"
+SINKS_JSON="$two_sinks" DEFAULT_SINK="alsa_output.analog-stereo" \
+  run "$BIN/audio-switch.sh" >/dev/null 2>&1
+check "two sinks still cycle to the other one" \
+  "$(grep -c 'set-default-sink bluez_output.AA' "$LOG")" "1"
+check "and report the switch" "$(grep -c 'Switched to: Headphones' "$LOG")" "1"
+
+# --- virtual-mirror-toggle.sh -----------------------------------------------
+
+# A PATH that genuinely lacks wl-mirror. Dropping the stub is not enough on a
+# machine that has the real one in /usr/bin, which is how the first version of
+# this check passed while proving nothing.
+BARE="$TMP/bare"; mkdir -p "$BARE"
+cp "$STUB"/* "$BARE/"
+rm -f "$BARE/wl-mirror"
+for real in bash jq; do ln -sf "$(command -v "$real")" "$BARE/$real"; done
+if [[ -x $BARE/wl-mirror ]] || PATH="$BARE" command -v wl-mirror >/dev/null; then
+  printf 'not ok - the bare PATH still finds wl-mirror, so the next checks prove nothing\n' >&2
+  failures=$((failures + 1))
+fi
+
+: >"$LOG"
+CALL_LOG="$LOG" MONITORS_JSON="$FIX/monitors-extended.json" \
+  PATH="$BARE" bash "$BIN/virtual-mirror-toggle.sh" >/dev/null 2>&1
+rc=$?
+check "a missing wl-mirror exits non-zero" "$rc" "1"
+check "and does not announce a mirror that never started" \
+  "$(grep -c 'Mirroring' "$LOG")" "0"
+check "and says what is missing" \
+  "$(grep -c 'wl-mirror is not installed' "$LOG")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Four keybound toggles that no suite had ever run. Two of them parse `hyprctl` output looking for text `hyprctl` does not print, and both failures are silent.

## `monitor-mirror-toggle.sh` (SUPER+SHIFT+M) could only ever turn mirroring on

`is_mirrored` grepped `hyprctl monitors` for `mirror of eDP-1`. hyprctl writes `mirrorOf: eDP-1`, and it sits 23 lines into the monitor block, so the `grep -A 5` window could not have reached the line even with the right words. Measured on a live session, `mirror of` appears zero times in the output.

So `is_mirrored` was always false and the toggle always took the `mirror_on` branch. Once an external display was mirroring there was no way back to an extended desktop except unplugging it. The field is now read by name out of `hyprctl monitors -j`.

## `live-wallpaper-toggle.sh` never froze on the wallpaper you were looking at

Turning live mode off asks hyprpaper which wallpaper is on screen, so that the cycling stops on that one rather than on whatever the cache last recorded. hyprpaper answers `eDP-1: /path`. The script stripped up to an `=` that is not in the output, so the path kept its `eDP-1: ` prefix, failed the script's own `-f` check, and fell back to the cached path every single time. The feature the lookup exists to provide has never once worked.

The `-f` and theme-prefix validation around it is unchanged and still covered, so a stray answer still cannot be cached.

## Two smaller ones, same family

An error discarded and success reported anyway, which is the shape this repository has now fixed seven times.

- `audio-switch.sh` on a machine with one sink cycles back to the sink already selected, sets no default, and still said `Switched to: ...`. It now says there is only one output. This machine has exactly one sink, so SUPER+F10 has always been a no-op that claimed otherwise.
- `virtual-mirror-toggle.sh` announced `Mirroring ...` without checking that `wl-mirror` is installed. It is an AUR package, so an install that skipped the AUR list has the keybind and not the program. `pkill wl-mirror` also became `pkill -x` to match the `pgrep -x` above it.

## Tests

`test/toggle-scripts-test.sh`, 16 checks, runs all four scripts with stubbed `hyprctl`, `pactl` and `notify-send`. The fixtures under `test/fixtures/hyprctl/` are captured from a live Hyprland session rather than written from memory, which is the whole point given that both bugs are a guess at an output format.

Each of the four fixes was reverted in turn and turned exactly its own checks red, cumulatively 8 of 16. The `wl-mirror` case needed a PATH with no `/usr/bin` on it, because the first version of that check found the real `wl-mirror` and passed while proving nothing.

Sweep: 34 suites, 0 failing, three consecutive runs. shellcheck clean at `style`.

No migration: all four are `.local/bin` scripts, delivered by `hyprsimple-update`.