### PR TITLE
Fix the NVIDIA install path: wrong package manager, unverified result, and two omissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,9 @@ jobs:
       - name: screenshot-and-battery-test
         run: bash test/screenshot-and-battery-test.sh
 
+      - name: nvidia-install-test
+        run: bash test/nvidia-install-test.sh
+
       - name: hw-predicate-test
         run: bash test/hw-predicate-test.sh
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -105,6 +105,15 @@ lsmod | grep nvidia                          # empty at boot = good
 prime-run glxinfo | grep "OpenGL renderer"   # still loads the dGPU on demand
 ```
 
+> [!IMPORTANT]
+> `prime-run` comes from `nvidia-prime` and `glxinfo` from `mesa-utils`. The
+> installer now installs `nvidia-prime` alongside the driver, but it did not
+> before, and `mesa-utils` is not installed at all. On an older install:
+>
+> ```bash
+> sudo pacman -S --needed nvidia-prime mesa-utils
+> ```
+
 > [!NOTE]
 > Scope the change to the bleeding-edge entry only; leave your LTS entry untouched as a
 > fallback. The community `nomodeset` workaround also boots, but disables **all** KMS

--- a/install.sh
+++ b/install.sh
@@ -139,21 +139,23 @@ detect_and_install_nvidia() {
 
   # Turing+ (GTX 16xx, RTX 20xx-50xx, RTX Pro, Quadro RTX, datacenter)
   if echo "$NVIDIA" | grep -qE "GTX 16[0-9]{2}|RTX [2-5][0-9]{3}|RTX PRO [0-9]{4}|Quadro RTX|RTX A[0-9]{4}|A[1-9][0-9]{2}|H[1-9][0-9]{2}|T4|L[0-9]+"; then
+    # The driver stack is kept apart from the additions, because a machine that
+    # already has a driver must be given the second without the first.
     if [[ -n $NVIDIA_OPEN_PREBUILT ]]; then
-      NVIDIA_PACKAGES=("$NVIDIA_OPEN_PREBUILT" nvidia-utils libva-nvidia-driver)
+      NVIDIA_DRIVER_PACKAGES=("$NVIDIA_OPEN_PREBUILT" nvidia-utils)
     else
-      NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-open-dkms nvidia-utils libva-nvidia-driver)
+      NVIDIA_DRIVER_PACKAGES=("$KERNEL_HEADERS" nvidia-open-dkms nvidia-utils)
     fi
-    # prime-run lives here, and FAQ.md's remedy for the Optimus boot hang is
-    # written around having it. Nothing installed it.
-    NVIDIA_PACKAGES+=(nvidia-prime)
+    # prime-run lives in nvidia-prime, and FAQ.md's remedy for the Optimus boot
+    # hang is written around having it. Nothing installed it.
+    NVIDIA_EXTRA_PACKAGES=(libva-nvidia-driver nvidia-prime)
     NVIDIA_LIB32_PACKAGES=(lib32-nvidia-utils)
     NVIDIA_INSTALLER=(sudo pacman -S --noconfirm)
-    NVIDIA_UTILS_PKG="nvidia-utils"
     GPU_ARCH="turing_plus"
   # Maxwell/Pascal/Volta (GTX 9xx/10xx, Quadro P/M, MX, Titan X/Xp/V)
   elif echo "$NVIDIA" | grep -qE "GTX (9[0-9]{2}|10[0-9]{2})|GT 10[0-9]{2}|Quadro [PM][0-9]{3,4}|Quadro GV100|MX *[0-9]+|Titan (X|Xp|V)|Tesla V100"; then
-    NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-580xx-dkms nvidia-580xx-utils nvidia-prime)
+    NVIDIA_DRIVER_PACKAGES=("$KERNEL_HEADERS" nvidia-580xx-dkms nvidia-580xx-utils)
+    NVIDIA_EXTRA_PACKAGES=(nvidia-prime)
     NVIDIA_LIB32_PACKAGES=(lib32-nvidia-580xx-utils)
     # The 580xx legacy series is not in any official Arch repository, so
     # installing it with `sudo pacman -S` could never have worked: every GTX
@@ -162,22 +164,39 @@ detect_and_install_nvidia() {
     # helper prefers the repo copy where one exists, so the helper is the right
     # installer on both.
     NVIDIA_INSTALLER=("$AUR_HELPER" -S --noconfirm)
-    NVIDIA_UTILS_PKG="nvidia-580xx-utils"
     GPU_ARCH="maxwell_pascal_volta"
   else
     echo -e "${YELLOW}No compatible NVIDIA driver found. See: https://wiki.archlinux.org/title/NVIDIA${NC}"
     return 0
   fi
 
-  # 32-bit OpenGL, which is Steam and wine. Arch ships [multilib] commented out
-  # and hyprsimple never edits pacman.conf, so on a stock install these names do
-  # not resolve at all. Upstream gets away with listing them unconditionally
-  # because it ships its own pacman.conf with multilib turned on. Asking is
-  # cheaper than adding three more entries to FAILED_PACKAGES.
-  if pacman-conf --repo-list 2>/dev/null | grep -qx multilib; then
-    NVIDIA_PACKAGES+=("${NVIDIA_LIB32_PACKAGES[@]}")
+  # Distributions built on Arch often ship a working driver already: CachyOS
+  # installs one whether or not the machine has an NVIDIA GPU. These packages do
+  # not upgrade that, they collide with it. nvidia-580xx-dkms conflicts with
+  # NVIDIA-MODULE, which every driver provides, and nvidia-580xx-utils conflicts
+  # with nvidia-utils, so on such a machine the transaction cannot resolve at
+  # all and --noconfirm turns that into a hard failure. --needed does not help,
+  # because the collision is between different package names.
+  #
+  # A driver that is already there is the distribution's choice and probably
+  # matches its kernel better than a guess from an lspci string does, so leave
+  # it alone and install only what is additive.
+  NVIDIA_PACKAGES=("${NVIDIA_EXTRA_PACKAGES[@]}")
+  INSTALLED_MODULE="$(pacman -Qq NVIDIA-MODULE 2>/dev/null | head -1)"
+  if [[ -n $INSTALLED_MODULE ]]; then
+    echo -e "${GREEN}$INSTALLED_MODULE already provides the NVIDIA kernel module, so the driver stack is being left as it is. Installing only ${NVIDIA_EXTRA_PACKAGES[*]}.${NC}"
+    echo -e "${YELLOW}If the GPU does not work after this, that driver is the one to change: remove $INSTALLED_MODULE, then re-run ./install.sh to get ${NVIDIA_DRIVER_PACKAGES[*]} instead.${NC}"
   else
-    echo -e "${YELLOW}[multilib] is not enabled, so ${NVIDIA_LIB32_PACKAGES[*]} is being skipped. Enable it in /etc/pacman.conf if you want 32-bit OpenGL for Steam or wine.${NC}"
+    NVIDIA_PACKAGES=("${NVIDIA_DRIVER_PACKAGES[@]}" "${NVIDIA_PACKAGES[@]}")
+    # 32-bit OpenGL, which is Steam and wine. Arch ships [multilib] commented
+    # out and hyprsimple never edits pacman.conf, so on a stock install these
+    # names do not resolve either. Upstream lists them unconditionally because
+    # it ships its own pacman.conf with multilib turned on.
+    if pacman-conf --repo-list 2>/dev/null | grep -qx multilib; then
+      NVIDIA_PACKAGES+=("${NVIDIA_LIB32_PACKAGES[@]}")
+    else
+      echo -e "${YELLOW}[multilib] is not enabled, so ${NVIDIA_LIB32_PACKAGES[*]} is being skipped. Enable it in /etc/pacman.conf if you want 32-bit OpenGL for Steam or wine.${NC}"
+    fi
   fi
 
   echo -e "${YELLOW}Installing NVIDIA packages: ${NVIDIA_PACKAGES[*]}${NC}"
@@ -187,10 +206,12 @@ detect_and_install_nvidia() {
   # way, so ask what actually landed. Writing the block below with no driver
   # present is worse than writing nothing: __GLX_VENDOR_LIBRARY_NAME=nvidia
   # points GLX at libGLX_nvidia.so.0, and with that file absent every OpenGL
-  # application in the next session fails. -Qq resolves provides, which is what
-  # is wanted here, since a package providing the driver is a driver.
-  if ! pacman -Qq "$NVIDIA_UTILS_PKG" &>/dev/null; then
-    echo -e "${YELLOW}$NVIDIA_UTILS_PKG is not installed, so the NVIDIA environment variables and the initramfs rebuild are being skipped. Leaving them out keeps OpenGL working. Install the packages listed above by hand, then re-run ./install.sh.${NC}"
+  # application in the next session fails. nvidia-utils is the name to ask for
+  # in every case: the legacy nvidia-580xx-utils provides it, and -Qq resolves
+  # provides, so one question covers both generations and the driver a
+  # distribution installed under some third name.
+  if ! pacman -Qq nvidia-utils &>/dev/null; then
+    echo -e "${YELLOW}No NVIDIA userspace driver is installed, so the NVIDIA environment variables and the initramfs rebuild are being skipped. Leaving them out keeps OpenGL working. Install the packages listed above by hand, then re-run ./install.sh.${NC}"
     return 0
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,11 @@ detect_and_install_nvidia() {
 
   # Derive the kernel package base from the running kernel's modules dir
   # (works for stock Arch and custom kernels like linux-cachyos-lts).
-  KERNEL_BASE="$(cat "/usr/lib/modules/$(uname -r)/pkgbase" 2>/dev/null || true)"
+  # Overridable so the suite can arrange both answers. A test that can only
+  # ever see the kernel this machine is running has only tested one of them,
+  # and on a CI runner with no pkgbase file at all it would test neither.
+  MODULES_DIR="${HYPRSIMPLE_MODULES_DIR:-/usr/lib/modules}"
+  KERNEL_BASE="$(cat "$MODULES_DIR/$(uname -r)/pkgbase" 2>/dev/null || true)"
   if [[ -z $KERNEL_BASE ]]; then
     echo -e "${YELLOW}Could not detect kernel package base; skipping NVIDIA driver install. Install '<kernel>-headers' and an NVIDIA driver manually: https://wiki.archlinux.org/title/NVIDIA${NC}"
     return 0
@@ -140,10 +144,20 @@ detect_and_install_nvidia() {
     else
       NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-open-dkms nvidia-utils libva-nvidia-driver)
     fi
+    NVIDIA_INSTALLER=(sudo pacman -S --noconfirm)
+    NVIDIA_UTILS_PKG="nvidia-utils"
     GPU_ARCH="turing_plus"
   # Maxwell/Pascal/Volta (GTX 9xx/10xx, Quadro P/M, MX, Titan X/Xp/V)
   elif echo "$NVIDIA" | grep -qE "GTX (9[0-9]{2}|10[0-9]{2})|GT 10[0-9]{2}|Quadro [PM][0-9]{3,4}|Quadro GV100|MX *[0-9]+|Titan (X|Xp|V)|Tesla V100"; then
     NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-580xx-dkms nvidia-580xx-utils lib32-nvidia-580xx-utils)
+    # The 580xx legacy series is not in any official Arch repository, so
+    # installing it with `sudo pacman -S` could never have worked: every GTX
+    # 9xx and 10xx machine on stock Arch got three "target not found" failures
+    # and nothing else. Some derivatives do ship these in a repo, and an AUR
+    # helper prefers the repo copy where one exists, so the helper is the right
+    # installer on both.
+    NVIDIA_INSTALLER=("$AUR_HELPER" -S --noconfirm)
+    NVIDIA_UTILS_PKG="nvidia-580xx-utils"
     GPU_ARCH="maxwell_pascal_volta"
   else
     echo -e "${YELLOW}No compatible NVIDIA driver found. See: https://wiki.archlinux.org/title/NVIDIA${NC}"
@@ -151,7 +165,18 @@ detect_and_install_nvidia() {
   fi
 
   echo -e "${YELLOW}Installing NVIDIA packages: ${NVIDIA_PACKAGES[*]}${NC}"
-  install_packages sudo pacman -S --noconfirm -- "${NVIDIA_PACKAGES[@]}"
+  install_packages "${NVIDIA_INSTALLER[@]}" -- "${NVIDIA_PACKAGES[@]}"
+
+  # install_packages collects failures into FAILED_PACKAGES and returns 0 either
+  # way, so ask what actually landed. Writing the block below with no driver
+  # present is worse than writing nothing: __GLX_VENDOR_LIBRARY_NAME=nvidia
+  # points GLX at libGLX_nvidia.so.0, and with that file absent every OpenGL
+  # application in the next session fails. -Qq resolves provides, which is what
+  # is wanted here, since a package providing the driver is a driver.
+  if ! pacman -Qq "$NVIDIA_UTILS_PKG" &>/dev/null; then
+    echo -e "${YELLOW}$NVIDIA_UTILS_PKG is not installed, so the NVIDIA environment variables and the initramfs rebuild are being skipped. Leaving them out keeps OpenGL working. Install the packages listed above by hand, then re-run ./install.sh.${NC}"
+    return 0
+  fi
 
   # Append NVIDIA env vars to uwsm/env
   if [[ $GPU_ARCH = "turing_plus" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -144,12 +144,17 @@ detect_and_install_nvidia() {
     else
       NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-open-dkms nvidia-utils libva-nvidia-driver)
     fi
+    # prime-run lives here, and FAQ.md's remedy for the Optimus boot hang is
+    # written around having it. Nothing installed it.
+    NVIDIA_PACKAGES+=(nvidia-prime)
+    NVIDIA_LIB32_PACKAGES=(lib32-nvidia-utils)
     NVIDIA_INSTALLER=(sudo pacman -S --noconfirm)
     NVIDIA_UTILS_PKG="nvidia-utils"
     GPU_ARCH="turing_plus"
   # Maxwell/Pascal/Volta (GTX 9xx/10xx, Quadro P/M, MX, Titan X/Xp/V)
   elif echo "$NVIDIA" | grep -qE "GTX (9[0-9]{2}|10[0-9]{2})|GT 10[0-9]{2}|Quadro [PM][0-9]{3,4}|Quadro GV100|MX *[0-9]+|Titan (X|Xp|V)|Tesla V100"; then
-    NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-580xx-dkms nvidia-580xx-utils lib32-nvidia-580xx-utils)
+    NVIDIA_PACKAGES=("$KERNEL_HEADERS" nvidia-580xx-dkms nvidia-580xx-utils nvidia-prime)
+    NVIDIA_LIB32_PACKAGES=(lib32-nvidia-580xx-utils)
     # The 580xx legacy series is not in any official Arch repository, so
     # installing it with `sudo pacman -S` could never have worked: every GTX
     # 9xx and 10xx machine on stock Arch got three "target not found" failures
@@ -162,6 +167,17 @@ detect_and_install_nvidia() {
   else
     echo -e "${YELLOW}No compatible NVIDIA driver found. See: https://wiki.archlinux.org/title/NVIDIA${NC}"
     return 0
+  fi
+
+  # 32-bit OpenGL, which is Steam and wine. Arch ships [multilib] commented out
+  # and hyprsimple never edits pacman.conf, so on a stock install these names do
+  # not resolve at all. Upstream gets away with listing them unconditionally
+  # because it ships its own pacman.conf with multilib turned on. Asking is
+  # cheaper than adding three more entries to FAILED_PACKAGES.
+  if pacman-conf --repo-list 2>/dev/null | grep -qx multilib; then
+    NVIDIA_PACKAGES+=("${NVIDIA_LIB32_PACKAGES[@]}")
+  else
+    echo -e "${YELLOW}[multilib] is not enabled, so ${NVIDIA_LIB32_PACKAGES[*]} is being skipped. Enable it in /etc/pacman.conf if you want 32-bit OpenGL for Steam or wine.${NC}"
   fi
 
   echo -e "${YELLOW}Installing NVIDIA packages: ${NVIDIA_PACKAGES[*]}${NC}"

--- a/test/nvidia-install-test.sh
+++ b/test/nvidia-install-test.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# detect_and_install_nvidia had never been run by anything, and it installed
+# the legacy driver with the wrong package manager.
+#
+# The Maxwell/Pascal/Volta branch installs nvidia-580xx-dkms, nvidia-580xx-utils
+# and lib32-nvidia-580xx-utils. None of the three is in any official Arch
+# repository, and all three were passed to `sudo pacman -S`, so on stock Arch
+# every GTX 9xx and 10xx machine got three "target not found" failures. That
+# was survivable. What followed was not: install_packages records failures and
+# returns 0 regardless, so the function went on to append
+# __GLX_VENDOR_LIBRARY_NAME=nvidia to uwsm/env, rebuild the initramfs, and
+# print "NVIDIA setup complete". That variable points GLX at libGLX_nvidia.so.0
+# and, with no driver installed, every OpenGL application in the next session
+# fails. The installer's own advice is to re-run it, which reproduced the same
+# state.
+#
+# Both branches are driven here, both with the install working and with it
+# failing, against stubs. Nothing installs anything.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# Take the function out of install.sh by name. install.sh cannot be sourced:
+# it installs a desktop from the top of the file down.
+FUNCS="$TMP/funcs.sh"
+sed -n '/^detect_and_install_nvidia() {/,/^}/p' "$REPO/install.sh" >"$FUNCS"
+sed -n '/^install_packages() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
+
+# An extraction that quietly produced nothing would let every check below pass
+# for the wrong reason. This is the shape that has already cost this repository
+# five vacuous checks, so assert the extraction before using it.
+for marker in 'detect_and_install_nvidia() {' 'install_packages() {' \
+  'NVIDIA_UTILS_PKG' 'nvidia-580xx-dkms' '__GLX_VENDOR_LIBRARY_NAME'; do
+  if grep -qF -- "$marker" "$FUNCS"; then
+    pass "extracted source contains $marker"
+  else
+    fail "extracted source is missing $marker, so nothing below is testing install.sh"
+  fi
+done
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+LOG="$TMP/calls"
+
+cat >"$STUB/lspci" <<'STUBEOF'
+#!/bin/bash
+printf '00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n'
+printf '01:00.0 VGA compatible controller: NVIDIA Corporation %s\n' "$NVIDIA_MODEL"
+STUBEOF
+
+# INSTALLED lists the packages pacman should claim are present, so the test
+# says whether the driver landed rather than the stub deciding.
+cat >"$STUB/pacman" <<'STUBEOF'
+#!/bin/bash
+printf 'pacman %s\n' "$*" >>"$CALL_LOG"
+case "${1:-}" in
+  -Si) [[ " ${REPO_PACKAGES:-} " == *" $2 "* ]] && exit 0; exit 1 ;;
+  -Qq) [[ " ${INSTALLED:-} " == *" $2 "* ]] && exit 0; exit 1 ;;
+esac
+exit 0
+STUBEOF
+
+# sudo runs what follows it, so `sudo pacman` reaches the pacman stub.
+cat >"$STUB/sudo" <<'STUBEOF'
+#!/bin/bash
+"$@"
+STUBEOF
+
+# The two installers a driver site can be handed. Each logs and reports whether
+# the test wants it to succeed.
+for helper in paru mkinitcpio; do
+  cat >"$STUB/$helper" <<STUBEOF
+#!/bin/bash
+printf '$helper %s\n' "\$*" >>"\$CALL_LOG"
+exit "\${INSTALL_RC:-0}"
+STUBEOF
+done
+chmod +x "$STUB"/*
+
+# A kernel whose pkgbase is known, so KERNEL_HEADERS is derived rather than
+# skipped. Without this the function returns early on any CI runner.
+MODULES="$TMP/modules/$(uname -r)"
+mkdir -p "$MODULES"
+printf 'linux\n' >"$MODULES/pkgbase"
+
+HOME_DIR="$TMP/home"
+
+# Run the function with one scenario's worth of environment.
+run_nvidia() {
+  rm -rf "$HOME_DIR"; mkdir -p "$HOME_DIR/.config/uwsm"
+  : >"$LOG"
+  HOME="$HOME_DIR" CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" \
+    HYPRSIMPLE_MODULES_DIR="$TMP/modules" \
+    NVIDIA_MODEL="$1" INSTALLED="$2" INSTALL_RC="${3:-0}" \
+    REPO_PACKAGES="${4:-}" \
+    bash -c '
+      set -uo pipefail
+      RED=""; GREEN=""; YELLOW=""; NC=""
+      AUR_HELPER="paru"
+      DOTFILES_DIR="'"$REPO"'"
+      FAILED_PACKAGES=()
+      source "'"$FUNCS"'"
+      detect_and_install_nvidia
+    ' >"$TMP/out" 2>&1
+}
+
+env_file() { cat "$HOME_DIR/.config/uwsm/env" 2>/dev/null; }
+
+# --- the legacy branch reaches the AUR helper, not pacman -------------------
+
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "nvidia-580xx-utils"
+check "a GTX 1060 is recognised as the legacy generation" \
+  "$(grep -c 'nvidia-580xx-dkms' "$LOG")" "1"
+check "and the legacy driver is installed with the AUR helper" \
+  "$(grep -c '^paru .*nvidia-580xx-dkms' "$LOG")" "1"
+check "and not with pacman, which cannot resolve those names" \
+  "$(grep -c '^pacman -S .*nvidia-580xx' "$LOG")" "0"
+
+# --- a failed install must not write the env vars ---------------------------
+
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "" 1
+check "with the legacy driver missing no GLX vendor is exported" \
+  "$(env_file | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
+check "and the initramfs is not rebuilt" "$(grep -c '^mkinitcpio' "$LOG")" "0"
+check "and the failure is named" \
+  "$(grep -c 'nvidia-580xx-utils is not installed' "$TMP/out")" "1"
+check "and it does not claim the setup completed" \
+  "$(grep -c 'NVIDIA setup complete' "$TMP/out")" "0"
+
+run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "" 1
+check "with the current driver missing no GLX vendor is exported either" \
+  "$(env_file | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
+check "and that failure names the current utils package" \
+  "$(grep -c 'nvidia-utils is not installed' "$TMP/out")" "1"
+
+# --- a successful install still writes the right block ----------------------
+
+run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "nvidia-utils"
+check "a working Turing+ install exports the direct backend" \
+  "$(env_file | grep -c 'NVD_BACKEND=direct')" "1"
+check "and rebuilds the initramfs" "$(grep -c '^mkinitcpio -P' "$LOG")" "1"
+check "and reports the architecture it chose" \
+  "$(grep -c 'arch: turing_plus' "$TMP/out")" "1"
+check "and Turing+ still goes through pacman" \
+  "$(grep -c '^pacman -S .*nvidia-open-dkms' "$LOG")" "1"
+
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "nvidia-580xx-utils"
+check "a working legacy install exports the egl backend" \
+  "$(env_file | grep -c 'NVD_BACKEND=egl')" "1"
+check "and never exports the direct backend" \
+  "$(env_file | grep -c 'NVD_BACKEND=direct')" "0"
+
+# A derivative that ships a prebuilt module for this kernel must be preferred
+# over the DKMS build.
+run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "nvidia-utils" 0 "linux-nvidia-open"
+check "a prebuilt kernel module is preferred over DKMS" \
+  "$(grep -c '^pacman -S .*linux-nvidia-open' "$LOG")" "1"
+check "and DKMS is then not installed" \
+  "$(grep -c 'nvidia-open-dkms' "$LOG")" "0"
+
+# --- no NVIDIA at all -------------------------------------------------------
+
+cat >"$STUB/lspci" <<'STUBEOF'
+#!/bin/bash
+printf '00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n'
+STUBEOF
+chmod +x "$STUB/lspci"
+run_nvidia "" ""
+check "a machine with no NVIDIA GPU installs nothing" \
+  "$(grep -c 'nvidia' "$LOG")" "0"
+check "and says so" "$(grep -c 'No NVIDIA GPU detected' "$TMP/out")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/nvidia-install-test.sh
+++ b/test/nvidia-install-test.sh
@@ -70,6 +70,18 @@ esac
 exit 0
 STUBEOF
 
+# multilib is a property of the machine's pacman.conf, so the test says whether
+# it is on rather than reading the real one.
+cat >"$STUB/pacman-conf" <<'STUBEOF'
+#!/bin/bash
+[[ ${MULTILIB:-on} == on ]] && printf 'core
+extra
+multilib
+' || printf 'core
+extra
+'
+STUBEOF
+
 # sudo runs what follows it, so `sudo pacman` reaches the pacman stub.
 cat >"$STUB/sudo" <<'STUBEOF'
 #!/bin/bash
@@ -102,7 +114,7 @@ run_nvidia() {
   HOME="$HOME_DIR" CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" \
     HYPRSIMPLE_MODULES_DIR="$TMP/modules" \
     NVIDIA_MODEL="$1" INSTALLED="$2" INSTALL_RC="${3:-0}" \
-    REPO_PACKAGES="${4:-}" \
+    REPO_PACKAGES="${4:-}" MULTILIB="${5:-on}" \
     bash -c '
       set -uo pipefail
       RED=""; GREEN=""; YELLOW=""; NC=""
@@ -167,6 +179,32 @@ check "a prebuilt kernel module is preferred over DKMS" \
   "$(grep -c '^pacman -S .*linux-nvidia-open' "$LOG")" "1"
 check "and DKMS is then not installed" \
   "$(grep -c 'nvidia-open-dkms' "$LOG")" "0"
+
+# --- 32-bit OpenGL is gated on multilib, and prime-run is always installed ---
+
+run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "nvidia-utils" 0 "" on
+check "with multilib on, Turing+ installs the 32-bit driver" \
+  "$(grep -c 'lib32-nvidia-utils' "$LOG")" "1"
+
+run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "nvidia-utils" 0 "" off
+check "with multilib off it is skipped rather than failed" \
+  "$(grep -c 'lib32-nvidia-utils' "$LOG")" "0"
+check "and the skip is explained" \
+  "$(grep -c 'multilib\] is not enabled' "$TMP/out")" "1"
+check "and the rest of the driver still installs" \
+  "$(grep -c '^pacman -S .*nvidia-open-dkms' "$LOG")" "1"
+
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "nvidia-580xx-utils" 0 "" off
+check "the legacy branch skips its 32-bit driver too" \
+  "$(grep -c 'lib32-nvidia-580xx-utils' "$LOG")" "0"
+check "and still installs the legacy driver itself" \
+  "$(grep -c '^paru .*nvidia-580xx-dkms' "$LOG")" "1"
+
+for gen in "AD107M [GeForce RTX 4050 Max-Q]:nvidia-utils" "GP106 [GeForce GTX 1060 6GB]:nvidia-580xx-utils"; do
+  run_nvidia "${gen%%:*}" "${gen##*:}"
+  check "nvidia-prime is installed for ${gen%% *}, since FAQ.md's fix needs prime-run" \
+    "$(grep -c 'nvidia-prime' "$LOG")" "1"
+done
 
 # --- no NVIDIA at all -------------------------------------------------------
 

--- a/test/nvidia-install-test.sh
+++ b/test/nvidia-install-test.sh
@@ -41,7 +41,8 @@ sed -n '/^install_packages() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
 # for the wrong reason. This is the shape that has already cost this repository
 # five vacuous checks, so assert the extraction before using it.
 for marker in 'detect_and_install_nvidia() {' 'install_packages() {' \
-  'NVIDIA_UTILS_PKG' 'nvidia-580xx-dkms' '__GLX_VENDOR_LIBRARY_NAME'; do
+  'NVIDIA_DRIVER_PACKAGES' 'NVIDIA-MODULE' 'nvidia-580xx-dkms' \
+  '__GLX_VENDOR_LIBRARY_NAME'; do
   if grep -qF -- "$marker" "$FUNCS"; then
     pass "extracted source contains $marker"
   else
@@ -65,7 +66,17 @@ cat >"$STUB/pacman" <<'STUBEOF'
 printf 'pacman %s\n' "$*" >>"$CALL_LOG"
 case "${1:-}" in
   -Si) [[ " ${REPO_PACKAGES:-} " == *" $2 "* ]] && exit 0; exit 1 ;;
-  -Qq) [[ " ${INSTALLED:-} " == *" $2 "* ]] && exit 0; exit 1 ;;
+  -Qq)
+    # NVIDIA-MODULE is a virtual provide, so answer it with the name of the
+    # package the test says is providing it, the way pacman does.
+    if [[ $2 == NVIDIA-MODULE ]]; then
+      [[ -n ${INSTALLED_MODULE_PKG:-} ]] || exit 1
+      printf '%s\n' "$INSTALLED_MODULE_PKG"; exit 0
+    fi
+    # nvidia-580xx-utils provides nvidia-utils, and -Qq resolves provides, so
+    # the stub has to as well or the gate looks broken when it is not.
+    if [[ $2 == nvidia-utils && " ${INSTALLED:-} " == *" nvidia-580xx-utils "* ]]; then exit 0; fi
+    [[ " ${INSTALLED:-} " == *" $2 "* ]] && exit 0; exit 1 ;;
 esac
 exit 0
 STUBEOF
@@ -115,6 +126,7 @@ run_nvidia() {
     HYPRSIMPLE_MODULES_DIR="$TMP/modules" \
     NVIDIA_MODEL="$1" INSTALLED="$2" INSTALL_RC="${3:-0}" \
     REPO_PACKAGES="${4:-}" MULTILIB="${5:-on}" \
+    INSTALLED_MODULE_PKG="${6:-}" \
     bash -c '
       set -uo pipefail
       RED=""; GREEN=""; YELLOW=""; NC=""
@@ -145,15 +157,15 @@ check "with the legacy driver missing no GLX vendor is exported" \
   "$(env_file | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
 check "and the initramfs is not rebuilt" "$(grep -c '^mkinitcpio' "$LOG")" "0"
 check "and the failure is named" \
-  "$(grep -c 'nvidia-580xx-utils is not installed' "$TMP/out")" "1"
+  "$(grep -c 'No NVIDIA userspace driver is installed' "$TMP/out")" "1"
 check "and it does not claim the setup completed" \
   "$(grep -c 'NVIDIA setup complete' "$TMP/out")" "0"
 
 run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "" 1
 check "with the current driver missing no GLX vendor is exported either" \
   "$(env_file | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
-check "and that failure names the current utils package" \
-  "$(grep -c 'nvidia-utils is not installed' "$TMP/out")" "1"
+check "and that failure is reported too" \
+  "$(grep -c 'No NVIDIA userspace driver is installed' "$TMP/out")" "1"
 
 # --- a successful install still writes the right block ----------------------
 
@@ -205,6 +217,47 @@ for gen in "AD107M [GeForce RTX 4050 Max-Q]:nvidia-utils" "GP106 [GeForce GTX 10
   check "nvidia-prime is installed for ${gen%% *}, since FAQ.md's fix needs prime-run" \
     "$(grep -c 'nvidia-prime' "$LOG")" "1"
 done
+
+# --- a driver the distribution already installed is left alone --------------
+
+# CachyOS installs an NVIDIA driver whether or not the machine has the GPU, and
+# these packages collide with it rather than upgrade it: nvidia-580xx-dkms
+# conflicts with NVIDIA-MODULE and nvidia-580xx-utils conflicts with
+# nvidia-utils, so under --noconfirm the whole transaction fails.
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "nvidia-utils" 0 "" on "linux-cachyos-lts-nvidia-open"
+check "an existing driver means the conflicting module is not installed" \
+  "$(grep -c 'nvidia-580xx-dkms' "$LOG")" "0"
+check "and the conflicting userspace driver is not installed either" \
+  "$(grep -c 'nvidia-580xx-utils' "$LOG")" "0"
+check "and neither is its 32-bit half" \
+  "$(grep -c 'lib32-nvidia-580xx-utils' "$LOG")" "0"
+check "but the additions still are" "$(grep -c 'nvidia-prime' "$LOG")" "1"
+check "and the driver that is already there is named" \
+  "$(grep -c 'linux-cachyos-lts-nvidia-open already provides' "$TMP/out")" "1"
+check "and the env vars are still written, because a driver is present" \
+  "$(env_file | grep -c 'NVD_BACKEND=egl')" "1"
+check "and the user is told what to remove if the GPU does not work" \
+  "$(grep -c 'remove linux-cachyos-lts-nvidia-open' "$TMP/out")" "1"
+
+run_nvidia "AD107M [GeForce RTX 4050 Max-Q]" "nvidia-utils" 0 "" on "linux-cachyos-nvidia-open"
+check "Turing+ leaves an existing driver alone too" \
+  "$(grep -c 'nvidia-open-dkms' "$LOG")" "0"
+check "and still writes the direct backend" \
+  "$(env_file | grep -c 'NVD_BACKEND=direct')" "1"
+
+# With no driver present the full stack is installed, which is the check that
+# stops the branch above from being a way to install nothing at all.
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "nvidia-580xx-utils" 0 "" on ""
+check "with no driver present the legacy stack is installed in full" \
+  "$(grep -c '^paru .*nvidia-580xx-dkms.*nvidia-580xx-utils' "$LOG")" "1"
+
+# The env gate asks for nvidia-utils, which the legacy package provides, so one
+# question covers both generations.
+run_nvidia "GP106 [GeForce GTX 1060 6GB]" "" 1 "" on ""
+check "a legacy install that failed writes no env vars" \
+  "$(env_file | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
+check "and says no userspace driver is installed" \
+  "$(grep -c 'No NVIDIA userspace driver is installed' "$TMP/out")" "1"
 
 # --- no NVIDIA at all -------------------------------------------------------
 


### PR DESCRIPTION
Two defects in `detect_and_install_nvidia`, which no suite had ever run.

## The legacy driver was installed with a package manager that cannot see it

The Maxwell/Pascal/Volta branch installs `nvidia-580xx-dkms`, `nvidia-580xx-utils` and `lib32-nvidia-580xx-utils` through `sudo pacman -S`. None of the three is in any official Arch repository, checked against `archlinux.org/packages/search/json`:

```
nvidia-580xx-dkms            arch repos: <none>     aur: 1
nvidia-580xx-utils           arch repos: <none>     aur: 1
lib32-nvidia-580xx-utils     arch repos: <none>     aur: 1
```

So on stock Arch this branch could never install anything. That is every GTX 9xx and 10xx machine, along with the Quadro P/M, MX and Titan X/Xp/V entries in the same regex. They are routed through `$AUR_HELPER` now. Some derivatives do carry these in a repo (they are in `cachyos` on this machine, which is why it went unnoticed here), and an AUR helper prefers the repo copy where one exists, so the helper is correct on both. Turing+ is unchanged and still uses pacman.

## Worse, the failure was invisible and then made things actively broken

`install_packages` records failures into `FAILED_PACKAGES` and returns 0 either way, by design, so that one bad name does not abort the desktop install. `detect_and_install_nvidia` never asked. After the install failed it went on to:

1. append `export __GLX_VENDOR_LIBRARY_NAME=nvidia` and `NVD_BACKEND=egl` to `~/.config/uwsm/env`
2. run `sudo mkinitcpio -P`
3. print `NVIDIA setup complete (arch: maxwell_pascal_volta)`

`__GLX_VENDOR_LIBRARY_NAME=nvidia` points GLX at `libGLX_nvidia.so.0`. With no driver installed that file is absent and every OpenGL application in the next session fails. The user is left worse off than if hardware detection had not run at all, having been told it succeeded. The installer's own failure message then says to re-run `./install.sh`, which reproduces the same state.

It now checks that the utils package is actually present before writing anything, and says which package is missing when it is not. Leaving the block out keeps OpenGL working on the software driver.

## Tests

`test/nvidia-install-test.sh`, 24 checks. It lifts `detect_and_install_nvidia` and `install_packages` out of `install.sh` by name, since `install.sh` cannot be sourced, and drives both GPU generations with the install working and failing, plus the no-NVIDIA case and the prebuilt-module preference. `lspci`, `pacman`, `sudo`, `paru` and `mkinitcpio` are stubbed. Nothing is installed.

Five of the checks assert the extraction itself found the real function first. Extraction quietly yielding nothing is the shape that has already cost this repository five vacuous checks.

`KERNEL_BASE` is now read from an overridable `HYPRSIMPLE_MODULES_DIR`, following `HYPRSIMPLE_SYSFS_NET` in `wifi.sh`. Without it the function returns early on any runner with no `pkgbase` file, and the suite would have tested nothing on CI.

Both fixes were reverted in turn: the installer change turns 2 checks red, the gate turns 6 red. Sweep: 35 suites, 0 failing, three consecutive runs. shellcheck clean at `style`.

No migration: `install.sh` is not delivered to existing installs, and this machine already has a working Turing+ block in `uwsm/env`.

---

## Added after reading FAQ.md

### `prime-run` was never installed

`FAQ.md:77` documents the Optimus boot hang and its remedy: blacklist the NVIDIA modules at boot, then reach the dGPU on demand with `prime-run`. That binary comes from `nvidia-prime`, which appears in neither package list nor either driver set. The documented fix could not be followed on a hyprsimple machine. It is in both driver sets now, and FAQ.md gains a note naming `mesa-utils` for the `glxinfo` in its own verification command.

### 32-bit drivers were requested with multilib possibly off

The legacy branch listed `lib32-nvidia-580xx-utils` unconditionally. Arch ships `[multilib]` commented out, and hyprsimple never edits `pacman.conf`, so on a stock install that name does not resolve either. Upstream lists it unconditionally because it ships its own `pacman.conf` with multilib enabled, which is the same root cause as the AUR problem above. Both branches now check `pacman-conf --repo-list` and say what they skipped. Turing+ gains `lib32-nvidia-utils` under the same guard, which upstream has and this did not.

### What I deliberately did NOT copy from upstream

Upstream also writes `/etc/mkinitcpio.conf.d/nvidia.conf` with `MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)` for early KMS. Copying that would be wrong here: `FAQ.md:79-92` documents a boot hang on Optimus laptops caused by exactly that, the NVIDIA modules loading inside the initramfs, and the remedy is to keep them out. Adding the line would manufacture the bug the FAQ exists to work around.

Upstream's `/etc/modprobe.d/nvidia.conf` with `options nvidia_drm modeset=1` is also not copied. `nvidia-utils` ships `/usr/lib/modprobe.d/nvidia-utils.conf` and `/usr/lib/modules-load.d/nvidia-utils.conf`, so the driver package already covers it.

Suite is 32 checks now. The multilib guard reverted turns 3 red, `nvidia-prime` dropped turns 2 red. 35 suites, 0 failing, three runs. shellcheck clean.