### PR TITLE
Stop setup_network leaving the machine with no DNS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,9 @@ jobs:
       - name: screenshot-and-battery-test
         run: bash test/screenshot-and-battery-test.sh
 
+      - name: setup-network-test
+        run: bash test/setup-network-test.sh
+
       - name: nvidia-install-test
         run: bash test/nvidia-install-test.sh
 

--- a/install.sh
+++ b/install.sh
@@ -419,9 +419,38 @@ setup_network() {
   echo -e "${YELLOW}Setting up Network...${NC}"
   # Prevent boot hanging on network
   sudo systemctl disable systemd-networkd-wait-online.service 2>/dev/null
-  # Symlink systemd-resolved
-  sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
-  echo -e "${GREEN}Network configured${NC}"
+
+  # Both overridable so the suite can arrange a machine without resolved without
+  # touching this one's DNS.
+  local resolv_conf="${HYPRSIMPLE_RESOLV_CONF:-/etc/resolv.conf}"
+  local resolved_stub="${HYPRSIMPLE_RESOLVED_STUB:-/run/systemd/resolve/stub-resolv.conf}"
+
+  # This used to repoint /etc/resolv.conf at the stub unconditionally. Nothing
+  # here installs or enables systemd-resolved, and when it is not running that
+  # path does not exist, so the link dangled and the machine had no DNS at all:
+  # not just afterwards, but for the rest of this script, which still has a
+  # release tag to fetch and two packages to install. setup-dns.sh already
+  # refuses to touch DNS when resolved is not running. This did the more
+  # destructive version of the same thing with no check.
+  if ! systemctl is-active --quiet systemd-resolved; then
+    echo -e "${YELLOW}systemd-resolved is not running, enabling it...${NC}"
+    sudo systemctl enable --now systemd-resolved 2>/dev/null || true
+  fi
+
+  # enable --now returns once the unit is active, which is not quite the same
+  # moment the stub appears.
+  local waited=0
+  while [[ ! -e $resolved_stub ]] && (( waited < 30 )); do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  if [[ -e $resolved_stub ]]; then
+    sudo ln -sf "$resolved_stub" "$resolv_conf"
+    echo -e "${GREEN}Network configured${NC}"
+  else
+    echo -e "${YELLOW}systemd-resolved is not running and could not be started, so $resolv_conf is being left alone. Pointing it at a stub that is not there would leave this machine with no DNS.${NC}"
+  fi
 }
 
 setup_printer() {

--- a/test/setup-network-test.sh
+++ b/test/setup-network-test.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# setup_network repointed /etc/resolv.conf at systemd-resolved's stub without
+# ever asking whether systemd-resolved was running.
+#
+# Nothing in hyprsimple installs or enables it. It is not in packages.txt, and
+# Arch does not enable it on a stock install. On such a machine
+# /run/systemd/resolve/stub-resolv.conf does not exist, so /etc/resolv.conf
+# became a dangling symlink and the host had no DNS at all. Not only afterwards:
+# setup_network runs at install.sh:463, and the script still has a release tag
+# to fetch over the network and two packages to install after that.
+#
+# The same repository already knew. setup-dns.sh:6 refuses to touch DNS when
+# resolved is not running, and says so in a comment. This did the far more
+# destructive version of the same operation with no check at all.
+#
+# This machine has resolved enabled, courtesy of CachyOS, which is why it never
+# showed up here. The paths are overridable so both answers can be arranged
+# without touching the DNS of whatever is running the suite.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+FUNCS="$TMP/funcs.sh"
+sed -n '/^setup_network() {/,/^}/p' "$REPO/install.sh" >"$FUNCS"
+for marker in 'setup_network() {' 'HYPRSIMPLE_RESOLV_CONF' 'is-active --quiet systemd-resolved'; do
+  if grep -qF -- "$marker" "$FUNCS"; then
+    pass "extracted source contains $marker"
+  else
+    fail "extracted source is missing $marker, so nothing below is testing install.sh"
+  fi
+done
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+LOG="$TMP/calls"
+
+# systemctl answers is-active from the test, and `enable --now` creates the stub
+# only when the test says starting resolved works, which is the whole variable.
+cat >"$STUB/systemctl" <<'STUBEOF'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  *"is-active"*"systemd-resolved"*) [[ ${RESOLVED_ACTIVE:-no} == yes ]] && exit 0; exit 3 ;;
+  *"enable --now systemd-resolved"*)
+    if [[ ${RESOLVED_STARTABLE:-no} == yes ]]; then
+      printf 'nameserver 127.0.0.53\n' >"$HYPRSIMPLE_RESOLVED_STUB"; exit 0
+    fi
+    exit 1 ;;
+esac
+exit 0
+STUBEOF
+cat >"$STUB/sudo" <<'STUBEOF'
+#!/bin/bash
+"$@"
+STUBEOF
+chmod +x "$STUB"/*
+
+run_setup_network() {
+  rm -rf "$TMP/root"; mkdir -p "$TMP/root/run"
+  : >"$LOG"
+  # A resolv.conf that something else already manages, so the test can tell
+  # "left alone" apart from "replaced".
+  printf 'nameserver 192.0.2.1\n' >"$TMP/root/resolv.conf"
+  [[ ${1:-no} == yes ]] && printf 'nameserver 127.0.0.53\n' >"$TMP/root/run/stub-resolv.conf"
+  CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" \
+    HYPRSIMPLE_RESOLV_CONF="$TMP/root/resolv.conf" \
+    HYPRSIMPLE_RESOLVED_STUB="$TMP/root/run/stub-resolv.conf" \
+    RESOLVED_ACTIVE="${2:-no}" RESOLVED_STARTABLE="${3:-no}" \
+    bash -c '
+      set -uo pipefail
+      RED=""; GREEN=""; YELLOW=""; NC=""
+      source "'"$FUNCS"'"
+      setup_network
+    ' >"$TMP/out" 2>&1
+}
+
+resolv_state() {
+  local f="$TMP/root/resolv.conf"
+  if [[ -L $f ]]; then
+    [[ -e $f ]] && echo "symlink-live" || echo "symlink-DANGLING"
+  elif [[ -f $f ]]; then echo "regular-file"
+  else echo "missing"; fi
+}
+
+# --- resolved already running: the original intent still happens -------------
+
+run_setup_network yes yes
+check "with resolved running the stub is linked" "$(resolv_state)" "symlink-live"
+check "and the link resolves to the stub" \
+  "$(cat "$TMP/root/resolv.conf")" "nameserver 127.0.0.53"
+check "and it does not try to enable an already running unit" \
+  "$(grep -c 'enable --now systemd-resolved' "$LOG")" "0"
+
+# --- resolved not running but startable: enable it, then link ----------------
+
+run_setup_network no no yes
+check "a stopped but startable resolved is enabled" \
+  "$(grep -c 'enable --now systemd-resolved' "$LOG")" "1"
+check "and the stub is linked once it is up" "$(resolv_state)" "symlink-live"
+
+# --- resolved not running and not startable: leave DNS alone -----------------
+
+run_setup_network no no no
+check "an unstartable resolved leaves resolv.conf as a real file" \
+  "$(resolv_state)" "regular-file"
+check "and the existing nameserver is untouched" \
+  "$(cat "$TMP/root/resolv.conf")" "nameserver 192.0.2.1"
+check "and the reason is stated" \
+  "$(grep -c 'is being left alone' "$TMP/out")" "1"
+check "and it does not claim the network was configured" \
+  "$(grep -c 'Network configured' "$TMP/out")" "0"
+
+# The point of the whole change: never leave a dangling resolv.conf.
+for scenario in "no no no" "no no yes" "yes yes yes"; do
+  # shellcheck disable=SC2086  # three positional arguments, deliberately split
+  run_setup_network $scenario
+  if [[ $(resolv_state) == "symlink-DANGLING" ]]; then
+    fail "scenario '$scenario' left /etc/resolv.conf dangling, which is no DNS"
+  else
+    pass "scenario '$scenario' never leaves resolv.conf dangling"
+  fi
+done
+
+# The boot-hang unit is still disabled in every case, which is the other half of
+# what this function is for.
+check "systemd-networkd-wait-online is still disabled" \
+  "$(grep -c 'disable systemd-networkd-wait-online' "$LOG")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`install.sh:423` repointed `/etc/resolv.conf` at systemd-resolved's stub with no check that systemd-resolved was running:

```bash
sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
```

Nothing in hyprsimple installs or enables systemd-resolved. It is not in `packages.txt`, and Arch does not enable it on a stock install. On such a machine `/run/systemd/resolve/stub-resolv.conf` does not exist, so this replaces a working `resolv.conf` with a **dangling symlink**: the host has no DNS at all.

Not only afterwards. `setup_network` runs at `install.sh:463`, and what comes after it needs the network:

- `install.sh:552` / `561` — `git ls-remote` and `git fetch` for the release tag
- `install.sh:732` — `muslimtify daemon install`
- `install.sh:736` — installing `thermald`

So the installer breaks DNS partway through and then fails at its own remaining steps, in ways that look unrelated to what caused them.

## The repository already knew

`.local/bin/setup-dns.sh:6` guards the same subsystem, with the reason spelled out directly above it:

```bash
# systemd-resolved is not in packages.txt, so it is not guaranteed to be the
# resolver on this machine. ...
if ! systemctl is-active --quiet systemd-resolved; then
  echo "systemd-resolved is not running, so this script cannot set your DNS." >&2
```

`setup-dns.sh` refuses to write a config file. `install.sh` replaced `/etc/resolv.conf` itself, and checked nothing.

## The fix

Start resolved if it is not running, wait for the stub to appear, and link only once it is actually there. If resolved cannot be started, `resolv.conf` is left exactly as it was and the reason is printed. Whatever manages it today is working; a dangling link is not.

## Why it never showed up here

This machine has systemd-resolved enabled courtesy of CachyOS, the same reason the NVIDIA problems in #74 stayed hidden. That is now three defects from one root cause: code that assumes a platform property the distribution supplies and hyprsimple does not.

## Tests

`test/setup-network-test.sh`, 16 checks, covering resolved running, stopped but startable, and stopped and unstartable. Both paths are overridable (`HYPRSIMPLE_RESOLV_CONF`, `HYPRSIMPLE_RESOLVED_STUB`) following `HYPRSIMPLE_SYSFS_NET` in `wifi.sh`, so the suite arranges a machine without resolved and never touches the DNS of the host running it. Three checks assert the function extraction found the real code first.

One check is the invariant rather than a scenario: across all three scenarios, `resolv.conf` is never left dangling.

Restoring the unconditional symlink turns 9 checks red, including `got symlink-DANGLING` and the previously working nameserver reading empty. My first sabotage attempt cut too much and broke the file's syntax, so it proved nothing; the numbers above are from the corrected one, verified with `bash -n` first.

Sweep: 36 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. `/etc/resolv.conf` on this machine is unchanged and still resolves.