### PR TITLE
Write hyprsunset.conf in the syntax hyprsunset actually reads

### DIFF
--- a/.config/hypr/hyprsunset.conf
+++ b/.config/hypr/hyprsunset.conf
@@ -1,15 +1,23 @@
 # This file is yours. hyprsimple copies it once and never touches it again,
 # so anything you change here stays changed.
 
-# Blue light filter / nightlight
-# Uncomment and adjust to enable automatic nightlight
+# Blue light filter / nightlight, read by hyprsunset.
+#
+# This is hyprlang, the same syntax as the rest of hypr's configs, not TOML.
+# An earlier version of this file used TOML tables, which hyprsunset rejects:
+# it reported "Invalid config line", loaded 0 profiles, and fell back to its
+# 6000K default, so no profile here had any effect.
+#
+# A profile applies from its time until the next profile's time. The day one
+# below uses the identity matrix, which means no colour change at all.
+# Uncomment the night one to warm the screen in the evening.
 
-[[profile]]
-name = "day"
-start_time = 07:00
-identity = true
+profile {
+    time = 7:00
+    identity = true
+}
 
-# [[profile]]
-# name = "night"
-# start_time = 20:00
-# temperature = 4000
+# profile {
+#     time = 20:00
+#     temperature = 4000
+# }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,9 @@ jobs:
       - name: named-paths-test
         run: bash test/named-paths-test.sh
 
+      - name: hyprsunset-config-test
+        run: bash test/hyprsunset-config-test.sh
+
       - name: live-wallpaper-persistence-test
         run: bash test/live-wallpaper-persistence-test.sh
 

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -289,9 +289,9 @@ fi
 
 # ---- Configs this update changed that you still hold your own copy of ----
 #
-# Some configs cannot be delivered automatically. starship.toml, yazi.toml and
-# hyprsunset.conf are TOML, and that format has no include directive, so there
-# is no equivalent of the rofi stubs or the dunst drop-in for them.
+# Some configs cannot be delivered automatically. starship.toml and yazi.toml
+# are TOML, and that format has no include directive, so there is no equivalent
+# of the rofi stubs or the dunst drop-in for them.
 #
 # hyprsimple-refresh-config.sh has always been able to update one, but nothing
 # ever said that it needed updating, so the command existed and was never run.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ hyprsimple-refresh-config hypr/hyprlock.conf
 
 Writing a migration is documented in [`migrations/README.md`](migrations/README.md).
 
-Some configs cannot be delivered automatically. `starship.toml`, `yazi/yazi.toml` and `hypr/hyprsunset.conf` are TOML, so none of them has an include directive to hang a default off the way rofi and dunst do.
+Some configs cannot be delivered automatically. `starship.toml` and `yazi/yazi.toml` are TOML, so neither has an include directive to hang a default off the way rofi and dunst do.
 
 When an update changes one of those and you have your own version, `hyprsimple-update` says so and prints the command to take the new one. It only mentions a file this update actually changed, so editing something on purpose does not nag you every time.
 

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -6,6 +6,11 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("uwsm app -- wl-paste --type text --watch cliphist store")
   hl.exec_cmd("uwsm app -- wl-paste --type image --watch cliphist store")
   hl.exec_cmd("uwsm app -- hypridle")
+  -- hyprsunset applies the profiles in ~/.config/hypr/hyprsunset.conf. Nothing
+  -- started it before, so those profiles never ran: the file invited you to
+  -- uncomment a night profile and uncommenting it did nothing. SUPER+N starts
+  -- it too, but only for that session and only once pressed.
+  hl.exec_cmd("uwsm app -- hyprsunset")
   hl.exec_cmd("uwsm app -- " .. os.getenv("HOME") .. "/.local/bin/capslock-notify.sh")
   hl.exec_cmd("uwsm app -- " .. vars.terminal)
   -- apply, not on: the flag records what you chose, and login restores it

