### PR TITLE
Two paths hyprsimple names that nothing creates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,9 @@ jobs:
       - name: waybar-refresh-test
         run: bash test/waybar-refresh-test.sh
 
+      - name: named-paths-test
+        run: bash test/named-paths-test.sh
+
       - name: cursor-theme-test
         run: bash test/cursor-theme-test.sh
 

--- a/.local/bin/record-audio.sh
+++ b/.local/bin/record-audio.sh
@@ -1,3 +1,14 @@
 #!/bin/bash
 
-ffmpeg -f alsa -i default "$HOME/Music/$(date +%Y%m%d_%H%M%S).wav"
+# Record audio from the default input into ~/Music.
+#
+# install.sh creates ~/Videos and ~/Pictures and not ~/Music, and ffmpeg does
+# not create the directory it is asked to write into, so on a machine where
+# xdg-user-dirs has not run this exited 254 with "No such file or directory"
+# and nothing else. Its two siblings both handle this: screen-record.sh checks
+# and says so, and screenshot.sh delegates to hyprshot, which does mkdir -p.
+# This one did neither.
+OUTPUT_DIR="${XDG_MUSIC_DIR:-$HOME/Music}"
+mkdir -p "$OUTPUT_DIR" || exit 1
+
+ffmpeg -f alsa -i default "$OUTPUT_DIR/$(date +%Y%m%d_%H%M%S).wav"

--- a/default/hypr/env.lua
+++ b/default/hypr/env.lua
@@ -2,8 +2,19 @@
 -- which is now a user-overridable module, so they moved here where changing
 -- them reaches everyone.
 
