### PR TITLE
Stop forcing every OpenGL application onto the discrete GPU

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,6 +136,9 @@ jobs:
       - name: setup-network-test
         run: bash test/setup-network-test.sh
 
+      - name: hybrid-gpu-env-test
+        run: bash test/hybrid-gpu-env-test.sh
+
       - name: nvidia-install-test
         run: bash test/nvidia-install-test.sh
 

--- a/install.sh
+++ b/install.sh
@@ -215,6 +215,35 @@ detect_and_install_nvidia() {
     return 0
   fi
 
+  # On a hybrid machine the desktop is rendered by the integrated GPU:
+  # detect_and_setup_multi_gpu below prefers Intel, then AMD, then NVIDIA, and
+  # points AQ_DRM_DEVICES at whichever it picks. Exporting
+  # __GLX_VENDOR_LIBRARY_NAME=nvidia on top of that sends every OpenGL
+  # application to the discrete card anyway, so frames are rendered on the dGPU
+  # and copied back to the iGPU that owns the display, and the dGPU never
+  # powers down. Measured on an Optimus laptop with this block in place,
+  # glxinfo reported "NVIDIA GeForce RTX 4050 Laptop GPU"; with the same three
+  # variables unset, "Mesa Intel(R) Graphics (RPL-P)". Choosing the discrete
+  # card per application is what prime-run is for.
+  #
+  # Upstream writes this block unconditionally and has no equivalent of
+  # detect_and_setup_multi_gpu, so there it is consistent with the rest of the
+  # configuration. Here it contradicted it.
+  #
+  # The same two lspci forms detect_and_setup_multi_gpu uses, so the two
+  # functions cannot disagree about what this machine is.
+  local other_gpu
+  other_gpu=$(lspci -D | grep -iE "VGA.*Intel" | head -1 | cut -d' ' -f1 || true)
+  [[ -z $other_gpu ]] &&
+    other_gpu=$(lspci -D -d ::0300 | grep -i "AMD" | head -1 | cut -d' ' -f1 || true)
+
+  if [[ -n $other_gpu ]]; then
+    echo -e "${GREEN}An integrated GPU is present at $other_gpu, so it will drive the desktop and the NVIDIA environment variables are being left out. Setting them would push every OpenGL application onto the discrete card.${NC}"
+    echo -e "${GREEN}Run a single program on the NVIDIA GPU with: prime-run <program>${NC}"
+    echo -e "${GREEN}NVIDIA setup complete (arch: $GPU_ARCH, offload only)${NC}"
+    return 0
+  fi
+
   # Append NVIDIA env vars to uwsm/env
   if [[ $GPU_ARCH = "turing_plus" ]]; then
     cat >>"$HOME/.config/uwsm/env" <<'EOF'

--- a/migrations/1788623900.sh
+++ b/migrations/1788623900.sh
@@ -1,0 +1,52 @@
+echo "Stop forcing every OpenGL application onto the discrete GPU"
+
+# install.sh appended a block to ~/.config/uwsm/env whenever it found an NVIDIA
+# GPU, without asking whether that GPU drives the desktop:
+#
+#   # NVIDIA (Turing+ with GSP firmware) - auto-detected by installer
+#   export NVD_BACKEND=direct
+#   export LIBVA_DRIVER_NAME=nvidia
+#   export __GLX_VENDOR_LIBRARY_NAME=nvidia
+#
+# On a hybrid laptop it does not. detect_and_setup_multi_gpu prefers the
+# integrated GPU and points AQ_DRM_DEVICES at it, so Hyprland renders on Intel
+# or AMD while those variables send every OpenGL application to the discrete
+# card. The frames are then copied back to the GPU that owns the display, and
+# the dGPU cannot power down. Measured on an Optimus laptop: with the block,
+# glxinfo reported the RTX 4050; without it, the Intel iGPU.
+#
+# Removed only on a machine that has an integrated GPU. A desktop whose only
+# card is NVIDIA needs these and keeps them. prime-run still puts a single
+# program on the discrete card.
+
+ENV_FILE="$HOME/.config/uwsm/env"
+
+[[ -f $ENV_FILE ]] || exit 0
+grep -q '^export __GLX_VENDOR_LIBRARY_NAME=nvidia$' "$ENV_FILE" || exit 0
+
+command -v lspci >/dev/null 2>&1 || exit 0
+other_gpu=$(lspci -D | grep -iE "VGA.*Intel" | head -1 | cut -d' ' -f1)
+[[ -n $other_gpu ]] ||
+  other_gpu=$(lspci -D -d ::0300 | grep -i "AMD" | head -1 | cut -d' ' -f1)
+
+if [[ -z $other_gpu ]]; then
+  echo "  This machine has no integrated GPU, so the NVIDIA variables are correct here and are being kept."
+  exit 0
+fi
+
+cp -f "$ENV_FILE" "$ENV_FILE.bak"
+
+# Only the block install.sh wrote: its comment line, and the exports that
+# follow it. A hand-written export elsewhere in the file is left alone.
+awk '
+  /^# NVIDIA \(.*\) - auto-detected by installer$/ { skip = 1; next }
+  skip && /^export (NVD_BACKEND|LIBVA_DRIVER_NAME|__GLX_VENDOR_LIBRARY_NAME)=/ { next }
+  skip { skip = 0 }
+  { print }
+' "$ENV_FILE.bak" >"$ENV_FILE"
+
+echo "  Removed the NVIDIA environment block from $ENV_FILE"
+echo "  Your previous version is at $ENV_FILE.bak"
+echo "  The desktop renders on the integrated GPU at $other_gpu, which is what AQ_DRM_DEVICES already says."
+echo "  Run one program on the NVIDIA GPU with: prime-run <program>"
+echo "  This takes effect at your next login."

--- a/test/hybrid-gpu-env-test.sh
+++ b/test/hybrid-gpu-env-test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# install.sh appended this to ~/.config/uwsm/env on any machine with an NVIDIA
+# GPU, without asking whether that GPU drives the desktop:
+#
+#   export NVD_BACKEND=direct
+#   export LIBVA_DRIVER_NAME=nvidia
+#   export __GLX_VENDOR_LIBRARY_NAME=nvidia
+#
+# On a hybrid laptop it does not drive the desktop. detect_and_setup_multi_gpu
+# prefers Intel, then AMD, then NVIDIA, and points AQ_DRM_DEVICES at what it
+# picks, so Hyprland renders on the integrated GPU. Those variables then send
+# every OpenGL application to the discrete card, whose frames have to be copied
+# back to the GPU that owns the display, and which never powers down.
+#
+# Measured on an Optimus laptop, inside the running session's own environment:
+#
+#   with the block     OpenGL renderer string: NVIDIA GeForce RTX 4050 Laptop GPU
+#   with it unset      OpenGL renderer string: Mesa Intel(R) Graphics (RPL-P)
+#
+# Upstream writes the same block and has no equivalent of
+# detect_and_setup_multi_gpu, so there it is consistent. hyprsimple added the
+# GPU selection and left this half alone, and the two contradicted each other.
+#
+# A desktop whose only card is NVIDIA still needs the block and keeps it. Both
+# answers are exercised here.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$REPO/migrations/1788623900.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+FUNCS="$TMP/funcs.sh"
+sed -n '/^detect_and_install_nvidia() {/,/^}/p' "$REPO/install.sh" >"$FUNCS"
+sed -n '/^install_packages() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
+for marker in 'detect_and_install_nvidia() {' 'other_gpu' '__GLX_VENDOR_LIBRARY_NAME'; do
+  if grep -qF -- "$marker" "$FUNCS"; then
+    pass "extracted source contains $marker"
+  else
+    fail "extracted source is missing $marker, so nothing below is testing install.sh"
+  fi
+done
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+LOG="$TMP/calls"
+
+# lspci answers with whichever machine the test is describing. Both the plain
+# and the -d ::0300 form have to be handled, because install.sh uses both.
+cat >"$STUB/lspci" <<'STUBEOF'
+#!/bin/bash
+printf '01:00.0 VGA compatible controller: NVIDIA Corporation AD107M [GeForce RTX 4050 Max-Q / Mobile]\n'
+case "${IGPU:-none}" in
+  intel) printf '00:02.0 VGA compatible controller: Intel Corporation Raptor Lake-P [UHD Graphics]\n' ;;
+  amd)   printf '05:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Rembrandt\n' ;;
+esac
+STUBEOF
+cat >"$STUB/pacman" <<'STUBEOF'
+#!/bin/bash
+case "${1:-}" in
+  -Si) exit 1 ;;
+  -Qq) [[ $2 == nvidia-utils ]] && exit 0; exit 1 ;;
+esac
+printf 'pacman %s\n' "$*" >>"$CALL_LOG"
+exit 0
+STUBEOF
+cat >"$STUB/pacman-conf" <<'STUBEOF'
+#!/bin/bash
+printf 'core\nextra\nmultilib\n'
+STUBEOF
+cat >"$STUB/sudo" <<'STUBEOF'
+#!/bin/bash
+"$@"
+STUBEOF
+for t in mkinitcpio paru; do
+  printf '#!/bin/bash\nprintf "%s %%s\\n" "$*" >>"$CALL_LOG"\nexit 0\n' "$t" >"$STUB/$t"
+done
+chmod +x "$STUB"/*
+
+MODULES="$TMP/modules/$(uname -r)"; mkdir -p "$MODULES"; printf 'linux\n' >"$MODULES/pkgbase"
+
+HOME_DIR="$TMP/home"
+run_nvidia() {
+  rm -rf "${TMP:?}/home"; mkdir -p "$HOME_DIR/.config/uwsm"
+  : >"$LOG"
+  HOME="$HOME_DIR" CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" IGPU="$1" \
+    HYPRSIMPLE_MODULES_DIR="$TMP/modules" \
+    bash -c '
+      set -uo pipefail
+      RED=""; GREEN=""; YELLOW=""; NC=""
+      AUR_HELPER="paru"; DOTFILES_DIR="'"$REPO"'"; FAILED_PACKAGES=()
+      source "'"$FUNCS"'"
+      detect_and_install_nvidia
+    ' >"$TMP/out" 2>&1
+}
+env_file() { cat "$HOME_DIR/.config/uwsm/env" 2>/dev/null; }
+
+# --- a hybrid machine gets no global override -------------------------------
+
+for igpu in intel amd; do
+  run_nvidia "$igpu"
+  check "with an $igpu iGPU, GLX is not forced to nvidia" \
+    "$(env_file | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
+  check "and VA-API is not either ($igpu)" \
+    "$(env_file | grep -c 'LIBVA_DRIVER_NAME')" "0"
+  check "and prime-run is named as the way to use the dGPU ($igpu)" \
+    "$(grep -c 'prime-run' "$TMP/out")" "1"
+done
+
+# The driver still installs. Without this the fix could be a way to skip NVIDIA
+# support altogether on every laptop.
+run_nvidia intel
+check "the driver is still installed on a hybrid machine" \
+  "$(grep -c 'nvidia-open-dkms' "$LOG")" "1"
+check "and the setup still reports completion" \
+  "$(grep -c 'NVIDIA setup complete' "$TMP/out")" "1"
+
+# --- an NVIDIA-only machine still gets it -----------------------------------
+
+run_nvidia none
+check "with no iGPU the GLX vendor is still exported" \
+  "$(env_file | grep -c 'export __GLX_VENDOR_LIBRARY_NAME=nvidia')" "1"
+check "and the backend with it" "$(env_file | grep -c 'NVD_BACKEND=direct')" "1"
+check "and the initramfs is rebuilt" "$(grep -c '^mkinitcpio' "$LOG")" "1"
+
+# --- the migration, for machines already carrying the block -----------------
+
+mk_env() {
+  rm -rf "${TMP:?}/mhome"; mkdir -p "$TMP/mhome/.config/uwsm"
+  cat >"$TMP/mhome/.config/uwsm/env" <<'ENVEOF'
+export XCURSOR_SIZE=24
+export GDK_BACKEND="wayland,x11,*"
+
+# NVIDIA (Turing+ with GSP firmware) - auto-detected by installer
+export NVD_BACKEND=direct
+export LIBVA_DRIVER_NAME=nvidia
+export __GLX_VENDOR_LIBRARY_NAME=nvidia
+export XCURSOR_THEME=Bibata
+ENVEOF
+}
+run_migration() {
+  HOME="$TMP/mhome" IGPU="$1" PATH="$STUB:/usr/bin:/bin" \
+    bash "$MIGRATION" >"$TMP/mout" 2>&1
+}
+menv() { cat "$TMP/mhome/.config/uwsm/env"; }
+
+mk_env
+check "the fixture starts with the block present" \
+  "$(menv | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "1"
+run_migration intel
+check "the migration removes the GLX override" \
+  "$(menv | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "0"
+check "and the VA-API one" "$(menv | grep -c 'LIBVA_DRIVER_NAME')" "0"
+check "and the backend" "$(menv | grep -c 'NVD_BACKEND')" "0"
+check "and its comment line" "$(menv | grep -c 'auto-detected by installer')" "0"
+check "and keeps everything else" \
+  "$(menv | grep -c 'GDK_BACKEND\|XCURSOR_SIZE\|XCURSOR_THEME')" "3"
+check "and leaves a backup" \
+  "$([[ -f $TMP/mhome/.config/uwsm/env.bak ]] && echo yes || echo no)" "yes"
+
+run_migration intel
+check "re-running changes nothing more" \
+  "$(menv | grep -c 'GDK_BACKEND\|XCURSOR_SIZE\|XCURSOR_THEME')" "3"
+
+# An NVIDIA-only machine must keep the block.
+mk_env
+run_migration none
+check "a machine with no iGPU keeps the block" \
+  "$(menv | grep -c '__GLX_VENDOR_LIBRARY_NAME')" "1"
+check "and says why" "$(grep -c 'no integrated GPU' "$TMP/mout")" "1"
+check "and writes no backup, having changed nothing" \
+  "$([[ -f $TMP/mhome/.config/uwsm/env.bak ]] && echo yes || echo no)" "no"
+
+# A file that never had the block is untouched.
+rm -rf "${TMP:?}/mhome"; mkdir -p "$TMP/mhome/.config/uwsm"
+printf 'export GDK_BACKEND=wayland\n' >"$TMP/mhome/.config/uwsm/env"
+run_migration intel
+check "an env file without the block is left alone" \
+  "$(menv)" "export GDK_BACKEND=wayland"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/nvidia-install-test.sh
+++ b/test/nvidia-install-test.sh
@@ -53,9 +53,16 @@ done
 STUB="$TMP/bin"; mkdir -p "$STUB"
 LOG="$TMP/calls"
 
+# Whether an integrated GPU is present decides more than which driver is
+# installed: on a hybrid machine detect_and_install_nvidia deliberately leaves
+# the environment block out, because the desktop renders on the iGPU. The
+# checks below are about the driver and the env block, so they describe a
+# machine whose only card is NVIDIA. hybrid-gpu-env-test.sh covers the other
+# answer.
 cat >"$STUB/lspci" <<'STUBEOF'
 #!/bin/bash
-printf '00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n'
+[[ ${IGPU:-none} == intel ]] &&
+  printf '00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n'
 printf '01:00.0 VGA compatible controller: NVIDIA Corporation %s\n' "$NVIDIA_MODEL"
 STUBEOF
 
@@ -126,7 +133,7 @@ run_nvidia() {
     HYPRSIMPLE_MODULES_DIR="$TMP/modules" \
     NVIDIA_MODEL="$1" INSTALLED="$2" INSTALL_RC="${3:-0}" \
     REPO_PACKAGES="${4:-}" MULTILIB="${5:-on}" \
-    INSTALLED_MODULE_PKG="${6:-}" \
+    INSTALLED_MODULE_PKG="${6:-}" IGPU="${7:-none}" \
     bash -c '
       set -uo pipefail
       RED=""; GREEN=""; YELLOW=""; NC=""
@@ -266,7 +273,7 @@ cat >"$STUB/lspci" <<'STUBEOF'
 printf '00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n'
 STUBEOF
 chmod +x "$STUB/lspci"
-run_nvidia "" ""
+run_nvidia "" "" 0 "" on "" intel
 check "a machine with no NVIDIA GPU installs nothing" \
   "$(grep -c 'nvidia' "$LOG")" "0"
 check "and says so" "$(grep -c 'No NVIDIA GPU detected' "$TMP/out")" "1"


### PR DESCRIPTION
`install.sh` appended this to `~/.config/uwsm/env` on any machine with an NVIDIA GPU, without asking whether that GPU drives the desktop:

```bash
export NVD_BACKEND=direct
export LIBVA_DRIVER_NAME=nvidia
export __GLX_VENDOR_LIBRARY_NAME=nvidia
```

On a hybrid laptop it does not drive the desktop. `detect_and_setup_multi_gpu`, twenty lines further down the same file, prefers Intel, then AMD, then NVIDIA, and points `AQ_DRM_DEVICES` at what it picks — so Hyprland renders on the **integrated** GPU. Those variables then send every OpenGL application to the **discrete** one, whose frames have to be copied back to the GPU that owns the display, and which cannot power down while anything is running.

Measured on an Optimus laptop, inside the running session's own environment:

```
with the block   OpenGL renderer string: NVIDIA GeForce RTX 4050 Laptop GPU/PCIe/SSE2
with it unset    OpenGL renderer string: Mesa Intel(R) Graphics (RPL-P)
```

while that same session has `AQ_DRM_DEVICES=/dev/dri/intel-gpu`.

## Where the contradiction came from

Upstream writes the same block and has **no** equivalent of `detect_and_setup_multi_gpu` — checked, nothing there mentions `AQ_DRM_DEVICES` or selects a primary GPU. So upstream is internally consistent: NVIDIA drives everything. hyprsimple added the GPU selection and left this half alone, and the two halves have contradicted each other since.

## What changes

Only whether those three variables are written. On a machine with an integrated GPU they are skipped and `prime-run` is named as the way to put one program on the discrete card. On a machine whose only card is NVIDIA they are written exactly as before.

The driver, the headers, the 32-bit packages and the initramfs rebuild are unchanged on both. A check asserts the driver still installs on the hybrid path, so this cannot become a way to skip NVIDIA support on every laptop.

## Migration

`migrations/1788623900.sh` removes the block from machines already carrying it, and only when an integrated GPU is present, using the same two `lspci` forms `detect_and_setup_multi_gpu` uses so the two cannot disagree about what the machine is. It keeps a `.bak`, removes only the comment line `install.sh` wrote and the exports beneath it, and leaves the rest of the file untouched. An NVIDIA-only desktop keeps the block and is told why.

## Tests

`test/hybrid-gpu-env-test.sh`, 26 checks: Intel iGPU, AMD iGPU, and no iGPU, across both the installer and the migration. Three of them assert the function extraction found the real code first.

Sabotage: writing the block unconditionally again turns 7 red; making the migration ignore whether an iGPU exists turns 3 red.

## One suite I had to correct

`nvidia-install-test.sh` began failing 5 checks. Its `lspci` stub always printed an Intel iGPU alongside the NVIDIA card, so with this change its env-block checks were describing a hybrid machine while asserting the desktop-only behaviour. It now takes an iGPU argument and those checks describe an NVIDIA-only machine, which is what they were always about.

Sweep: 39 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. This machine's own `uwsm/env` is unchanged and no `.bak` was written, checked after the sweeps.