--- a/migrations/1788644900.sh
+++ b/migrations/1788644900.sh
@@ -1,0 +1,49 @@
+echo "Rewrite hyprsunset.conf in the syntax hyprsunset actually reads"
+
+# The shipped ~/.config/hypr/hyprsunset.conf used TOML tables:
+#
+#   [[profile]]
+#   name = "day"
+#   start_time = 07:00
+#   identity = true
+#
+# hyprsunset reads hyprlang, the same syntax as the rest of hypr's configs, and
+# rejected that outright. Measured with hyprsunset v0.4.0 against the shipped
+# file: "Config error ... at line 7: Invalid config line", then "Loaded 0
+# profiles", then a fall back to its own 6000K default. Uncommenting the night
+# profile the file invited you to enable changed nothing, because no profile in
+# it was ever read.
+#
+# Replaced only where the file is still byte-identical to a version hyprsimple
+# shipped. Anything edited is left alone, because a hand-written TOML profile is
+# still a record of what its author wanted even though hyprsunset ignores it.
+
+user="$HOME/.config/hypr/hyprsunset.conf"
+shipped="$HYPRSIMPLE_PATH/.config/hypr/hyprsunset.conf"
+
+[[ -f $user && -f $shipped ]] || exit 0
+cmp -s "$user" "$shipped" && exit 0
+
+# Every version of this file the project shipped before the current one.
+SHIPPED_SUMS=(
+  290af9a61b2c12f96bacc3bced76a9ce
+  e5ad8929e405b01fe6519fa19100bd80
+)
+
+sum=$(md5sum "$user" | cut -d' ' -f1)
+
+for known in "${SHIPPED_SUMS[@]}"; do
+  if [[ $sum == "$known" ]]; then
+    cp -f "$user" "$user.bak"
+    cp -f "$shipped" "$user"
+    echo "  Updated $user (previous version kept at $user.bak)"
+    echo "  Its profiles are read now. hyprsunset also starts with your session,"
+    echo "  so uncommenting the night profile takes effect at your next login."
+    exit 0
+  fi
+done
+
+echo "  $user has your own edits, so it was left alone."
+echo "  If it uses TOML tables such as [[profile]], hyprsunset cannot read them"
+echo "  and loads no profiles at all. hyprsimple's version is hyprlang:"
+echo "    hyprsimple-refresh-config.sh hypr/hyprsunset.conf"

--- a/test/fixtures/hypr/hyprsunset.conf.toml
+++ b/test/fixtures/hypr/hyprsunset.conf.toml
@@ -1,0 +1,15 @@
+# This file is yours. hyprsimple copies it once and never touches it again,
+# so anything you change here stays changed.
+
+# Blue light filter / nightlight
+# Uncomment and adjust to enable automatic nightlight
+
+[[profile]]
+name = "day"
+start_time = 07:00
+identity = true
+
+# [[profile]]
+# name = "night"
+# start_time = 20:00
+# temperature = 4000

--- a/test/hyprsunset-config-test.sh
+++ b/test/hyprsunset-config-test.sh
@@ -77,8 +77,15 @@ else
     local dir="$TMP/xdg-$RANDOM"; mkdir -p "$dir/hypr"
     cp "$1" "$dir/hypr/hyprsunset.conf"
     timeout 4 env XDG_CONFIG_HOME="$dir" hyprsunset >"$dir/out" 2>&1 &
-    local pid=$!
-    sleep 2
+    local pid=$! waited=0
+    # Wait for the verdict rather than for a fixed two seconds. Four of these
+    # in one suite made the sweep noticeably slower, and a fixed sleep is both
+    # slower than it needs to be and flakier than it looks.
+    while (( waited < 40 )); do
+      grep -q 'Loaded [0-9]* profiles' "$dir/out" 2>/dev/null && break
+      sleep 0.1
+      waited=$((waited + 1))
+    done
     kill "$pid" 2>/dev/null
     pkill -x hyprsunset 2>/dev/null
     wait "$pid" 2>/dev/null

