### PR TITLE
Make a screenshot notify once, and refuse an unknown mode

### DIFF
--- a/.local/bin/screenshot.sh
+++ b/.local/bin/screenshot.sh
@@ -2,31 +2,38 @@
 
 set -e
 
-mode="$1"
-
-if [ -z "$mode" ]; then
-  echo "Usage: $0 <mode>"
-  echo "Modes: clipboard, window, region, monitor"
+usage() {
+  echo "Usage: $(basename "$0") <mode>" >&2
+  echo "Modes: clipboard, window, region, monitor" >&2
   exit 1
-fi
+}
 
-if [ "$mode" == "clipboard" ]; then
-    hyprshot -m output --clipboard-only
-    notify-send "Screenshot" "Copied to clipboard"
-    exit 0
-fi
+mode="${1:-}"
+SHOTS="$HOME/Pictures/Screenshots"
 
-if [ "$mode" == "window" ]; then
-    hyprshot -m window --freeze --output-folder "$HOME/Pictures/Screenshots"
-    exit 0
-fi
-
-if [ "$mode" == "region" ]; then
-    hyprshot -m region --freeze --output-folder "$HOME/Pictures/Screenshots"
-    exit 0
-fi
-
-if [ "$mode" == "monitor" ]; then
-    hyprshot -m output --freeze --output-folder "$HOME/Pictures/Screenshots"
-    exit 0
-fi
+case "$mode" in
+clipboard)
+  # --silent because hyprsimple sends its own message below. hyprshot notifies
+  # unless told not to, so without this the one keypress produced two
+  # notifications saying the same thing: its "Image copied to the clipboard"
+  # and ours.
+  hyprshot -m output --clipboard-only --silent
+  notify-send "Screenshot" "Copied to clipboard"
+  ;;
+window)
+  # The three saving modes have no notify of their own: hyprshot's names the
+  # file it wrote, which is more useful than anything repeated here.
+  hyprshot -m window --freeze --output-folder "$SHOTS"
+  ;;
+region)
+  hyprshot -m region --freeze --output-folder "$SHOTS"
+  ;;
+monitor)
+  hyprshot -m output --freeze --output-folder "$SHOTS"
+  ;;
+*)
+  # A mode that is not one of the four used to fall past every branch and exit
+  # 0, so a typo took no screenshot and reported success.
+  usage
+  ;;
+esac

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -49,6 +49,54 @@ done
 # one mode where freezing matters never froze.
 check "no screenshot mode passes a flag hyprshot does not know" \
   "$(grep -c -- '--freze' "$BIN/screenshot.sh")" "0"
+
+# hyprshot notifies unless told not to, so a mode that also notifies here sent
+# two messages for one keypress. Measured before the fix, with a hyprshot stub
+# notifying the way the real one does: two notifications, "Image copied to the
+# clipboard" and "Copied to clipboard".
+cat >"$STUB/hyprshot" <<'STUBEOF'
+#!/bin/bash
+printf '%s|%s
+' "$#" "$*" >>"${CALL_LOG:?}"
+# The real hyprshot notifies unless --silent is passed.
+for a in "$@"; do [[ $a == --silent ]] && exit 0; done
+notify-send "Screenshot saved" "Image copied to the clipboard"
+STUBEOF
+chmod +x "$STUB/hyprshot"
+NLOG_SHOT="$TMP/shot-notifications"
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s
+' "$*" >>"${NOTIFY_LOG:?}"
+STUBEOF
+chmod +x "$STUB/notify-send"
+
+for mode in clipboard window region monitor; do
+  : >"$LOG"; : >"$NLOG_SHOT"
+  CALL_LOG="$LOG" NOTIFY_LOG="$NLOG_SHOT" HOME="$SPACED" PATH="$STUB:$PATH"     bash "$BIN/screenshot.sh" "$mode" >/dev/null 2>&1
+  check "screenshot $mode notifies exactly once" \
+    "$(wc -l <"$NLOG_SHOT" | tr -d ' ')" "1"
+done
+
+# A mode that is not one of the four used to fall past every branch and exit 0.
+: >"$LOG"; : >"$NLOG_SHOT"
+CALL_LOG="$LOG" NOTIFY_LOG="$NLOG_SHOT" HOME="$SPACED" PATH="$STUB:$PATH" \
+  bash "$BIN/screenshot.sh" clipbaord >"$TMP/shot-out" 2>"$TMP/shot-err"
+check "an unknown mode exits non-zero" "$?" "1"
+check "and takes no screenshot" "$(wc -l <"$LOG" | tr -d ' ')" "0"
+check "and puts its usage on stderr" "$(grep -c 'Usage:' "$TMP/shot-err")" "1"
+check "and nothing on stdout" "$(wc -c <"$TMP/shot-out" | tr -d ' ')" "0"
+
+# The original hyprshot stub, restored for anything after this point.
+cat >"$STUB/hyprshot" <<'STUBEOF'
+#!/bin/bash
+printf '%s|%s
+' "$#" "$*" >>"${CALL_LOG:?}"
+STUBEOF
+chmod +x "$STUB/hyprshot"
+printf '#!/bin/bash
+exit 0
+' >"$STUB/notify-send"; chmod +x "$STUB/notify-send"
 check "region freezes the screen" \
   "$(grep -c -- '-m region --freeze' "$BIN/screenshot.sh")" "1"
 


