### PR TITLE
Persist the cursor theme, so it survives a login and reaches XWayland

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,9 @@ jobs:
       - name: waybar-refresh-test
         run: bash test/waybar-refresh-test.sh
 
+      - name: cursor-theme-test
+        run: bash test/cursor-theme-test.sh
+
       - name: theme-picker-test
         run: bash test/theme-picker-test.sh
 

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -166,10 +166,31 @@ elif [[ -f "$THEME_PATH/icon-theme" ]]; then
   gsettings set org.gnome.desktop.interface icon-theme "$(cat "$THEME_PATH/icon-theme")"
 fi
 
+# Replace one export in uwsm/env rather than appending another. The file is
+# read once at login, so a second export of the same name would win silently
+# and the file would grow a line per theme switch.
+set_session_env() {
+  local name="$1" value="$2"
+  local file="$HOME/.config/uwsm/env"
+  [[ -f $file ]] || return 0
+  local tmp="$file.tmp.$$"
+  grep -v "^export $name=" "$file" >"$tmp" || true
+  printf 'export %s=%s\n' "$name" "$value" >>"$tmp"
+  mv "$tmp" "$file"
+}
+
 if [[ -f "$THEME_PATH/cursor-theme" ]]; then
   CURSOR="$(cat "$THEME_PATH/cursor-theme")"
   gsettings set org.gnome.desktop.interface cursor-theme "$CURSOR"
   [[ -z "$THEME_SWITCHER_NO_RELOAD" ]] && hyprctl setcursor "$CURSOR" 24
+
+  # gsettings reaches GTK and `hyprctl setcursor` reaches Hyprland, but only
+  # until logout. XCURSOR_THEME is what survives a login and what XWayland, SDL
+  # and Qt read, and nothing here ever wrote it: install.sh wrote it once, and
+  # only if the theme it installed with declared a cursor. The default theme is
+  # deep-sea, which does not, so on a fresh install it was never set at all,
+  # and switching to a theme that does declare one did not set it either.
+  set_session_env XCURSOR_THEME "$CURSOR"
 fi
 
 # 11. Reload Services (skipped during install via THEME_SWITCHER_NO_RELOAD=1)

--- a/install.sh
+++ b/install.sh
@@ -729,7 +729,6 @@ fi
 DEFAULT_THEME="deep-sea"
 echo ""
 echo -e "${YELLOW}Initializing Theme Manager (Default: ${DEFAULT_THEME})...${NC}"
-THEME_DIR="$HOME/.config/hypr/themes/$DEFAULT_THEME"
 CACHE_DIR="$HOME/.cache"
 mkdir -p "$CACHE_DIR"
 mkdir -p "$HOME/.config/btop/themes"
@@ -769,11 +768,10 @@ touch "$CACHE_DIR/live_wallpaper_enabled"
 # Apply the default theme via theme-switcher.sh (skip runtime reloads — Hyprland isn't running yet)
 THEME_SWITCHER_NO_RELOAD=1 bash "$HOME/.local/bin/theme-switcher.sh" "$DEFAULT_THEME"
 
-# Install-only: persist cursor theme into uwsm/env so it's available on next login
-if [[ -f "$THEME_DIR/cursor-theme" ]]; then
-  CURSOR="$(cat "$THEME_DIR/cursor-theme")"
-  echo "export XCURSOR_THEME=$CURSOR" >> "$HOME/.config/uwsm/env"
-fi
+# The cursor theme is persisted by theme-switcher.sh, which the line above just
+# ran. It used to be done here instead, which meant it happened only at install
+# time and only for whichever theme was the default, so switching themes later
+# never updated it.
 echo -e "${GREEN}Theme initialized${NC}"
 
 mkdir -p ~/Videos