--- XCOMPOSE file used by GTK input methods
-hl.env("XCOMPOSEFILE", os.getenv("HOME") .. "/.XCompose")
+-- There was an hl.env("XCOMPOSEFILE", "$HOME/.XCompose") here. Nothing in
+-- hyprsimple creates that file: upstream writes one in its own install step,
+-- and only the environment variable was carried over.
+--
+-- The variable was redundant even when the file does exist. man 5 Compose gives
+-- the search order as $XCOMPOSEFILE, then ~/.XCompose, then the locale's
+-- system compose file, so ~/.XCompose is already found without being named.
+-- Pointing the first rule at a file that is not there is what stops the third
+-- rule from being reached.
+--
+-- Nothing binds a compose key either: input.lua leaves kb_options empty, so no
+-- key produces Multi_key. Someone who wants compose sequences writes
+-- ~/.XCompose and sets kb_options, and both work without this line.
 
 hl.config({
   xwayland = {

--- a/test/named-paths-test.sh
+++ b/test/named-paths-test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Two places where hyprsimple named a path that nothing creates.
+#
+# record-audio.sh wrote to $HOME/Music. install.sh creates ~/Videos and
+# ~/Pictures and not ~/Music, and ffmpeg does not create the directory it is
+# asked to write into. Measured before the fix, with HOME pointed at an empty
+# directory:
+#
+#   Error opening output .../Music/20260905_130134.wav: No such file or directory
+#   exit 254, and no directory created
+#
+# Its two siblings both handle this. screen-record.sh checks and notifies;
+# screenshot.sh delegates to hyprshot, which runs mkdir -p itself. This one did
+# neither, and it is the documented way to record audio.
+#
+# default/hypr/env.lua exported XCOMPOSEFILE=$HOME/.XCompose. Nothing creates
+# that file either: upstream writes one in its own install step and only the
+# variable was carried over. man 5 Compose gives the search order as
+# $XCOMPOSEFILE, then ~/.XCompose, then the locale's system compose file, so
+# the home file is already found without being named, and naming a file that is
+# not there is what stops the third rule from being reached.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+# ffmpeg records nothing here. It reports the directory it was handed, which is
+# the whole question, and refuses to write if that directory is missing, which
+# is what the real one does.
+cat >"$STUB/ffmpeg" <<'STUBEOF'
+#!/bin/bash
+out="${*: -1}"
+printf 'ffmpeg %s\n' "$*" >>"$CALL_LOG"
+[[ -d ${out%/*} ]] || { printf 'Error opening output %s: No such file or directory\n' "$out" >&2; exit 254; }
+: >"$out"
+STUBEOF
+chmod +x "$STUB/ffmpeg"
+
+LOG="$TMP/calls"
+run_record() {
+  rm -rf "${TMP:?}/home"; mkdir -p "$TMP/home"
+  : >"$LOG"
+  HOME="$TMP/home" CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" \
+    ${1:+env XDG_MUSIC_DIR="$1"} bash "$BIN/record-audio.sh" >/dev/null 2>&1
+  echo $?
+}
+
+# --- record-audio.sh --------------------------------------------------------
+
+rc=$(run_record "")
+check "recording into a home with no Music directory now succeeds" "$rc" "0"
+check "and the directory was created" \
+  "$([[ -d $TMP/home/Music ]] && echo yes || echo no)" "yes"
+check "and the file landed in it" \
+  "$(find "$TMP/home/Music" -name '*.wav' | wc -l | tr -d ' ')" "1"
+check "and ffmpeg was actually invoked" "$(grep -c '^ffmpeg ' "$LOG")" "1"
+
+# The failing shape the fix is for, proven with the stub, so the checks above
+# are not passing because the stub is lenient.
+mkdir -p "$TMP/probe"
+CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" \
+  bash -c 'ffmpeg -f alsa -i default "'"$TMP"'/probe/absent/x.wav"' >/dev/null 2>&1
+check "the stub does refuse a missing directory, so the fixture is honest" "$?" "254"
+
+# XDG_MUSIC_DIR wins where it is set, which is how the sibling screen-record.sh
+# already reads XDG_VIDEOS_DIR.
+rc=$(run_record "$TMP/elsewhere")
+check "XDG_MUSIC_DIR is honoured" "$rc" "0"
+check "and that is where the recording goes" \
+  "$(find "$TMP/elsewhere" -name '*.wav' 2>/dev/null | wc -l | tr -d ' ')" "1"
+check "and ~/Music is not created when it is not used" \
+  "$([[ -d $TMP/home/Music ]] && echo yes || echo no)" "no"
+
+# --- XCOMPOSEFILE ------------------------------------------------------------
+
+# Anchored to the start of a line, because the comment left in env.lua names
+# the call it replaced and an unanchored grep counts that too.
+lua_call='^[[:space:]]*hl\.env\("XCOMPOSEFILE"'
+check "env.lua no longer exports XCOMPOSEFILE" \
+  "$(grep -cE "$lua_call" "$REPO/default/hypr/env.lua")" "0"
+check "and nothing else in the tree does" \
+  "$(grep -rlE "$lua_call" "$REPO/default" "$REPO/.config" 2>/dev/null | wc -l | tr -d ' ')" "0"
+# The anchor has to be able to find a real call, or the two checks above pass
+# because the pattern is wrong rather than because the line is gone.
+printf 'hl.env("XCOMPOSEFILE", "x")\n' >"$TMP/anchor-probe.lua"
+check "the anchor does match a real call, so those two mean something" \
+  "$(grep -cE "$lua_call" "$TMP/anchor-probe.lua")" "1"
+
+# The file it named is still not shipped, which is the reason the export had to
+# go rather than be pointed somewhere else.
+check "no .XCompose is shipped, which is why the export was removed" \
+  "$(find "$REPO" -name '.XCompose' -not -path '*/.git/*' -not -path '*/external/*' | wc -l | tr -d ' ')" "0"
+
+# env.lua still does its other work, so this is not a check that the file was
+# emptied.
+check "env.lua still sets xwayland scaling" \
+  "$(grep -c 'force_zero_scaling' "$REPO/default/hypr/env.lua")" "1"
+check "and still disables the update news" \
+  "$(grep -c 'no_update_news' "$REPO/default/hypr/env.lua")" "1"
+
+if command -v lua >/dev/null 2>&1; then
+  if lua -e 'local f = loadfile("'"$REPO"'/default/hypr/env.lua"); if f then os.exit(0) else os.exit(1) end'; then
+    pass "env.lua still parses as lua"
+  else
+    fail "env.lua no longer parses as lua"
+  fi
+fi
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Same root cause as #74, #75 and #79: a reference carried over without the thing it depends on.

## `record-audio.sh` writes to a directory nothing makes

```bash
ffmpeg -f alsa -i default "$HOME/Music/$(date +%Y%m%d_%H%M%S).wav"
```

`install.sh` creates `~/Videos` and `~/Pictures`. Not `~/Music`. `xdg-user-dirs` is in neither package list and is never run. `ffmpeg` does not create the directory it is asked to write into. Measured with `HOME` pointed at an empty directory:

```
Error opening output .../Music/20260905_130134.wav: No such file or directory
exit 254, and no directory created
```

Its two siblings both handle this. `screen-record.sh` checks the directory and notifies. `screenshot.sh` delegates to `hyprshot`, which runs `mkdir -p` itself (line 118 of that binary). This one did neither, and it is the documented way to record audio.

It creates the directory now, and reads `XDG_MUSIC_DIR` the way `screen-record.sh` already reads `XDG_VIDEOS_DIR`.

## `XCOMPOSEFILE` points at a file nothing writes

`default/hypr/env.lua` exported `XCOMPOSEFILE=$HOME/.XCompose`. Nothing in hyprsimple creates it — upstream writes one in its own install step (`install/config/xcompose.sh`) and only the variable was carried over. It is absent on this machine.

The variable was redundant even where the file **does** exist. From `man 5 Compose`:

```
The compose file is searched for in the following order:
  - If the environment variable $XCOMPOSEFILE is set, its value is used ...
  - If the user's home directory has a file named .XCompose, it is used ...
  - The system provided compose file is used by mapping the locale ...
```

`~/.XCompose` is already the second rule, found without being named. Pointing the first rule at a file that is not there is what stops the third rule — the system compose file — from being reached.

Nothing binds a compose key either: `input.lua` leaves `kb_options` empty, so no key produces `Multi_key`. Removing the export leaves anyone who wants compose sequences free to write `~/.XCompose` and set `kb_options`, both of which work without it. That is a feature to add deliberately, not a line to leave pointing at nothing.

## Tests

`test/named-paths-test.sh`, 15 checks.

Two of them exist to keep the others honest: one drives the stub `ffmpeg` at a missing directory and asserts it really does refuse with 254, so the passing cases are not passing because the stub is lenient; and one checks the lua-call pattern matches a real call, so the two "no longer exports" checks cannot pass because the regex is wrong. Two more assert `env.lua` still does its other work, so this is not a check that the file was emptied.

Sabotage: dropping the `mkdir` turns 5 red; restoring the export turns 2 red.

Sweep: 41 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. `~/.XCompose` is still absent here and the suites created nothing in the real home.

One repeat of a mistake from #81: my first version of the "no longer exports" check counted 1, because the comment left in `env.lua` names the call it replaced. Anchored to the start of a line now, with the anchor itself checked.