### PR TITLE
Remove two rofi theme links that never pointed at anything

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,9 @@ jobs:
       - name: screenshot-and-battery-test
         run: bash test/screenshot-and-battery-test.sh
 
+      - name: rofi-theme-link-test
+        run: bash test/rofi-theme-link-test.sh
+
       - name: setup-network-test
         run: bash test/setup-network-test.sh
 

--- a/install.sh
+++ b/install.sh
@@ -723,9 +723,16 @@ ln -sfn "$HYPRSIMPLE_PATH/default/hypr" "$HOME/.config/hypr/hyprsimple"
 # migration, the same guarantee dunstrc.d and hypr/hyprsimple already give.
 ln -sfn "$HYPRSIMPLE_PATH/default/rofi" "$HOME/.config/rofi/hyprsimple"
 
-# One-time setup: symlink rofi launcher/powermenu dirs to the default theme
-ln -sfn "$THEME_DIR/rofi/launcher" "$HOME/.config/rofi/launcher"
-ln -sfn "$THEME_DIR/rofi/powermenu" "$HOME/.config/rofi/powermenu"
+# There were two `ln -sfn "$THEME_DIR/rofi/<type>" ~/.config/rofi/<type>` lines
+# here, meant to point the rofi directories at the active theme. They did
+# neither thing. ~/.config/rofi/launcher is a real directory by then, copied
+# from .config/rofi above, and `ln -s` given an existing directory writes the
+# link inside it, so the result was ~/.config/rofi/launcher/launcher. And no
+# theme has ever shipped a rofi/ directory, so the target did not exist either
+# way and both links dangled from the moment they were made.
+#
+# theme-switcher.sh is what actually themes rofi: it writes images/ and patches
+# style.rasi inside those real directories. Nothing was ever reading the links.
 
 # Enable live wallpaper by default (theme-switcher reads this when writing hyprpaper.conf)
 touch "$CACHE_DIR/live_wallpaper_enabled"

