### PR TITLE
Install the icon themes the themes name

### DIFF
--- a/.config/hypr/themes/vantablack/icons.theme
+++ b/.config/hypr/themes/vantablack/icons.theme
@@ -1,1 +1,1 @@
-Yaru-gray
+Yaru-dark

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,9 @@ jobs:
       - name: named-paths-test
         run: bash test/named-paths-test.sh
 
+      - name: icon-themes-test
+        run: bash test/icon-themes-test.sh
+
       - name: hyprsunset-config-test
         run: bash test/hyprsunset-config-test.sh
 

--- a/aur-packages.txt
+++ b/aur-packages.txt
@@ -1,4 +1,5 @@
 # AUR Packages
+yaru-icon-theme
 wl-mirror
 wl-screenrec-git
 muslimtify

--- a/default/dunst/10-hyprsimple.conf
+++ b/default/dunst/10-hyprsimple.conf
@@ -2,9 +2,7 @@
     follow = mouse
     indicate_hidden = yes
 
-    offset = 10x10
-
-    notification_height = 0
+    offset = (10, 10)
 
     separator_height = 2
 
@@ -33,9 +31,16 @@
     min_icon_size = 0
     max_icon_size = 64
 
-    icon_path = /usr/share/icons/Papirus-Dark/16x16/status/:/usr/share/icons/Papirus-Dark/16x16/devices/:/usr/share/icons/Papirus-Dark/16x16/actions/:/usr/share/icons/Papirus-Dark/16x16/animations/:/usr/share/icons/Papirus-Dark/16x16/apps/:/usr/share/icons/Papirus-Dark/16x16/categories/:/usr/share/icons/Papirus-Dark/16x16/emblems/:/usr/share/icons/Papirus-Dark/16x16/emotes/:/usr/share/icons/Papirus-Dark/16x16/devices/mimetypes:/usr/share/icons/Papirus-Dark/16x16/panel/:/usr/share/icons/Papirus-Dark/16x16/places/
+    # Was eleven hardcoded /usr/share/icons/Papirus-Dark/16x16/* paths, and
+    # papirus-icon-theme was in neither package list, so every one of them
+    # resolved to nothing. Naming themes instead lets dunst do its own lookup,
+    # and the fallback means a missing theme degrades rather than disappears.
+    icon_theme = "Papirus-Dark, Adwaita"
+    enable_recursive_icon_lookup = true
 
-    dmenu = /usr/bin/wofi -p dunst:
+    # rofi, not wofi: wofi is in neither package list, and rofi is what
+    # hyprsimple installs and uses everywhere else.
+    dmenu = /usr/bin/rofi -dmenu -p dunst:
     browser = /usr/bin/brave
 
     title = Dunst

--- a/packages.txt
+++ b/packages.txt
@@ -64,6 +64,8 @@ alsa-utils
 ffmpeg
 swayimg
 
+papirus-icon-theme
+
 # CLI Tools
 fzf
 bat