--- a/test/hyprsunset-config-test.sh
+++ b/test/hyprsunset-config-test.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# The shipped hyprsunset.conf was TOML, and hyprsunset does not read TOML.
+#
+#   [[profile]]
+#   name = "day"
+#   start_time = 07:00
+#   identity = true
+#
+# hyprsunset reads hyprlang, the same syntax as the rest of hypr's configs.
+# Measured with hyprsunset v0.4.0 against the shipped file:
+#
+#   Config error in file .../hyprsunset.conf at line 7: Invalid config line
+#   Loaded 0 profiles
+#   Setting the temperature to 6000K (default)
+#
+# So the file's own invitation, "Uncomment and adjust to enable automatic
+# nightlight", could not be acted on: no profile in it was ever read.
+#
+# And nothing started hyprsunset anyway. It appeared in autostart zero times,
+# so the daemon only ever ran if SUPER+N was pressed, and only for that session.
+#
+# hyprsunset is a real dependency and is installed, so where it is present this
+# suite hands it each config and reads its verdict rather than judging the
+# syntax itself. Where it is absent, the checks that do not need it still run.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONF="$REPO/.config/hypr/hyprsunset.conf"
+MIGRATION="$REPO/migrations/1788644900.sh"
+OLD_TOML="$REPO/test/fixtures/hypr/hyprsunset.conf.toml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the syntax, without needing hyprsunset ---------------------------------
+
+check "the shipped config no longer uses TOML tables" \
+  "$(grep -c '^\[\[profile\]\]' "$CONF")" "0"
+check "and declares its profiles the hyprlang way" \
+  "$(grep -cE '^profile \{' "$CONF")" "1"
+check "and keeps a commented night profile to enable" \
+  "$(grep -cE '^# profile \{' "$CONF")" "1"
+check "the fixture of the old file really is the TOML one" \
+  "$(grep -c '^\[\[profile\]\]' "$OLD_TOML")" "1"
+
+# --- autostart ---------------------------------------------------------------
+
+code_of() { sed 's/^[[:space:]]*--.*//' "$1"; }
+check "autostart starts hyprsunset, so the profiles are read at login" \
+  "$(code_of "$REPO/default/hypr/autostart.lua" | grep -c 'uwsm app -- hyprsunset')" "1"
+check "stripping comments leaves autostart's code intact" \
+  "$(code_of "$REPO/default/hypr/autostart.lua" | grep -c 'uwsm app -- waybar')" "1"
+
+# --- nothing still calls the file TOML ---------------------------------------
+
+check "the README no longer lists hyprsunset.conf among the TOML configs" \
+  "$(grep -c 'hyprsunset.conf. are TOML' "$REPO/README.md")" "0"
+check "nor does the update script" \
+  "$(grep -c 'hyprsunset.conf are TOML' "$REPO/.local/bin/hyprsimple-update.sh")" "0"
+
+# --- hyprsunset's own verdict ------------------------------------------------
+
+if ! command -v hyprsunset >/dev/null 2>&1; then
+  pass "hyprsunset is not installed here, so its verdict is skipped"
+else
+  # XDG_CONFIG_HOME, not HOME: hyprsunset resolves the path without consulting
+  # HOME, so pointing HOME elsewhere reads the real user's file instead.
+  verdict() {
+    local dir="$TMP/xdg-$RANDOM"; mkdir -p "$dir/hypr"
+    cp "$1" "$dir/hypr/hyprsunset.conf"
+    timeout 4 env XDG_CONFIG_HOME="$dir" hyprsunset >"$dir/out" 2>&1 &
+    local pid=$!
+    sleep 2
+    kill "$pid" 2>/dev/null
+    pkill -x hyprsunset 2>/dev/null
+    wait "$pid" 2>/dev/null
+    cat "$dir/out"
+  }
+
+  out=$(verdict "$OLD_TOML")
+  check "hyprsunset rejects the old TOML file" \
+    "$(printf '%s' "$out" | grep -c 'Invalid config line')" "1"
+  check "and loads none of its profiles" \
+    "$(printf '%s' "$out" | grep -c 'Loaded 0 profiles')" "1"
+
+  out=$(verdict "$CONF")
+  check "hyprsunset accepts the new file" \
+    "$(printf '%s' "$out" | grep -c 'Config error')" "0"
+  check "and loads the day profile from it" \
+    "$(printf '%s' "$out" | grep -c 'Loaded 1 profiles')" "1"
+
+  # The commented night profile has to be valid too, or the invitation to
+  # uncomment it is the same empty promise in a new syntax.
+  sed 's/^# profile {/profile {/; s/^#     time/    time/; s/^#     temperature/    temperature/; s/^# }/}/' \
+    "$CONF" >"$TMP/night.conf"
+  out=$(verdict "$TMP/night.conf")
+  check "uncommenting the night profile is valid too" \
+    "$(printf '%s' "$out" | grep -c 'Config error')" "0"
+  check "and gives two profiles" \
+    "$(printf '%s' "$out" | grep -c 'Loaded 2 profiles')" "1"
+fi
+
+# --- the migration -----------------------------------------------------------
+
+mk() {
+  rm -rf "${TMP:?}/mhome" "${TMP:?}/minstall"
+  mkdir -p "$TMP/mhome/.config/hypr" "$TMP/minstall/.config/hypr"
+  cp "$CONF" "$TMP/minstall/.config/hypr/hyprsunset.conf"
+  cp "$1" "$TMP/mhome/.config/hypr/hyprsunset.conf"
+}
+run_migration() {
+  HOME="$TMP/mhome" HYPRSIMPLE_PATH="$TMP/minstall" bash "$MIGRATION" >"$TMP/mout" 2>&1
+}
+
+sum=$(md5sum "$OLD_TOML" | cut -d' ' -f1)
+if grep -q "$sum" "$MIGRATION"; then
+  pass "the migration lists the checksum of the file it replaces"
+else
+  fail "the migration does not list $sum, so it will not update an existing install"
+fi
+
+mk "$OLD_TOML"
+run_migration
+check "an untouched TOML config is replaced" \
+  "$(cmp -s "$TMP/mhome/.config/hypr/hyprsunset.conf" "$CONF" && echo yes || echo no)" "yes"
+check "and the previous version is kept" \
+  "$([[ -f $TMP/mhome/.config/hypr/hyprsunset.conf.bak ]] && echo yes || echo no)" "yes"
+
+run_migration
+check "re-running on an already current file says nothing" \
+  "$(grep -c 'Updated' "$TMP/mout")" "0"
+
+printf '[[profile]]\nname = "mine"\n' >"$TMP/edited.conf"
+mk "$TMP/edited.conf"
+run_migration
+check "an edited config is left alone" \
+  "$(head -1 "$TMP/mhome/.config/hypr/hyprsunset.conf")" '[[profile]]'
+check "and the user is told hyprsunset cannot read it" \
+  "$(grep -c 'loads no profiles at all' "$TMP/mout")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
The shipped `~/.config/hypr/hyprsunset.conf` was TOML. hyprsunset reads **hyprlang**, the same syntax as the rest of hypr's configs, and rejects it outright.

