### PR TITLE
Point btop at the theme hyprsimple has been generating for it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,9 @@ jobs:
       - name: named-paths-test
         run: bash test/named-paths-test.sh
 
+      - name: btop-theme-test
+        run: bash test/btop-theme-test.sh
+
       - name: config-ownership-test
         run: bash test/config-ownership-test.sh
 

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -93,9 +93,31 @@ else
 fi
 
 # 8. Update btop theme
+#
+# Copying the theme into place was never enough: btop only reads the file its
+# own config names, and nothing set that. hyprsimple installs btop, install.sh
+# creates the themes directory, every theme renders a btop.theme and every
+# switch copied one here, and btop.conf still said color_theme = "Default",
+# which is what btop writes for itself on first run. The themed btop has never
+# worked on any install.
+#
+# btop names a theme by its filename without the extension, so the file written
+# below is selected as "current".
 if [[ -f "$GEN/btop.theme" ]]; then
   mkdir -p "$HOME/.config/btop/themes"
   cp "$GEN/btop.theme" "$HOME/.config/btop/themes/current.theme"
+
+  BTOP_CONF="$HOME/.config/btop/btop.conf"
+  if [[ ! -f $BTOP_CONF ]]; then
+    # btop fills in every key it does not find, so naming the theme is enough.
+    printf 'color_theme = "current"\n' >"$BTOP_CONF"
+  elif grep -q '^color_theme = ' "$BTOP_CONF"; then
+    # Replaced rather than appended: btop reads the file top to bottom and a
+    # second assignment would win, and the file would grow a line per switch.
+    sed -i 's|^color_theme = .*|color_theme = "current"|' "$BTOP_CONF"
+  else
+    printf 'color_theme = "current"\n' >>"$BTOP_CONF"
+  fi
 fi
 
 # 9. Wallpaper (copy so hyprpaper detects change)

--- a/migrations/1788636400.sh
+++ b/migrations/1788636400.sh
@@ -1,0 +1,48 @@
+echo "Point btop at the theme hyprsimple has been generating for it"
+
+# hyprsimple installs btop, install.sh creates ~/.config/btop/themes, every
+# shipped theme renders a btop.theme, and every theme switch copied one to
+# themes/current.theme. Nothing ever told btop to use it: btop.conf still said
+# color_theme = "Default", which is what btop writes for itself on first run.
+# The themed btop has never worked on any install.
+#
+# Only a config that has not chosen a theme is changed. "Default" and "TTY" are
+# btop's two built-ins, and a missing key means the same thing. Anything else is
+# a theme the user picked, and is left alone.
+
+CONF="$HOME/.config/btop/btop.conf"
+THEME="$HOME/.config/btop/themes/current.theme"
+
+if [[ ! -f $THEME ]]; then
+  echo "  No generated btop theme here yet. Switching theme will write one."
+  exit 0
+fi
+
+if [[ ! -f $CONF ]]; then
+  mkdir -p "$(dirname "$CONF")"
+  printf 'color_theme = "current"\n' >"$CONF"
+  echo "  Created $CONF selecting the generated theme."
+  exit 0
+fi
+
+current=$(sed -n 's/^color_theme = "\(.*\)"$/\1/p' "$CONF" | head -1)
+
+case "$current" in
+  current)
+    exit 0
+    ;;
+  "" | Default | TTY)
+    cp -f "$CONF" "$CONF.bak"
+    if grep -q '^color_theme = ' "$CONF"; then
+      sed -i 's|^color_theme = .*|color_theme = "current"|' "$CONF"
+    else
+      printf 'color_theme = "current"\n' >>"$CONF"
+    fi
+    echo "  btop now uses your hyprsimple theme (previous config at $CONF.bak)."
+    ;;
+  *)
+    echo "  btop is set to the \"$current\" theme, which you chose, so it was left alone."
+    echo "  To use hyprsimple's instead, set this in $CONF:"
+    echo "    color_theme = \"current\""
+    ;;
+esac

