### PR TITLE
Keep one broken override from taking the whole config down

### DIFF
--- a/.config/hypr/hyprland.lua
+++ b/.config/hypr/hyprland.lua
@@ -13,12 +13,46 @@ package.path = home .. "/.config/?.lua;" .. hyprsimple .. "/?.lua;" .. package.p
 require("default.hypr.hyprsimple")
 
 -- Your overrides, from ~/.config. Loaded after the defaults so they win.
-require("hypr.monitors")
-require("hypr.bindings.applications")
-require("hypr.looknfeel")
-require("hypr.input")
-require("hypr.windows")
-require("hypr.autostart")
+--
+-- Each of these is a file you are invited to edit, and a bare require aborts
+-- this whole file on a syntax error or a deleted one: every later require, and
+-- the theme overlay at the bottom, then never runs. Measured with a
+-- one-character typo in windows.lua, nothing after that line loaded, so the
+-- session came up with no theme and no explanation.
+--
+-- default/hypr/vars.lua already loads your vars.lua with pcall for this reason.
+-- These do the same, and name the file that failed.
+local failed = {}
+
+local function load_override(module)
+  local ok, err = pcall(require, module)
+  if not ok then
+    -- Single quotes and newlines are removed because the message is passed to
+    -- notify-send inside a single-quoted shell argument.
+    local message = (tostring(err):gsub("'", ""):gsub("%s+", " "))
+    failed[#failed + 1] = message
+  end
+end
+
+load_override("hypr.monitors")
+load_override("hypr.bindings.applications")
+load_override("hypr.looknfeel")
+load_override("hypr.input")
+load_override("hypr.windows")
+load_override("hypr.autostart")
+
+-- Reported once the session is up, because a notification cannot be shown
+-- while the config is still being parsed.
+if #failed > 0 then
+  hl.on("hyprland.start", function()
+    for _, message in ipairs(failed) do
+      hl.exec_cmd(
+        "notify-send -u critical 'hyprsimple: a config file did not load' "
+          .. "'" .. message .. "'"
+      )
+    end
+  end)
+end
 
 -- Theme overlay loaded last so it wins on shared keys (col.active_border, etc).
 -- dofile() because the symlink target changes when the theme switches; require()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,9 @@ jobs:
       - name: waybar-refresh-test
         run: bash test/waybar-refresh-test.sh
 
+      - name: broken-override-test
+        run: bash test/broken-override-test.sh
+
       - name: cursor-theme-test
         run: bash test/cursor-theme-test.sh
 

--- a/migrations/1788627800.sh
+++ b/migrations/1788627800.sh
@@ -1,0 +1,48 @@
+echo "Keep one broken override from taking the whole config down"
+
+# ~/.config/hypr/hyprland.lua required your six override files with a bare
+# require. A syntax error in any of them, or a deleted one, aborted the file:
+# every later require and the theme overlay at the bottom never ran, so the
+# session came up with no theme, no bindings from the later files, and nothing
+# saying why. Measured with a one-character typo in windows.lua.
+#
+# default/hypr/vars.lua already loaded your vars.lua with pcall for exactly this
+# reason. The entrypoint now does the same and names the file that failed.
+#
+# hyprland.lua is yours, so it is only replaced when it is still byte-identical
+# to a version hyprsimple shipped. An edited one is left alone and reported.
+
+user="$HOME/.config/hypr/hyprland.lua"
+shipped="$HYPRSIMPLE_PATH/.config/hypr/hyprland.lua"
+
+[[ -f $user && -f $shipped ]] || exit 0
+
+if cmp -s "$user" "$shipped"; then
+  exit 0
+fi
+
+# Every version of this file the project shipped before the current one.
+SHIPPED_SUMS=(
+  0c1d78c21b6dc7bf6d1c73a3403fd3dd
+  75f67c42753b28e5a9189b8a65009e27
+  af26427696efda1879c6fba8a355cb50
+)
+
+sum=$(md5sum "$user" | cut -d' ' -f1)
+
+for known in "${SHIPPED_SUMS[@]}"; do
+  if [[ $sum == "$known" ]]; then
+    cp -f "$user" "$user.bak"
+    cp -f "$shipped" "$user"
+    echo "  Updated $user (previous version kept at $user.bak)"
+    echo "  A broken override file now reports itself instead of silently"
+    echo "  taking the rest of your config with it."
+    exit 0
+  fi
+done
+
+echo "  $user has your own edits, so it was left alone."
+echo "  It still loads your override files with a bare require, so a syntax"
+echo "  error in any of them takes down everything after it."
+echo "  To take hyprsimple's version and lose your edits:"
+echo "    hyprsimple-refresh-config.sh hypr/hyprland.lua"

--- a/test/broken-override-test.sh
+++ b/test/broken-override-test.sh
@@ -42,21 +42,17 @@ fi
 # A home with the six override files, a stand-in for the install tree, and a
 # theme overlay that records whether it was reached.
 build_home() {
-  rm -rf "${TMP:?}/home"
-  mkdir -p "$TMP/home/.config/hypr/bindings" "$TMP/home/install/default/hypr"
+  rm -rf "${TMP:?}/fakehome"
+  mkdir -p "$TMP/fakehome/.config/hypr/bindings" "$TMP/fakehome/install/default/hypr"
   for m in monitors looknfeel input windows autostart; do
-    printf 'return {}\n' >"$TMP/home/.config/hypr/$m.lua"
+    printf 'return {}\n' >"$TMP/fakehome/.config/hypr/$m.lua"
   done
-  printf 'return {}\n' >"$TMP/home/.config/hypr/bindings/applications.lua"
-  # The install side only has to be requireable.
-  cat >"$TMP/home/install/default/hypr/hyprsimple.lua" <<'LUAEOF'
-return {}
-LUAEOF
-  mkdir -p "$TMP/home/install/default/hypr"
+  printf 'return {}\n' >"$TMP/fakehome/.config/hypr/bindings/applications.lua"
+  # The install side only has to be requireable, and to record that it ran.
   printf 'DEFAULTS_LOADED = true\nreturn {}\n' \
-    >"$TMP/home/install/default/hypr/hyprsimple.lua"
+    >"$TMP/fakehome/install/default/hypr/hyprsimple.lua"
   # The theme overlay, which the old code could never reach after a failure.
-  printf 'THEME_LOADED = true\n' >"$TMP/home/.config/hypr/theme-active.lua"
+  printf 'THEME_LOADED = true\n' >"$TMP/fakehome/.config/hypr/theme-active.lua"
 }
 
 # Runs the real entrypoint with hl stubbed, and prints what happened.
@@ -81,7 +77,7 @@ print("DEFAULTS_LOADED=" .. tostring(DEFAULTS_LOADED))
 -- would report a failure.
 for _, fn in ipairs(calls) do fn() end
 LUAEOF
-  HOME="$TMP/home" HYPRSIMPLE_PATH="$TMP/home/install" \
+  HOME="$TMP/fakehome" HYPRSIMPLE_PATH="$TMP/fakehome/install" \
     lua "$TMP/run.lua" 2>&1
 }
 
