### PR TITLE
Carry the vantablack icon theme fix to installs that already exist

### DIFF
--- a/migrations/1788645000.sh
+++ b/migrations/1788645000.sh
@@ -1,0 +1,56 @@
+echo "Give vantablack an icon theme that exists"
+
+# vantablack named Yaru-gray. Yaru has no gray: the variants it ships are
+# Yaru and Yaru-bark, -blue, -dark, -magenta, -mate, -olive, -prussiangreen,
+# -purple, -red, -sage, -viridian, -wartybrown, -yellow. Selecting vantablack
+# therefore set gsettings icon-theme to a name nothing provides and GTK fell
+# back to hicolor.
+#
+# #91 corrected the shipped file to Yaru-dark and stopped there. Everything
+# under ~/.config is copied once and never overwritten, so that correction
+# reached new installs only, and every machine installed before #91 still
+# names the theme that does not exist. This carries it the rest of the way.
+#
+# Only the exact wrong value is replaced. Anything else in this file is a
+# choice someone made and is left alone.
+
+THEME_FILE="$HOME/.config/hypr/themes/vantablack/icons.theme"
+
+if [[ ! -f $THEME_FILE ]]; then
+  echo "  No vantablack theme here, nothing to do."
+  exit 0
+fi
+
+current=$(tr -d '[:space:]' <"$THEME_FILE")
+
+case "$current" in
+  Yaru-dark)
+    exit 0
+    ;;
+  Yaru-gray)
+    printf 'Yaru-dark\n' >"$THEME_FILE"
+    echo "  vantablack now uses Yaru-dark. Yaru-gray does not exist."
+    ;;
+  *)
+    echo "  vantablack names the \"$current\" icon theme, which you chose, so it was left alone."
+    exit 0
+    ;;
+esac
+
+# Rewriting the file is enough for the next theme switch, but if vantablack is
+# the theme in force right now then gsettings still holds Yaru-gray, and
+# nothing would correct it until the user switched away and back.
+#
+# readlink exits non-zero when the path is not a symlink, which is an ordinary
+# state here rather than an error.
+active_lua=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null || true)
+active_theme=""
+if [[ -n $active_lua ]]; then
+  # .../themes/<name>/generated/hyprland-colors.lua
+  active_theme=$(basename "$(dirname "$(dirname "$active_lua")")")
+fi
+
+if [[ $active_theme == vantablack ]] && command -v gsettings >/dev/null 2>&1; then
+  gsettings set org.gnome.desktop.interface icon-theme Yaru-dark 2>/dev/null || true
+  echo "  vantablack is active, so the change was applied now rather than at the next switch."
+fi

--- a/test/icon-themes-test.sh
+++ b/test/icon-themes-test.sh
@@ -137,6 +137,92 @@ else
     "$(probe 'notification_height = 0')" "1"
 fi
 