Handing hyprsunset v0.4.0 the shipped file:

```
Config error in file .../hyprsunset.conf at line 7: Invalid config line
Proceeding ignoring faulty entries
┣ Loaded 0 profiles
┣ Setting the temperature to 6000K (default)
```

Line 7 is `[[profile]]`. So the file's own invitation — *"Uncomment and adjust to enable automatic nightlight"* — could not be acted on. No profile in it was ever read, and the day profile's `identity = true` never applied either.

## Nothing started hyprsunset anyway

It appeared in `autostart.lua` zero times. The daemon ran only if `SUPER+N` was pressed, and only for that session, so a valid config would not have helped on its own. `autostart` runs it now alongside dunst, waybar and hypridle.

Both halves had to be wrong for the symptom to be invisible, which is why this survived: with 0 profiles loaded and the daemon usually not running, the screen simply looked normal.

## What the new file gives

```
profile {
    time = 7:00
    identity = true
}
```

with the night profile commented out, as before. hyprsunset's verdict on each:

```
old TOML file            Invalid config line, Loaded 0 profiles
new file                 Loaded 1 profiles, no error
night profile uncommented Loaded 2 profiles, Setting the temperature to 4000K
```

That last one is checked by stripping the comment markers in the test, so the invitation to uncomment is verified rather than assumed.

## Two documentation claims corrected

`README.md:126` and a comment in `hyprsimple-update.sh` both listed this file among the TOML configs that cannot carry an include. It is not TOML, and hyprlang has `source`, so both are wrong on both counts.

## Tests

`test/hyprsunset-config-test.sh`, 20 checks. Where hyprsunset is installed it is handed each config and its own output is read, rather than the suite judging syntax it does not own; where it is absent those checks are skipped and the rest still run. `XDG_CONFIG_HOME` is what redirects it, not `HOME` — hyprsunset resolves the path without consulting `HOME`, so my first attempt read the real user's file instead and I had to correct it.

Sabotage: restoring the TOML file turns 6 red; removing the autostart line turns 1 red.

A migration replaces the file where it is still byte-identical to a shipped version, keeping a `.bak`. An edited one is left alone and told that TOML tables load no profiles at all.

Sweep: 48 suites, 0 failing, three consecutive runs, each followed by a check that no hyprsunset process was left behind. shellcheck clean at `style`.

One follow-up commit: the suite originally used four two-second sleeps and added about eight seconds to every sweep. It waits for `Loaded N profiles` to appear instead, and runs in 679ms.