@@ -98,7 +94,7 @@ check "and nothing is reported" "$(printf '%s' "$out" | grep -c 'did not load')"
 # --- a syntax error in one override -----------------------------------------
 
 build_home
-printf 'local x = {\n' >"$TMP/home/.config/hypr/windows.lua"
+printf 'local x = {\n' >"$TMP/fakehome/.config/hypr/windows.lua"
 out=$(run_entry)
 check "a typo in one override no longer aborts the entrypoint" \
   "$(printf '%s' "$out" | grep -c 'ENTRYPOINT ABORTED')" "0"
@@ -112,7 +108,7 @@ check "and the report names the file" \
 # --- a deleted override ------------------------------------------------------
 
 build_home
-rm "$TMP/home/.config/hypr/windows.lua"
+rm "$TMP/fakehome/.config/hypr/windows.lua"
 out=$(run_entry)
 check "a deleted override does not abort the entrypoint either" \
   "$(printf '%s' "$out" | grep -c 'ENTRYPOINT ABORTED')" "0"
@@ -123,8 +119,8 @@ check "and it is reported" "$(printf '%s' "$out" | grep -c 'did not load')" "1"
 # --- more than one broken at a time -----------------------------------------
 
 build_home
-printf 'local x = {\n' >"$TMP/home/.config/hypr/windows.lua"
-rm "$TMP/home/.config/hypr/input.lua"
+printf 'local x = {\n' >"$TMP/fakehome/.config/hypr/windows.lua"
+rm "$TMP/fakehome/.config/hypr/input.lua"
 out=$(run_entry)
 check "two broken overrides are both reported" \
   "$(printf '%s' "$out" | grep -c 'did not load')" "2"