--- a/test/btop-theme-test.sh
+++ b/test/btop-theme-test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# btop was themed everywhere except in btop.
+#
+# hyprsimple installs btop, install.sh creates ~/.config/btop/themes, all
+# sixteen shipped themes render a btop.theme, and every theme switch copied one
+# to themes/current.theme. Nothing ever told btop to read it. btop selects a
+# theme by the color_theme key in its own config, and that said:
+#
+#   color_theme = "Default"
+#
+# which is what btop writes for itself on first run. Measured on a live install
+# with rosepine active: themes/current.theme held rosepine's colours, and
+# btop.conf still said "Default". The themed btop has never worked anywhere.
+#
+# This is the shape the wlogout colours had, inverted: there a stylesheet was
+# wired to colours nothing rendered, here colours are rendered and delivered
+# and nothing selects them.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+MIGRATION="$REPO/migrations/1788636400.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the premise ------------------------------------------------------------
+
+# The switcher reads the generated theme, not one shipped per theme, so what
+# matters is that every theme renders one: a colors.toml plus the template.
+# Checking for a shipped btop.theme instead would have been asking the wrong
+# question, and one theme does not have one.
+themes=0; with_colors=0
+for t in "$REPO/.config/hypr/themes"/*/; do
+  name=$(basename "$t"); [[ $name == templates* ]] && continue
+  themes=$((themes + 1))
+  [[ -f $t/colors.toml ]] && with_colors=$((with_colors + 1))
+done
+if (( themes < 5 )); then
+  fail "found $themes themes, too few for this to mean anything"
+else
+  pass "checked $themes shipped themes"
+fi
+check "the btop template exists, so a theme can be rendered at all" \
+  "$([[ -f $REPO/.config/hypr/themes/templates/btop.theme.tpl ]] && echo yes || echo no)" "yes"
+check "every theme has the colors the template needs, so every switch renders one" \
+  "$with_colors" "$themes"
+check "and btop is a package hyprsimple installs" \
+  "$(grep -cx 'btop' "$REPO/packages.txt")" "1"
+check "and hyprsimple ships no btop config of its own, which is why nothing set the key" \
+  "$([[ -d $REPO/.config/btop ]] && echo yes || echo no)" "no"
+
+# --- the switcher selects it ------------------------------------------------
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+for tool in gsettings hyprctl systemctl pkill busctl hyprsimple-restart-waybar.sh; do
+  printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
+done
+
+HOME_DIR="$TMP/home"
+setup_home() {
+  rm -rf "${TMP:?}/home"
+  mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.config/uwsm" "$HOME_DIR/.cache" \
+    "$HOME_DIR/.config/hypr/themes/demo/generated"
+  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+    "$HOME_DIR/.local/bin/"
+  printf 'theme[main_bg]="#191724"\n' \
+    >"$HOME_DIR/.config/hypr/themes/demo/generated/btop.theme"
+}
+switch() {
+  HOME="$HOME_DIR" THEME_SWITCHER_NO_RELOAD=1 PATH="$STUB:/usr/bin:/bin" \
+    bash "$HOME_DIR/.local/bin/theme-switcher.sh" demo >/dev/null 2>&1
+}
+btop_conf() { cat "$HOME_DIR/.config/btop/btop.conf" 2>/dev/null; }
+
+setup_home
+switch
+check "the generated theme is still copied into place" \
+  "$([[ -f $HOME_DIR/.config/btop/themes/current.theme ]] && echo yes || echo no)" "yes"
+check "and with no btop.conf one is written that selects it" \
+  "$(btop_conf | grep -c '^color_theme = "current"$')" "1"
+
+# btop writes a full config on first run, with its own default selected.
+setup_home
+mkdir -p "$HOME_DIR/.config/btop"
+printf 'truecolor = true\ncolor_theme = "Default"\nvim_keys = false\n' \
+  >"$HOME_DIR/.config/btop/btop.conf"
+switch
+check "an existing config has the key replaced" \
+  "$(btop_conf | grep -c '^color_theme = "current"$')" "1"
+check "and not appended, which would leave two" \
+  "$(btop_conf | grep -c '^color_theme = ')" "1"
+check "and every other setting is kept" \
+  "$(btop_conf | grep -c 'truecolor\|vim_keys')" "2"
+
+setup_home
+mkdir -p "$HOME_DIR/.config/btop"
+printf 'truecolor = true\n' >"$HOME_DIR/.config/btop/btop.conf"
+switch
+check "a config with no color_theme line gains one" \
+  "$(btop_conf | grep -c '^color_theme = "current"$')" "1"
+check "and keeps what was there" "$(btop_conf | grep -c 'truecolor')" "1"
+
+# A theme with no btop.theme must not touch btop at all.
+setup_home
+rm "$HOME_DIR/.config/hypr/themes/demo/generated/btop.theme"
+switch
+check "a theme with no btop theme writes no btop config" \
+  "$([[ -f $HOME_DIR/.config/btop/btop.conf ]] && echo yes || echo no)" "no"
+
+# --- the migration ----------------------------------------------------------
+
+mk() {
+  rm -rf "${TMP:?}/mhome"; mkdir -p "$TMP/mhome/.config/btop/themes"
+  printf 'theme[main_bg]="#191724"\n' >"$TMP/mhome/.config/btop/themes/current.theme"
+  [[ -n ${1:-} ]] && printf '%s\n' "$1" >"$TMP/mhome/.config/btop/btop.conf"
+  return 0
+}
+run_migration() { HOME="$TMP/mhome" bash "$MIGRATION" >"$TMP/out" 2>&1; }
+mconf() { cat "$TMP/mhome/.config/btop/btop.conf" 2>/dev/null; }
+
+mk 'color_theme = "Default"'
+run_migration
+check "a config left on btop's default is switched over" \
+  "$(mconf | grep -c '^color_theme = "current"$')" "1"
+check "and the previous one is kept" \
+  "$([[ -f $TMP/mhome/.config/btop/btop.conf.bak ]] && echo yes || echo no)" "yes"
+
+mk 'color_theme = "gruvbox_dark"'
+run_migration
+check "a theme the user chose is left alone" \
+  "$(mconf)" 'color_theme = "gruvbox_dark"'
+check "and they are told how to switch" "$(grep -c 'color_theme = ' "$TMP/out")" "1"
+check "and no backup is written, nothing having changed" \
+  "$([[ -f $TMP/mhome/.config/btop/btop.conf.bak ]] && echo yes || echo no)" "no"
+
+mk 'color_theme = "current"'
+run_migration
+check "an already correct config is untouched" \
+  "$([[ -f $TMP/mhome/.config/btop/btop.conf.bak ]] && echo yes || echo no)" "no"
+
+mk ''
+run_migration
+check "no btop.conf at all gets one" \
+  "$(mconf | grep -c '^color_theme = "current"$')" "1"
+
+rm -rf "${TMP:?}/mhome"; mkdir -p "$TMP/mhome/.config/btop"
+run_migration
+check "a home with no generated theme is left alone and says so" \
+  "$(grep -c 'Switching theme will write one' "$TMP/out")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
btop is themed everywhere except in btop.

- `btop` is installed by hyprsimple (`packages.txt:38`)
- `install.sh:734` creates `~/.config/btop/themes`
- every shipped theme renders a `btop.theme` from the template
- every theme switch copies one to `themes/current.theme`

And nothing ever told btop to read it. btop selects a theme by the `color_theme` key in its own config, and on this machine that says:

```
themes/current.theme   theme[main_bg]="#191724"     <- rosepine, current
btop.conf              color_theme = "Default"      <- btop's own first-run default
```

`"Default"` is what btop writes for itself the first time it runs. hyprsimple ships no btop config at all, so nothing has ever changed it. **The themed btop has never worked on any install.**

This is the shape the wlogout colours had, inverted: there a stylesheet was wired to colours nothing rendered, here the colours are rendered and delivered and nothing selects them.

## What changes

`theme-switcher.sh` sets the key alongside the copy it already does. btop names a theme by its filename without the extension, so the file it writes is selected as `"current"`.

The line is **replaced** rather than appended: btop reads its config top to bottom, so a second assignment would win and the file would grow a line per theme switch. A config with no `color_theme` line gains one, and no config at all gets a one-line file, which is enough because btop fills in every key it does not find.

A theme with no `btop.theme` leaves btop alone entirely, with a check for it.

## Migration

`migrations/1788636400.sh` does the same for existing installs, and **only where the config has not chosen a theme**: `Default` and `TTY` are btop's two built-ins, and a missing key means the same thing. A theme the user picked is left alone and reported with the line to change if they want hyprsimple's instead. A home with no generated theme yet is told a theme switch will write one.

## Tests

`test/btop-theme-test.sh`, 20 checks, covering the switcher and the migration.

Four establish the premise before testing anything: the template exists, every theme has the colours it needs, `btop` really is a package hyprsimple installs, and hyprsimple really ships no btop config of its own — which is why the key was never set.

Sabotage: copying the theme without selecting it turns 3 red; making the migration override a chosen theme turns 3 red.

## One correction to my own work

My first premise check asserted that every theme ships a `btop.theme`. That was the wrong question, and it failed at 15 of 16 — `catppuccin` does not ship one. The switcher reads the *generated* theme, so what matters is that every theme renders one, which follows from having `colors.toml` and the template. Checked that way now.

Sweep: 44 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. This machine's `btop.conf` still reads `"Default"`, untouched by the suites — the migration will change it on your next update.