### PR DESCRIPTION
Three defects in `screenshot.sh`, all reproduced with stubs.

## SUPER + CTRL + Print sent two notifications for one keypress

hyprshot notifies unless `--silent` is passed. From its own source, the only guard on `send_notification` is:

```bash
function send_notification() {
    if [ $SILENT -eq 1 ]; then
        return 0
    fi
    local message=$([ $CLIPBOARD -eq 1 ] && \
        echo "Image copied to the clipboard" || ...
```

`screenshot.sh` never passed `--silent`, and added its own on top. Measured with a hyprshot stub notifying the way the real one does:

```
notifications sent: 2
  notify-send Screenshot saved | Image copied to the clipboard    (hyprshot)
  notify-send Screenshot       | Copied to clipboard              (screenshot.sh)
```

The clipboard mode passes `--silent` now, so hyprsimple's message stands alone. The three saving modes are unchanged and still rely on hyprshot's, which names the file it wrote — repeating that here would add nothing.

## An unknown mode reported success and took no screenshot

The four modes were four separate `if` blocks with no fallthrough, so anything else exited 0 having done nothing:

```
$ screenshot.sh clipbaord
exit=0  stdout=[]  stderr=[]  calls=0
```

It is a `case` with a default now, which prints usage and exits 1.

## And the usage went to stdout

Two lines on stdout, none on stderr, the same defect already fixed in `search_by_keyword.sh` and `bluetooth-toggle.sh`.

## Tests

Four checks assert each mode notifies **exactly once**, driven by a hyprshot stub that notifies unless `--silent` is passed, so the count is measured against hyprshot's real behaviour rather than assumed. Four more cover the unknown mode.

Sabotage: dropping `--silent` turns the clipboard count red at `want 1, got 2`; removing the default case turns 2 red.

`notification-idiom-test.sh` still passes unchanged, which is part of why `--silent` was preferred over deleting hyprsimple's own message: that suite exists to prove the script's control flow reaches a notification, and it still does.

Sweep: 51 suites, 0 failing, three consecutive runs. shellcheck clean at `style`.

## Two things I checked and did not report

Both looked like bugs and were not, so they are off the list rather than sitting in a backlog.

`capslock-notify.sh` picks its LED with a glob that sorts `input46::capslock` before `input4::capslock`, so on this machine it watches the wireless dongle while Hyprland's main keyboard is the built-in one. That looked wrong until I read the triggers: both are `kbd-capslock`, the kernel's global state, so they track together and either works.

Its fallback path, for a machine with no capslock LED at all, spawns `hyprctl` and `jq` twice a second forever — about 14400 processes an hour. That is a real cost but it is an efficiency question rather than a defect, and not one to fix quietly inside a screenshot PR.