@@ -134,7 +130,7 @@ check "and the theme overlay still loads" \
 # A single quote in the error text must not break the shell command the report
 # is built into.
 build_home
-printf "local x = 'unterminated\n" >"$TMP/home/.config/hypr/windows.lua"
+printf "local x = 'unterminated\n" >"$TMP/fakehome/.config/hypr/windows.lua"
 out=$(run_entry)
 check "an error containing a quote produces a single-quoted command" \
   "$(printf '%s' "$out" | grep -c "^EXEC notify-send -u critical 'hyprsimple: a config file did not load' '")" "1"

--- a/test/broken-override-test.sh
+++ b/test/broken-override-test.sh
@@ -160,21 +160,26 @@ run_migration() {
     bash "$MIGRATION" >"$TMP/mout" 2>&1
 }
 
-# A previous shipped version, taken from git rather than retyped. Written
-# straight to a file: a command substitution strips the trailing newline, which
-# changes the checksum and makes the comparison below meaningless.
-git -C "$REPO" show "HEAD:.config/hypr/hyprland.lua" >"$TMP/prev.lua" 2>/dev/null || true
-if [[ ! -s $TMP/prev.lua ]]; then
-  fail "could not read the previous hyprland.lua from git, so the migration is untested"
+# The version this replaces, as a committed fixture. Not read from git history:
+# CI checks out shallow, so `git show HEAD:` there hands back the current file
+# and the migration check would compare it against itself and pass.
+PREV="$REPO/test/fixtures/hypr/hyprland.lua.pre-softload"
+if [[ ! -s $PREV ]]; then
+  fail "the pre-fix fixture is missing, so the migration is untested"
 else
-  prev_sum=$(md5sum "$TMP/prev.lua" | cut -d' ' -f1)
+  prev_sum=$(md5sum "$PREV" | cut -d' ' -f1)
+  if cmp -s "$PREV" "$ENTRY"; then
+    fail "the fixture is identical to the current entrypoint, so it is not a previous version"
+  else
+    pass "the fixture differs from the current entrypoint, as a previous version must"
+  fi
   if grep -q "$prev_sum" "$MIGRATION"; then
     pass "the migration lists the checksum of the version it replaces"
   else
     fail "the migration does not list $prev_sum, so it will not update an existing install"
   fi
 
-  mk_migration_home_from_file "$TMP/prev.lua"
+  mk_migration_home_from_file "$PREV"
   run_migration
   check "an untouched entrypoint is replaced" \
     "$(cmp -s "$TMP/mhome/.config/hypr/hyprland.lua" "$ENTRY" && echo yes || echo no)" "yes"