--- a/migrations/1788620441.sh
+++ b/migrations/1788620441.sh
@@ -1,0 +1,32 @@
+echo "Remove the two dangling rofi theme links"
+
+# install.sh tried to point ~/.config/rofi/launcher and .../powermenu at the
+# active theme with `ln -sfn "$THEME_DIR/rofi/<type>" "$HOME/.config/rofi/<type>"`.
+# Both halves were wrong. By that point ~/.config/rofi/launcher is a real
+# directory, copied from the repository's .config/rofi, and `ln -s` given an
+# existing directory writes the link inside it rather than replacing it, so what
+# appeared was ~/.config/rofi/launcher/launcher. And no theme has ever shipped a
+# rofi/ directory, so the target did not exist and the link dangled from birth.
+#
+# They were never read. theme-switcher.sh themes rofi by writing images/ and
+# patching style.rasi inside the real directories.
+#
+# Only a link that does not resolve and points into a theme's rofi/ is removed.
+# Anything else in that spot belongs to whoever put it there.
+
+for type in launcher powermenu; do
+  link="$HOME/.config/rofi/$type/$type"
+
+  [[ -L $link ]] || continue
+  [[ -e $link ]] && continue
+
+  target=$(readlink "$link")
+  case "$target" in
+    */themes/*/rofi/"$type") ;;
+    *) continue ;;
+  esac
+
+  rm -f "$link"
+  echo "  Removed $link"
+  echo "  It pointed at $target, which no theme has."
+done

--- a/test/rofi-theme-link-test.sh
+++ b/test/rofi-theme-link-test.sh
@@ -69,7 +69,7 @@ check "no shipped theme has a rofi directory, which is what made the link dangle
 # --- the migration removes what earlier installs already have ----------------
 
 mk_home() {
-  rm -rf "$TMP/home"
+  rm -rf "${TMP:?}/home"
   mkdir -p "$TMP/home/.config/rofi/launcher" "$TMP/home/.config/rofi/powermenu"
   mkdir -p "$TMP/home/.config/hypr/themes/deep-sea"
   # The real directories carry real files, as they do on a live install.

--- a/test/rofi-theme-link-test.sh
+++ b/test/rofi-theme-link-test.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# install.sh carried two lines meant to point the rofi directories at the
+# active theme:
+#
+#   ln -sfn "$THEME_DIR/rofi/launcher"  "$HOME/.config/rofi/launcher"
+#   ln -sfn "$THEME_DIR/rofi/powermenu" "$HOME/.config/rofi/powermenu"
+#
+# Both halves were wrong, independently.
+#
+# By the time they ran, ~/.config/rofi/launcher was a real directory, copied
+# from the repository's .config/rofi a few hundred lines earlier. `ln -s` given
+# an existing directory writes the link inside it rather than replacing it, so
+# what actually appeared was ~/.config/rofi/launcher/launcher.
+#
+# And no theme has ever shipped a rofi/ directory. All sixteen lack one. So the
+# target did not exist and the link dangled from the moment it was created.
+#
+# Measured on the maintainer's machine before the fix:
+#   ~/.config/rofi/launcher/launcher  -> .../themes/deep-sea/rofi/launcher  BROKEN
+#   ~/.config/rofi/powermenu/powermenu -> .../themes/deep-sea/rofi/powermenu BROKEN
+#
+# Both pointed at deep-sea, the install-time default, while the active theme was
+# rosepine. Nothing read them. theme-switcher.sh themes rofi by writing images/
+# and patching style.rasi inside the real directories.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$REPO/migrations/1788620441.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the lines are gone from install.sh -------------------------------------
+
+check "install.sh no longer links rofi/launcher at a theme" \
+  "$(grep -c 'ln -sfn "\$THEME_DIR/rofi/launcher"' "$REPO/install.sh")" "0"
+check "install.sh no longer links rofi/powermenu at a theme" \
+  "$(grep -c 'ln -sfn "\$THEME_DIR/rofi/powermenu"' "$REPO/install.sh")" "0"
+
+# The links it does still make are the ones that work, so this is not a check
+# that install.sh stopped linking anything at all.
+check "the hyprsimple defaults link is still made" \
+  "$(grep -c 'ln -sfn "\$HYPRSIMPLE_PATH/default/rofi" "\$HOME/.config/rofi/hyprsimple"' "$REPO/install.sh")" "1"
+
+# --- no shipped theme has the directory those lines pointed at ---------------
+
+themes=0; with_rofi=0
+for theme in "$REPO/.config/hypr/themes"/*/; do
+  [[ -d $theme ]] || continue
+  themes=$((themes + 1))
+  [[ -d $theme/rofi ]] && with_rofi=$((with_rofi + 1))
+done
+if (( themes < 5 )); then
+  fail "found only $themes themes, so this check is not looking at the real set"
+else
+  pass "checked $themes shipped themes"
+fi
+check "no shipped theme has a rofi directory, which is what made the link dangle" \
+  "$with_rofi" "0"
+
+# --- the migration removes what earlier installs already have ----------------
+
+mk_home() {
+  rm -rf "$TMP/home"
+  mkdir -p "$TMP/home/.config/rofi/launcher" "$TMP/home/.config/rofi/powermenu"
+  mkdir -p "$TMP/home/.config/hypr/themes/deep-sea"
+  # The real directories carry real files, as they do on a live install.
+  printf 'x\n' >"$TMP/home/.config/rofi/launcher/style.rasi"
+  printf 'x\n' >"$TMP/home/.config/rofi/powermenu/style.rasi"
+}
+migration_rc=0
+run_migration() {
+  HOME="$TMP/home" bash "$MIGRATION" >"$TMP/out" 2>&1
+  migration_rc=$?
+}
+
+# The exact shape a pre-fix install leaves behind.
+mk_home
+ln -sfn "$TMP/home/.config/hypr/themes/deep-sea/rofi/launcher" "$TMP/home/.config/rofi/launcher/launcher"
+ln -sfn "$TMP/home/.config/hypr/themes/deep-sea/rofi/powermenu" "$TMP/home/.config/rofi/powermenu/powermenu"
+check "the fixture reproduces the bug: the launcher link is broken" \
+  "$([[ -L $TMP/home/.config/rofi/launcher/launcher && ! -e $TMP/home/.config/rofi/launcher/launcher ]] && echo broken || echo no)" "broken"
+
+run_migration
+check "the migration removes the launcher link" \
+  "$([[ -e $TMP/home/.config/rofi/launcher/launcher || -L $TMP/home/.config/rofi/launcher/launcher ]] && echo present || echo gone)" "gone"
+check "and the powermenu link" \
+  "$([[ -e $TMP/home/.config/rofi/powermenu/powermenu || -L $TMP/home/.config/rofi/powermenu/powermenu ]] && echo present || echo gone)" "gone"
+check "and leaves the real files alone" \
+  "$([[ -f $TMP/home/.config/rofi/launcher/style.rasi ]] && echo kept || echo lost)" "kept"
+check "and reports both" "$(grep -c '^  Removed ' "$TMP/out")" "2"
+
+run_migration
+check "re-running reports nothing" "$(grep -c '^  Removed ' "$TMP/out")" "0"
+check "and still exits 0" "$migration_rc" "0"
+
+# --- what it must not touch --------------------------------------------------
+
+mk_home
+mkdir -p "$TMP/home/.config/hypr/themes/deep-sea/rofi/launcher"
+ln -sfn "$TMP/home/.config/hypr/themes/deep-sea/rofi/launcher" "$TMP/home/.config/rofi/launcher/launcher"
+run_migration
+check "a link that does resolve is left alone" \
+  "$([[ -L $TMP/home/.config/rofi/launcher/launcher ]] && echo kept || echo removed)" "kept"
+
+mk_home
+ln -sfn "$TMP/home/somewhere-else" "$TMP/home/.config/rofi/launcher/launcher"
+run_migration
+check "a broken link pointing somewhere else is left alone" \
+  "$([[ -L $TMP/home/.config/rofi/launcher/launcher ]] && echo kept || echo removed)" "kept"
+
+mk_home
+mkdir -p "$TMP/home/.config/rofi/launcher/launcher"
+run_migration
+check "a real directory in that spot is left alone" \
+  "$([[ -d $TMP/home/.config/rofi/launcher/launcher ]] && echo kept || echo removed)" "kept"
+
+mk_home
+run_migration
+check "a home that never had the links removes nothing" \
+  "$(grep -c '^  Removed ' "$TMP/out")" "0"
+check "and exits 0" "$migration_rc" "0"
+check "and prints only its title, as every migration does" \
+  "$(wc -l <"$TMP/out")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Two lines in `install.sh` were meant to point the rofi directories at the active theme:

```bash
ln -sfn "$THEME_DIR/rofi/launcher"  "$HOME/.config/rofi/launcher"
ln -sfn "$THEME_DIR/rofi/powermenu" "$HOME/.config/rofi/powermenu"
```

Both halves were wrong, independently.

**The link landed one level too deep.** By the time these ran, `~/.config/rofi/launcher` was a real directory, copied from the repository's `.config/rofi` a few hundred lines earlier. `ln -s` given an existing directory writes the link *inside* it rather than replacing it. What appeared was `~/.config/rofi/launcher/launcher`.

**The target did not exist.** No theme has ever shipped a `rofi/` directory. All seventeen lack one, so the link dangled from the moment it was created.

Measured on this machine before the fix:

```
~/.config/rofi/launcher/launcher   -> .../themes/deep-sea/rofi/launcher    BROKEN
~/.config/rofi/powermenu/powermenu -> .../themes/deep-sea/rofi/powermenu   BROKEN
```

Both pointing at `deep-sea`, the install-time default, while the active theme was `rosepine`.

## Nothing was reading them

`theme-switcher.sh:113-121` is what actually themes rofi: it writes `images/` and patches `style.rasi` inside the real directories. That is why removing these changes nothing a user can see, and why the failure sat there unnoticed since the lines were written.

The `ln -sfn "$HYPRSIMPLE_PATH/default/rofi" ~/.config/rofi/hyprsimple` link on the line above is a different thing, works, and is untouched. A check asserts it survives, so this is not a change that stopped `install.sh` linking anything at all.

## Migration

`migrations/1788620441.sh` removes the two links from installs that already have them, and only when the link does not resolve **and** points into a theme's `rofi/`. A link that resolves, a broken link pointing elsewhere, and a real directory in that spot are each left alone, with a check for each.

## Tests

`test/rofi-theme-link-test.sh`, 19 checks. One asserts the fixture actually reproduces the bug before the migration runs, and one counts the shipped themes before concluding that none of them has a `rofi/` directory, so neither conclusion can come from an empty search.

Restoring the two lines turns 2 checks red. Making the migration remove any symlink regardless of target turns 1 red. Sweep: 37 suites, 0 failing, three consecutive runs. shellcheck clean at `style`.

One fix to my own test in this branch: shellcheck caught `rm -rf "$TMP/home"` in the teardown, which would expand to `/home` if `TMP` were ever empty. It is `${TMP:?}` now.