--- a/test/icon-themes-test.sh
+++ b/test/icon-themes-test.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Every shipped theme named an icon theme that nothing installed.
+#
+# theme-switcher.sh runs
+#
+#   gsettings set org.gnome.desktop.interface icon-theme "$(cat icons.theme)"
+#
+# for every theme, and all sixteen name one: fifteen a Yaru variant, one
+# Papirus-Dark. Neither yaru-icon-theme nor papirus-icon-theme was in
+# packages.txt or aur-packages.txt. Measured on a live install with rosepine
+# active: gsettings read 'Yaru-blue' and /usr/share/icons held only Adwaita,
+# breeze and hicolor. GTK silently fell back, so the per-theme icons have never
+# worked anywhere.
+#
+# This is the shape the btop theme had in #86: the whole chain built, and the
+# last link never connected. There the config key was never set; here the
+# package was never installed.
+#
+# The dunst drop-in named things that were not installed too, and two settings
+# dunst rejects outright. Where dunst is present this suite asks it rather than
+# judging its syntax here.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DROPIN="$REPO/default/dunst/10-hyprsimple.conf"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# The variants Yaru actually ships, recorded here rather than fetched: a suite
+# must not need the network, and this is the list that made Yaru-gray a bug.
+YARU_VARIANTS="Yaru Yaru-bark Yaru-blue Yaru-dark Yaru-magenta Yaru-mate \
+Yaru-olive Yaru-prussiangreen Yaru-purple Yaru-red Yaru-sage Yaru-viridian \
+Yaru-wartybrown Yaru-yellow"
+
+# --- every named icon theme comes from a package we install ------------------
+
+themes=0; named=0; unpackaged=(); unknown=()
+for t in "$REPO/.config/hypr/themes"/*/; do
+  name=$(basename "$t"); [[ $name == templates* ]] && continue
+  themes=$((themes + 1))
+  icon=$(cat "$t/icons.theme" 2>/dev/null || cat "$t/icon-theme" 2>/dev/null)
+  icon=${icon//[$'\n\r']/}
+  [[ -z $icon ]] && continue
+  named=$((named + 1))
+  case "$icon" in
+    Yaru*)
+      grep -qx 'yaru-icon-theme' "$REPO/aur-packages.txt" || unpackaged+=("$name:$icon")
+      printf '%s\n' $YARU_VARIANTS | grep -qx "$icon" || unknown+=("$name:$icon")
+      ;;
+    Papirus*)
+      grep -qx 'papirus-icon-theme' "$REPO/packages.txt" || unpackaged+=("$name:$icon")
+      ;;
+    *) unknown+=("$name:$icon") ;;
+  esac
+done
+
+if (( themes < 5 )); then
+  fail "found $themes themes, too few for this to mean anything"
+else
+  pass "checked $themes shipped themes"
+fi
+check "most of them name an icon theme, so there is something to install" \
+  "$([[ $named -ge 10 ]] && echo enough || echo "only $named")" "enough"
+
+u=""; (( ${#unpackaged[@]} > 0 )) && u="$(printf '%s; ' "${unpackaged[@]}")"
+check "every named icon theme comes from a package in a list" "$u" ""
+
+# Yaru has no gray. vantablack asked for Yaru-gray, which would have fallen
+# back even once the package was installed.
+k=""; (( ${#unknown[@]} > 0 )) && k="$(printf '%s; ' "${unknown[@]}")"
+check "and every Yaru variant named is one Yaru actually ships" "$k" ""
+
+# The package list entries have to be in the right file: yaru-icon-theme is AUR
+# only, papirus-icon-theme is in extra.
+check "yaru-icon-theme is in the AUR list, where an AUR-only package belongs" \
+  "$(grep -cx 'yaru-icon-theme' "$REPO/aur-packages.txt")" "1"
+check "and not in the pacman list, which cannot resolve it" \
+  "$(grep -cx 'yaru-icon-theme' "$REPO/packages.txt")" "0"
+check "papirus-icon-theme is in the pacman list, being in extra" \
+  "$(grep -cx 'papirus-icon-theme' "$REPO/packages.txt")" "1"
+
+# --- the dunst drop-in -------------------------------------------------------
+
+check "the drop-in no longer hardcodes Papirus icon paths" \
+  "$(grep -c 'icon_path' "$DROPIN")" "0"
+check "and names icon themes with a fallback instead" \
+  "$(grep -c 'icon_theme = "Papirus-Dark, Adwaita"' "$DROPIN")" "1"
+check "its dmenu uses rofi, which hyprsimple installs" \
+  "$(grep -c 'dmenu = /usr/bin/rofi -dmenu' "$DROPIN")" "1"
+# Comments stripped: the note left beside the dmenu line names wofi, and an
+# unanchored grep counts that.
+code_of() { sed 's/#.*//' "$1"; }
+check "and not wofi, which is in neither list" \
+  "$(code_of "$DROPIN" | grep -c 'wofi')" "0"
+check "stripping comments leaves the drop-in's settings intact" \
+  "$(code_of "$DROPIN" | grep -c 'dmenu = /usr/bin/rofi')" "1"
+# grep -c across two files prints one count per file. Summed in the shell,
+# because bc is not installed on a hyprsimple machine.
+wofi_listed=0
+while read -r n; do wofi_listed=$((wofi_listed + n)); done < <(
+  grep -cx 'wofi' "$REPO/packages.txt" "$REPO/aur-packages.txt" | cut -d: -f2
+)
+check "wofi really is absent from both lists, which is why" "$wofi_listed" "0"
+
+if ! command -v dunst >/dev/null 2>&1; then
+  pass "dunst is not installed here, so its verdict is skipped"
+else
+  # A theme directory dunst can find, so the only remaining warning on a
+  # machine without papirus-icon-theme installed does not mask a real one.
+  mkdir -p "$TMP/icons/Papirus-Dark/16x16/status"
+  printf '[Icon Theme]\nName=Papirus-Dark\nDirectories=16x16/status\n[16x16/status]\nSize=16\n' \
+    >"$TMP/icons/Papirus-Dark/index.theme"
+  complaints=$(XDG_DATA_DIRS="$TMP:/usr/share" dunst --config "$DROPIN" --print 2>&1 |
+    grep -icE 'warning|legacy|does.t exist' || true)
+  check "dunst accepts the drop-in with no warning of any kind" "$complaints" "0"
+
+  # And the two it used to make are gone for the right reason, not because the
+  # check stopped looking.
+  probe() {
+    printf '[global]\n%s\n' "$1" >"$TMP/probe.conf"
+    dunst --config "$TMP/probe.conf" --print 2>&1 | grep -icE 'warning|legacy|does.t exist' || true
+  }
+  check "dunst still rejects the old offset syntax, so that check means something" \
+    "$(probe 'offset = 10x10')" "1"
+  check "and still rejects notification_height" \
+    "$(probe 'notification_height = 0')" "1"
+fi
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/icon-themes-test.sh
+++ b/test/icon-themes-test.sh
@@ -37,9 +37,11 @@ check() {
 
 # The variants Yaru actually ships, recorded here rather than fetched: a suite
 # must not need the network, and this is the list that made Yaru-gray a bug.
-YARU_VARIANTS="Yaru Yaru-bark Yaru-blue Yaru-dark Yaru-magenta Yaru-mate \
-Yaru-olive Yaru-prussiangreen Yaru-purple Yaru-red Yaru-sage Yaru-viridian \
-Yaru-wartybrown Yaru-yellow"
+YARU_VARIANTS=(
+  Yaru Yaru-bark Yaru-blue Yaru-dark Yaru-magenta Yaru-mate Yaru-olive
+  Yaru-prussiangreen Yaru-purple Yaru-red Yaru-sage Yaru-viridian
+  Yaru-wartybrown Yaru-yellow
+)
 
 # --- every named icon theme comes from a package we install ------------------
 
@@ -54,7 +56,7 @@ for t in "$REPO/.config/hypr/themes"/*/; do
   case "$icon" in
     Yaru*)
       grep -qx 'yaru-icon-theme' "$REPO/aur-packages.txt" || unpackaged+=("$name:$icon")
-      printf '%s\n' $YARU_VARIANTS | grep -qx "$icon" || unknown+=("$name:$icon")
+      printf '%s\n' "${YARU_VARIANTS[@]}" | grep -qx "$icon" || unknown+=("$name:$icon")
       ;;
     Papirus*)
       grep -qx 'papirus-icon-theme' "$REPO/packages.txt" || unpackaged+=("$name:$icon")


### PR DESCRIPTION
Every shipped theme names an icon theme, and nothing installed any of them.

`theme-switcher.sh` runs `gsettings set org.gnome.desktop.interface icon-theme` from each theme's `icons.theme`. All sixteen name one: fifteen a Yaru variant, one `Papirus-Dark`. Neither `yaru-icon-theme` nor `papirus-icon-theme` was in `packages.txt` or `aur-packages.txt`.

Measured on a live install with rosepine active:

```
gsettings icon-theme        Yaru-blue
/usr/share/icons            Adwaita  breeze  breeze-dark  hicolor  ...
installed icon packages     adwaita-icon-theme, hicolor-icon-theme
```

GTK falls back silently, so the per-theme icons have never worked on any install. This is #86 again: the whole chain built, and the last link never connected. There the config key was never set; here the package was never installed.

`papirus-icon-theme` is in `extra`, so it goes in `packages.txt`. `yaru-icon-theme` is **AUR only** — checked against both `archlinux.org` and the AUR RPC — so it goes in `aur-packages.txt`.

## One theme named a variant that does not exist

`vantablack` asked for `Yaru-gray`. Yaru ships bark, blue, dark, magenta, mate, olive, prussiangreen, purple, red, sage, viridian, wartybrown and yellow, checked against `ubuntu/yaru`. There is no gray, so that one would have fallen back even after installing the package. It asks for `Yaru-dark` now, the neutral variant, which suits a black theme.

## The dunst drop-in named absent things too

| was | why it was wrong |
|---|---|
| eleven hardcoded `/usr/share/icons/Papirus-Dark/16x16/*` paths | none of them resolved, the package was not installed |
| `dmenu = /usr/bin/wofi -p dunst:` | `wofi` is in neither package list; hyprsimple installs and uses rofi everywhere else |

The icon paths become `icon_theme = "Papirus-Dark, Adwaita"` with `enable_recursive_icon_lookup`, so a missing theme degrades instead of disappearing.

## And two settings dunst rejects outright

Asked dunst 1.13.2 directly:

```
offset = 10x10             MESSAGE: Using legacy offset syntax NxN, switch to (N, N)
notification_height = 0    WARNING: Setting notification_height in section global doesn't exist
offset = (10, 10)          accepted
```

`notification_height` is **removed** rather than translated to `height`. It has never applied on this dunst, so removing it keeps today's behaviour, whereas `height = (min, max)` would cap the maximum and change how notifications look.

dunst now parses the drop-in with no warning of any kind, verified with a `Papirus-Dark` theme visible on `XDG_DATA_DIRS` so the one legitimate "theme not found" message on this machine does not mask a real one.

## Tests

`test/icon-themes-test.sh`, 17 checks. Two of them keep the dunst verdict honest by confirming dunst *still* rejects `offset = 10x10` and `notification_height`, so "no warnings" cannot pass because the check stopped looking. The Yaru variant list is recorded in the suite rather than fetched, since a suite must not need the network.

Sabotage: removing the packages turns 3 red and names all sixteen themes; restoring `Yaru-gray` turns 1 red; restoring the old dunst settings turns 4 red.

## Three corrections in my own suite

- A `grep -c wofi` counted the comment I had just written explaining why wofi was removed. Fifth time in this series, and it now uses the comment-stripping helper with a check that the stripper leaves real settings behind.
- `bc` is not installed on a hyprsimple machine, so summing two `grep -c` results through it failed. Summed in the shell.
- shellcheck flagged deliberate word splitting on the variant list at `style`, which CI lints at, so it is an array now. Re-ran the `Yaru-gray` sabotage afterwards to confirm the array did not weaken the check.

Sweep: 49 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. The running dunst was never restarted.