--- a/test/broken-override-test.sh
+++ b/test/broken-override-test.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# ~/.config/hypr/hyprland.lua required the six user override files with a bare
+# require:
+#
+#   require("hypr.monitors")
+#   require("hypr.bindings.applications")
+#   ...
+#
+# A syntax error in any of them, or a deleted one, aborts the file. Everything
+# after that line stops, including the theme overlay at the bottom, which is
+# what applies the theme's colours. Measured with a one-character typo in
+# windows.lua: the overlay did not load, and nothing said why.
+#
+# These are files the user is invited to edit, so a syntax error in one is an
+# ordinary event rather than an exotic one. default/hypr/vars.lua already loaded
+# the user's vars.lua with pcall for this reason, with the reason in a comment
+# above it. The entrypoint did not.
+#
+# Everything here runs in plain lua against the real file, with hl stubbed.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRY="$REPO/.config/hypr/hyprland.lua"
+MIGRATION="$REPO/migrations/1788627800.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+if ! command -v lua >/dev/null 2>&1; then
+  fail "lua is not installed, so none of this suite can run"
+  exit 1
+fi
+
+# A home with the six override files, a stand-in for the install tree, and a
+# theme overlay that records whether it was reached.
+build_home() {
+  rm -rf "${TMP:?}/home"
+  mkdir -p "$TMP/home/.config/hypr/bindings" "$TMP/home/install/default/hypr"
+  for m in monitors looknfeel input windows autostart; do
+    printf 'return {}\n' >"$TMP/home/.config/hypr/$m.lua"
+  done
+  printf 'return {}\n' >"$TMP/home/.config/hypr/bindings/applications.lua"
+  # The install side only has to be requireable.
+  cat >"$TMP/home/install/default/hypr/hyprsimple.lua" <<'LUAEOF'
+return {}
+LUAEOF
+  mkdir -p "$TMP/home/install/default/hypr"
+  printf 'DEFAULTS_LOADED = true\nreturn {}\n' \
+    >"$TMP/home/install/default/hypr/hyprsimple.lua"
+  # The theme overlay, which the old code could never reach after a failure.
+  printf 'THEME_LOADED = true\n' >"$TMP/home/.config/hypr/theme-active.lua"
+}
+
+# Runs the real entrypoint with hl stubbed, and prints what happened.
+run_entry() {
+  cat >"$TMP/run.lua" <<LUAEOF
+local calls = {}
+hl = {
+  on = function(_, fn) table.insert(calls, fn) end,
+  exec_cmd = function(cmd) print("EXEC " .. cmd) end,
+  config = function() end,
+  env = function() end,
+  bind = function() end,
+  gesture = function() end,
+  device = function() end,
+  dsp = setmetatable({}, { __index = function() return function() end end }),
+}
+local ok, err = pcall(dofile, "$ENTRY")
+if not ok then print("ENTRYPOINT ABORTED: " .. tostring(err)) end
+print("THEME_LOADED=" .. tostring(THEME_LOADED))
+print("DEFAULTS_LOADED=" .. tostring(DEFAULTS_LOADED))
+-- Anything registered for hyprland.start runs now, which is when the session
+-- would report a failure.
+for _, fn in ipairs(calls) do fn() end
+LUAEOF
+  HOME="$TMP/home" HYPRSIMPLE_PATH="$TMP/home/install" \
+    lua "$TMP/run.lua" 2>&1
+}
+
+# --- everything intact -------------------------------------------------------
+
+build_home
+out=$(run_entry)
+check "with every override present the theme overlay loads" \
+  "$(printf '%s' "$out" | grep -c 'THEME_LOADED=true')" "1"
+check "and the install defaults load" \
+  "$(printf '%s' "$out" | grep -c 'DEFAULTS_LOADED=true')" "1"
+check "and nothing is reported" "$(printf '%s' "$out" | grep -c 'did not load')" "0"
+
+# --- a syntax error in one override -----------------------------------------
+
+build_home
+printf 'local x = {\n' >"$TMP/home/.config/hypr/windows.lua"
+out=$(run_entry)
+check "a typo in one override no longer aborts the entrypoint" \
+  "$(printf '%s' "$out" | grep -c 'ENTRYPOINT ABORTED')" "0"
+check "and the theme overlay still loads" \
+  "$(printf '%s' "$out" | grep -c 'THEME_LOADED=true')" "1"
+check "and the failure is reported once" \
+  "$(printf '%s' "$out" | grep -c 'did not load')" "1"
+check "and the report names the file" \
+  "$(printf '%s' "$out" | grep -c 'windows.lua')" "1"
+
+# --- a deleted override ------------------------------------------------------
+
+build_home
+rm "$TMP/home/.config/hypr/windows.lua"
+out=$(run_entry)
+check "a deleted override does not abort the entrypoint either" \
+  "$(printf '%s' "$out" | grep -c 'ENTRYPOINT ABORTED')" "0"
+check "and the theme overlay still loads" \
+  "$(printf '%s' "$out" | grep -c 'THEME_LOADED=true')" "1"
+check "and it is reported" "$(printf '%s' "$out" | grep -c 'did not load')" "1"
+
+# --- more than one broken at a time -----------------------------------------
+
+build_home
+printf 'local x = {\n' >"$TMP/home/.config/hypr/windows.lua"
+rm "$TMP/home/.config/hypr/input.lua"
+out=$(run_entry)
+check "two broken overrides are both reported" \
+  "$(printf '%s' "$out" | grep -c 'did not load')" "2"
+check "and the theme overlay still loads" \
+  "$(printf '%s' "$out" | grep -c 'THEME_LOADED=true')" "1"
+
+# A single quote in the error text must not break the shell command the report
+# is built into.
+build_home
+printf "local x = 'unterminated\n" >"$TMP/home/.config/hypr/windows.lua"
+out=$(run_entry)
+check "an error containing a quote produces a single-quoted command" \
+  "$(printf '%s' "$out" | grep -c "^EXEC notify-send -u critical 'hyprsimple: a config file did not load' '")" "1"
+check "and no stray quote survives in the message" \
+  "$(printf '%s' "$out" | grep 'did not load' | tr -cd "'" | wc -c | tr -d ' ')" "4"
+
+# --- the migration -----------------------------------------------------------
+
+mk_migration_home() {
+  rm -rf "${TMP:?}/mhome" "${TMP:?}/minstall"
+  mkdir -p "$TMP/mhome/.config/hypr" "$TMP/minstall/.config/hypr"
+  cp "$ENTRY" "$TMP/minstall/.config/hypr/hyprland.lua"
+  printf '%s' "$1" >"$TMP/mhome/.config/hypr/hyprland.lua"
+}
+mk_migration_home_from_file() {
+  rm -rf "${TMP:?}/mhome" "${TMP:?}/minstall"
+  mkdir -p "$TMP/mhome/.config/hypr" "$TMP/minstall/.config/hypr"
+  cp "$ENTRY" "$TMP/minstall/.config/hypr/hyprland.lua"
+  cp "$1" "$TMP/mhome/.config/hypr/hyprland.lua"
+}
+run_migration() {
+  HOME="$TMP/mhome" HYPRSIMPLE_PATH="$TMP/minstall" \
+    bash "$MIGRATION" >"$TMP/mout" 2>&1
+}
+
+# A previous shipped version, taken from git rather than retyped. Written
+# straight to a file: a command substitution strips the trailing newline, which
+# changes the checksum and makes the comparison below meaningless.
+git -C "$REPO" show "HEAD:.config/hypr/hyprland.lua" >"$TMP/prev.lua" 2>/dev/null || true
+if [[ ! -s $TMP/prev.lua ]]; then
+  fail "could not read the previous hyprland.lua from git, so the migration is untested"
+else
+  prev_sum=$(md5sum "$TMP/prev.lua" | cut -d' ' -f1)
+  if grep -q "$prev_sum" "$MIGRATION"; then
+    pass "the migration lists the checksum of the version it replaces"
+  else
+    fail "the migration does not list $prev_sum, so it will not update an existing install"
+  fi
+
+  mk_migration_home_from_file "$TMP/prev.lua"
+  run_migration
+  check "an untouched entrypoint is replaced" \
+    "$(cmp -s "$TMP/mhome/.config/hypr/hyprland.lua" "$ENTRY" && echo yes || echo no)" "yes"
+  check "and the previous version is kept" \
+    "$([[ -f $TMP/mhome/.config/hypr/hyprland.lua.bak ]] && echo yes || echo no)" "yes"
+
+  run_migration
+  check "re-running on an already current file says nothing" \
+    "$(grep -c 'Updated' "$TMP/mout")" "0"
+fi
+
+mk_migration_home "-- my own entrypoint
+require('hypr.monitors')
+"
+run_migration
+check "an edited entrypoint is left alone" \
+  "$(head -1 "$TMP/mhome/.config/hypr/hyprland.lua")" "-- my own entrypoint"
+check "and the user is told how to take the new one" \
+  "$(grep -c 'hyprsimple-refresh-config.sh hypr/hyprland.lua' "$TMP/mout")" "1"
+check "and no backup is written, nothing having changed" \
+  "$([[ -f $TMP/mhome/.config/hypr/hyprland.lua.bak ]] && echo yes || echo no)" "no"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/fixtures/hypr/hyprland.lua.pre-softload
+++ b/test/fixtures/hypr/hyprland.lua.pre-softload
@@ -1,0 +1,33 @@
+-- Hyprland Lua config entrypoint.
+-- See https://wiki.hypr.land/Configuring/Start/
+
+local home = os.getenv("HOME") or ""
+local hyprsimple = os.getenv("HYPRSIMPLE_PATH") or (home .. "/.local/share/hyprsimple")
+
+-- Defaults come from the install and user overrides from ~/.config. ~/.config is
+-- first so a user file of the same name wins, and the requires below load the
+-- defaults before the user's, so user settings override on shared keys.
+package.path = home .. "/.config/?.lua;" .. hyprsimple .. "/?.lua;" .. package.path
+
+-- hyprsimple defaults, from the install.
+require("default.hypr.hyprsimple")
+
+-- Your overrides, from ~/.config. Loaded after the defaults so they win.
+require("hypr.monitors")
+require("hypr.bindings.applications")
+require("hypr.looknfeel")
+require("hypr.input")
+require("hypr.windows")
+require("hypr.autostart")
+
+-- Theme overlay loaded last so it wins on shared keys (col.active_border, etc).
+-- dofile() because the symlink target changes when the theme switches; require()
+-- would cache by module name and miss the swap.
+do
+  local theme_path = home .. "/.config/hypr/theme-active.lua"
+  local f = io.open(theme_path, "r")
+  if f then
+    f:close()
+    dofile(theme_path)
+  end
+end