+# --- the correction reaches a machine that already exists --------------------
+#
+# Fixing the shipped file was only half of it. Everything under ~/.config is
+# copied once and never overwritten, so #91's correction reached new installs
+# and nothing else, and every machine installed before it still named
+# Yaru-gray. Measured on a live install after that update landed: the shipped
+# file read Yaru-dark and the home copy still read Yaru-gray.
+
+MIGRATION="$REPO/migrations/1788645000.sh"
+check "the migration that carries it exists" \
+  "$([[ -f $MIGRATION ]] && echo yes || echo no)" "yes"
+check "and it sorts after every migration written before it" \
+  "$(basename "$MIGRATION" .sh)" \
+  "$(for m in "$REPO/migrations"/*.sh; do basename "$m" .sh; done | sort -n | tail -1)"
+
+MHOME="$TMP/fakehome"
+mk() {
+  rm -rf "${TMP:?}/fakehome"
+  mkdir -p "$MHOME/.config/hypr/themes/vantablack"
+  [[ -n ${1:-} ]] && printf '%s\n' "$1" >"$MHOME/.config/hypr/themes/vantablack/icons.theme"
+  return 0
+}
+run_migration() { HOME="$MHOME" PATH="$TMP/mbin:$PATH" bash "$MIGRATION" >"$TMP/mout" 2>&1; }
+named() { tr -d '[:space:]' <"$MHOME/.config/hypr/themes/vantablack/icons.theme" 2>/dev/null; }
+
+# gsettings is stubbed to record rather than to touch the running desktop. A
+# suite must not repaint the machine it runs on.
+mkdir -p "$TMP/mbin"
+cat >"$TMP/mbin/gsettings" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$TMP/gsettings.log"
+EOF
+chmod +x "$TMP/mbin/gsettings"
+
+mk 'Yaru-gray'
+run_migration
+check "the value that does not exist is replaced" "$(named)" "Yaru-dark"
+check "and the replacement is one Yaru ships" \
+  "$(printf '%s\n' "${YARU_VARIANTS[@]}" | grep -cx "$(named)")" "1"
+check "and it says so" "$(grep -c 'Yaru-gray does not exist' "$TMP/mout")" "1"
+
+mk 'Yaru-dark'
+run_migration
+check "a home already corrected is left as it is" "$(named)" "Yaru-dark"
+# Every migration prints its own title line, so silence here means that line
+# and nothing after it.
+check "and reports nothing beyond its title, having done nothing" \
+  "$(grep -vc 'Give vantablack an icon theme' "$TMP/mout" || true)" "0"
+
+mk 'Papirus-Dark'
+run_migration
+check "a value the user chose is not overwritten" "$(named)" "Papirus-Dark"
+check "and they are told it was left alone" \
+  "$(grep -c 'left alone' "$TMP/mout")" "1"
+
+rm -rf "${TMP:?}/fakehome"; mkdir -p "$MHOME/.config/hypr/themes"
+run_migration
+check "a home without vantablack is left alone and says so" \
+  "$(grep -c 'nothing to do' "$TMP/mout")" "1"
+
+# Rewriting the file is enough for the next theme switch. If vantablack is the
+# theme in force, gsettings still holds Yaru-gray and nothing else would
+# correct it until the user switched away and back.
+rm -f "$TMP/gsettings.log"
+mk 'Yaru-gray'
+mkdir -p "$MHOME/.config/hypr/themes/vantablack/generated"
+printf 'return {}\n' >"$MHOME/.config/hypr/themes/vantablack/generated/hyprland-colors.lua"
+ln -sf "$MHOME/.config/hypr/themes/vantablack/generated/hyprland-colors.lua" \
+  "$MHOME/.config/hypr/theme-active.lua"
+run_migration
+check "with vantablack active the change is applied now" \
+  "$(grep -c 'icon-theme Yaru-dark' "$TMP/gsettings.log" 2>/dev/null || true)" "1"
+
+# And not applied when some other theme is in force, which would repaint a
+# desktop the user is not looking at.
+rm -f "$TMP/gsettings.log"
+mk 'Yaru-gray'
+mkdir -p "$MHOME/.config/hypr/themes/rosepine/generated"
+printf 'return {}\n' >"$MHOME/.config/hypr/themes/rosepine/generated/hyprland-colors.lua"
+ln -sf "$MHOME/.config/hypr/themes/rosepine/generated/hyprland-colors.lua" \
+  "$MHOME/.config/hypr/theme-active.lua"
+run_migration
+check "the file is still fixed for next time" "$(named)" "Yaru-dark"
+check "but another theme's desktop is not repainted" \
+  "$([[ -f $TMP/gsettings.log ]] && echo called || echo untouched)" "untouched"
+
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
## The bug

`vantablack/icons.theme` named `Yaru-gray`. Yaru ships no gray. The variants it builds, read from `ubuntu/yaru` at the tag the AUR package uses, are `Yaru` plus `-bark`, `-blue`, `-dark`, `-magenta`, `-mate`, `-olive`, `-prussiangreen`, `-purple`, `-red`, `-sage`, `-viridian`, `-wartybrown`, `-yellow`. Selecting vantablack therefore set

    gsettings set org.gnome.desktop.interface icon-theme Yaru-gray

to a name nothing provides, and GTK fell back to hicolor.

#91 corrected the shipped file to `Yaru-dark` and stopped there. Everything under `~/.config` is copied once and never overwritten, so that correction reached new installs only.

Measured on a live install after that update landed:

    DRIFT: hypr/themes/vantablack/icons.theme   shipped=[Yaru-dark] yours=[Yaru-gray]

which is the bug #91 set out to fix, still running on every machine installed before it.

## The fix

A migration rewrites the file. Only the exact wrong value is replaced, so `Papirus-Dark` or anything else someone chose is left alone and reported rather than clobbered. A home already carrying `Yaru-dark` is silent.

Rewriting the file alone would only take effect at the next theme switch, so when vantablack is the theme in force the migration re-applies gsettings immediately. When some other theme is active it does not, because repainting a desktop the user is not looking at is its own bug.

## Evidence

Thirteen checks in `test/icon-themes-test.sh`, the suite that already owns this bug. gsettings is stubbed to a log file, so the suite cannot repaint the machine it runs on, and I confirmed the live `icon-theme` read `Yaru-blue` before and after all three sweeps.

Three sabotages, each red for its own reason:

- migration reduced to a no-op: 7 checks red
- catch-all removed so any value is replaced: `a value the user chose is not overwritten (want Papirus-Dark, got Yaru-dark)`
- gsettings applied regardless of the active theme: `but another theme's desktop is not repainted (want untouched, got called)`

51 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` pass over migrations.

## One thing worth knowing

The migration is named `1788645000`, chosen by hand rather than by `hyprsimple-dev-add-migration.sh`. That tool names a migration after the last commit's timestamp on the claim that it "sorts after every existing migration", and that no longer holds: `1788644900`, which I added in #90, sits about six hours ahead of every commit date in the repo, so the tool would now generate a name that sorts before it. Harmless between two independent migrations, but the invariant is broken and the tool still asserts it. A check that the new migration sorts last is included here; fixing the tool is a separate change.