--- a/test/cursor-theme-test.sh
+++ b/test/cursor-theme-test.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# The cursor a theme declares never survived a login, and on a fresh install it
+# was never applied at all.
+#
+# theme-switcher.sh set it two ways, both of which end at logout:
+#
+#   gsettings set org.gnome.desktop.interface cursor-theme "$CURSOR"
+#   hyprctl setcursor "$CURSOR" 24
+#
+# gsettings reaches GTK and setcursor reaches the running Hyprland. XCURSOR_THEME
+# is what a new session reads, and what XWayland, SDL and Qt read, and the
+# switcher never wrote it. install.sh wrote it once, at the very end, and only
+# when the theme it installed with shipped a cursor-theme file:
+#
+#   if [[ -f "$THEME_DIR/cursor-theme" ]]; then
+#     echo "export XCURSOR_THEME=$CURSOR" >> "$HOME/.config/uwsm/env"
+#
+# The install-time default is deep-sea, which has no such file. Two of the
+# sixteen shipped themes have one at all. So XCURSOR_THEME was unset on a fresh
+# install, and switching to catppuccin or rosepine, which do declare a cursor,
+# did not set it either. Confirmed on the maintainer's machine: active theme
+# rosepine, which declares Adwaita-dark, and XCURSOR_THEME unset in the running
+# session.
+#
+# uwsm carries XCURSOR_THEME in UWSM_FINALIZE_VARNAMES, so the variable is the
+# mechanism this setup already expects.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the premise: the default theme declares no cursor ----------------------
+
+themes=0; with_cursor=0
+for t in "$REPO/.config/hypr/themes"/*/; do
+  name=$(basename "$t"); [[ $name == templates* ]] && continue
+  themes=$((themes + 1))
+  [[ -f $t/cursor-theme ]] && with_cursor=$((with_cursor + 1))
+done
+if (( themes < 5 )); then
+  fail "found $themes themes, which is too few for this check to mean anything"
+else
+  pass "checked $themes shipped themes"
+fi
+check "the install-time default theme declares no cursor, so install.sh alone never set one" \
+  "$([[ -f $REPO/.config/hypr/themes/deep-sea/cursor-theme ]] && echo yes || echo no)" "no"
+if (( with_cursor > 0 )); then
+  pass "$with_cursor themes do declare a cursor, so there is something to persist"
+else
+  fail "no theme declares a cursor, so this suite is testing nothing"
+fi
+
+check "install.sh no longer writes XCURSOR_THEME itself" \
+  "$(grep -c 'XCURSOR_THEME' "$REPO/install.sh")" "0"
+
+# --- the switcher persists it ------------------------------------------------
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+for tool in gsettings hyprctl systemctl pkill hyprsimple-restart-waybar.sh; do
+  printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
+done
+
+HOME_DIR="$TMP/home"
+setup_home() {
+  rm -rf "${TMP:?}/home"
+  mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.config/uwsm" "$HOME_DIR/.cache" \
+    "$HOME_DIR/.config/hypr/themes/withcursor" "$HOME_DIR/.config/hypr/themes/plain"
+  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+    "$HOME_DIR/.local/bin/"
+  printf 'Adwaita-dark\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+  cat >"$HOME_DIR/.config/uwsm/env" <<'ENVEOF'
+export XCURSOR_SIZE=24
+export GDK_BACKEND="wayland,x11,*"
+ENVEOF
+}
+switch_to() {
+  HOME="$HOME_DIR" THEME_SWITCHER_NO_RELOAD=1 PATH="$STUB:/usr/bin:/bin" \
+    bash "$HOME_DIR/.local/bin/theme-switcher.sh" "$1" >/dev/null 2>&1
+}
+env_file() { cat "$HOME_DIR/.config/uwsm/env"; }
+
+setup_home
+check "the fixture starts with no XCURSOR_THEME" \
+  "$(env_file | grep -c XCURSOR_THEME)" "0"
+
+switch_to withcursor
+check "switching to a theme that declares a cursor writes XCURSOR_THEME" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=Adwaita-dark$')" "1"
+check "and the rest of the file is kept" \
+  "$(env_file | grep -c 'XCURSOR_SIZE\|GDK_BACKEND')" "2"
+
+# The file is read once at login, so a second export would win silently and the
+# file would grow a line per switch.
+printf 'Bibata-Original-Classic\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+switch_to withcursor
+check "switching again replaces the line rather than appending one" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=')" "1"
+check "and it holds the new value" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=Bibata-Original-Classic$')" "1"
+
+# A theme with no cursor-theme file leaves the setting alone, which is what
+# gsettings and setcursor already did. Changing that is a separate decision.
+switch_to plain
+check "a theme that declares no cursor leaves the value alone" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=Bibata-Original-Classic$')" "1"
+
+# The two runtime paths still happen, so this is not a swap of one mechanism
+# for another.
+check "gsettings is still called" \
+  "$(grep -c 'gsettings set org.gnome.desktop.interface cursor-theme' "$BIN/theme-switcher.sh")" "1"
+# Anchored to the code, not the prose: the comment added beside it names
+# `hyprctl setcursor` too, and a bare grep counted both.
+check "and hyprctl setcursor is still called" \
+  "$(grep -c '^ *\[\[ -z "\$THEME_SWITCHER_NO_RELOAD" \]\] && hyprctl setcursor' "$BIN/theme-switcher.sh")" "1"
+
+# No uwsm/env at all must not break a theme switch.
+setup_home
+rm -f "$HOME_DIR/.config/uwsm/env"
+switch_to withcursor
+check "a home with no uwsm/env still switches theme without error" \
+  "$([[ -e $HOME_DIR/.config/uwsm/env ]] && echo created || echo absent)" "absent"
+check "and leaves no temporary file behind" \
+  "$(find "$HOME_DIR/.config/uwsm" -name 'env.tmp.*' | wc -l | tr -d ' ')" "0"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`theme-switcher.sh` set the cursor two ways, and both end at logout:

```bash
gsettings set org.gnome.desktop.interface cursor-theme "$CURSOR"
hyprctl setcursor "$CURSOR" 24
```

`gsettings` reaches GTK. `hyprctl setcursor` reaches the *running* Hyprland. `XCURSOR_THEME` is what a new session reads, and what XWayland, SDL and Qt read — and the switcher never wrote it.

`install.sh` wrote it once, at the very end, and only when the theme it installed with shipped a `cursor-theme` file:

```bash
if [[ -f "$THEME_DIR/cursor-theme" ]]; then
  echo "export XCURSOR_THEME=$CURSOR" >> "$HOME/.config/uwsm/env"
```

The install-time default is `deep-sea`, which has no such file. **Two of the sixteen shipped themes have one at all.** So on a fresh install `XCURSOR_THEME` was never set, and switching afterwards to `catppuccin` or `rosepine`, which do declare a cursor, did not set it either.

Measured on this machine: active theme `rosepine`, which declares `Adwaita-dark`, and `XCURSOR_THEME` unset in the running session. `uwsm` already carries the variable in `UWSM_FINALIZE_VARNAMES`, so it is the mechanism this setup expects.

## What changes

The switcher writes `XCURSOR_THEME` whenever the theme declares a cursor, **replacing** any existing export rather than appending one. `uwsm/env` is read once at login, so a second export of the same name would win silently while the file grew a line per theme switch.

`gsettings` and `hyprctl setcursor` are both still called; a check asserts each, so this is not one mechanism swapped for another.

The install-only block is removed, since `theme-switcher.sh` runs during install on the line directly above it. `THEME_DIR` went with it — nothing else still used it, and shellcheck flagged it as dead once the block was gone.

A theme that declares no cursor still leaves the setting alone, matching what `gsettings` and `setcursor` already did. Whether an undeclared cursor should reset to a default is a separate question and is not answered here.

## Tests

`test/cursor-theme-test.sh`, 14 checks. Three of them establish the premise before testing the fix: that the shipped theme set is real, that the install default declares no cursor, and that at least one theme does — otherwise the suite would be asserting against nothing.

Sabotage: dropping the persistence turns 4 red; appending instead of replacing turns 1 red.

One correction in the suite: the check for `hyprctl setcursor` counted 2, because the comment added beside that line names it too. It is anchored to the code line now.

Sweep: 40 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. This machine's `uwsm/env` still has no `XCURSOR_THEME` and no stray `env.tmp.*`, checked after the sweeps.