### PR DESCRIPTION
`~/.config/hypr/hyprland.lua` required the six user override files with a bare `require`:

```lua
require("hypr.monitors")
require("hypr.bindings.applications")
require("hypr.looknfeel")
require("hypr.input")
require("hypr.windows")
require("hypr.autostart")
```

A syntax error in any one of them, or a deleted one, aborts the file. Every later `require` stops, **and so does the theme overlay at the bottom** — the block that applies the theme's colours. Measured in plain lua against the real entrypoint, with a one-character typo in `windows.lua`:

```
lua: error loading module 'hypr.windows' ... unexpected symbol near <eof>
THEME_LOADED=nil
```

Same with the file simply deleted.

These are files the user is invited to edit — the comment above them says "Your overrides". A syntax error in one is an ordinary event, not an exotic one, and the result is a session with no theme, missing the bindings from the later files, and nothing saying why. That is the same shape as the failure in #62/#63.

`default/hypr/vars.lua` already loads the user's `vars.lua` with `pcall`, with the reason written above it: "so a syntax error in the user's file degrades to these defaults rather than killing the session". The entrypoint did not.

## What changes

Each override is loaded with `pcall`. Any that fail are named in a critical notification once the session is up, since nothing can be shown while the config is still parsing. Single quotes and whitespace are stripped from the error text, because the message goes into a single-quoted shell argument — there is a check for that.

## Migration

`hyprland.lua` is user-owned, so `migrations/1788627800.sh` replaces it only where it is still byte-identical to a version hyprsimple shipped, keeping a `.bak`. An edited one is left alone, told what it is still exposed to, and pointed at `hyprsimple-refresh-config.sh`.

## Tests

`test/broken-override-test.sh`, 19 checks, running the real entrypoint in plain lua with `hl` stubbed. Both failure modes, one and two broken files at once, an error containing a quote, and the intact case — which is what stops the fix from being a way to load nothing at all.

Sabotage: restoring the bare `require` turns 8 red; dropping a checksum from the migration turns 3 red.

## Two corrections to my own work here

Both caught by the repository's own guards, which is what they are for.

- My first migration check read the previous `hyprland.lua` with `git show HEAD:`. CI checks out shallow, where that returns the *current* file, so the check would have compared it against itself and passed. `suite-hygiene-test.sh` exists because two suites did this before. It is a committed fixture now, with a check that the fixture actually differs from the current file.
- `committed-symlinks-test.sh` then failed: my temp directory was `$TMP/home/...`, and the literal `/home/` trips the hardcoded-path guard. Renamed rather than loosening the guard.

Sweep: 41 suites, 0 failing, three consecutive runs. shellcheck clean at `style`.