### PR TITLE
Make the logout count windows rather than come back empty

### DIFF
--- a/.local/bin/hypr-logout.sh
+++ b/.local/bin/hypr-logout.sh
@@ -23,8 +23,23 @@
 CLOSE_TIMEOUT_MS="${HYPRSIMPLE_LOGOUT_TIMEOUT_MS:-8000}"
 POLL_MS=100
 
+# Prints how many windows are open, or "unknown" when Hyprland's IPC does not
+# answer.
+#
+# This used to end `| jq 'length' 2>/dev/null || echo 0`. That fallback could
+# never run. A pipeline's exit status is its last command's, and jq handed an
+# empty stream prints nothing and exits 0, so with hyprctl unavailable the
+# count came back empty rather than 0. `[[ "" == 0 ]]` is false, so a logout
+# with no reachable IPC waited out the whole timeout and then announced windows
+# that had not closed, on a session that had none open.
 window_count() {
-  hyprctl clients -j 2>/dev/null | jq 'length' 2>/dev/null || echo 0
+  local count
+  count=$(hyprctl clients -j 2>/dev/null | jq 'length' 2>/dev/null)
+  if [[ $count =~ ^[0-9]+$ ]]; then
+    printf '%s' "$count"
+  else
+    printf 'unknown'
+  fi
 }
 
 hyprctl clients -j 2>/dev/null | jq -r '.[].address' 2>/dev/null | while read -r addr; do
@@ -34,14 +49,19 @@ done
 
 waited=0
 while (( waited < CLOSE_TIMEOUT_MS )); do
-  [[ $(window_count) == 0 ]] && break
+  count=$(window_count)
+  # Nothing left to wait for, or no way to find out. Waiting on a question that
+  # cannot be answered just delays the logout by the length of the timeout.
+  [[ $count == 0 || $count == unknown ]] && break
   sleep "0.$(printf '%03d' "$POLL_MS")"
   waited=$((waited + POLL_MS))
 done
 
-if [[ $(window_count) != 0 ]]; then
+remaining=$(window_count)
+if [[ $remaining != 0 && $remaining != unknown ]]; then
   # Said out loud rather than silently waiting the full timeout again: this is
   # the case where something did not close and is about to be stopped anyway.
+  # Not said when the count is unknown, which reports on windows nobody counted.
   notify-send "Logging out" "Some windows did not close in time" -t 2000 2>/dev/null
 fi
 

--- a/test/logout-test.sh
+++ b/test/logout-test.sh
@@ -121,6 +121,50 @@ fi
 check "the session is stopped anyway" "$(grep -c '^uwsm stop' "$LOG")" "1"
 check "and the user is told why" "$(grep -c 'did not close in time' "$LOG")" "1"
 
+# --- an IPC that does not answer ---------------------------------------------
+#
+# The count came from
+#
+#   hyprctl clients -j 2>/dev/null | jq 'length' 2>/dev/null || echo 0
+#
+# and the `|| echo 0` could never fire: a pipeline's status is its last
+# command's, and jq on an empty stream prints nothing and exits 0. So the count
+# was empty rather than 0, `[[ "" == 0 ]]` was false, and a logout with no
+# reachable compositor sat through the full timeout and then blamed windows
+# that were never counted.
+#
+# Reproduced with an hyprctl that fails the way a missing socket does.
+cat >"$STUB/hyprctl" <<'STUBEOF'
+#!/bin/bash
+printf 'hyprctl %s\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  "clients -j")
+    echo "Couldn't connect to the socket. (3)" >&2
+    exit 3
+    ;;
+  "dispatch closewindow"*) : >"$STATE/closed" ;;
+esac
+STUBEOF
+chmod +x "$STUB/hyprctl"
+
+run_logout 1 8000
+elapsed=$(cat "$TMP/elapsed")
+if (( elapsed < 3000 )); then
+  pass "an unreachable compositor does not cost the full timeout (${elapsed}ms)"
+else
+  fail "waited ${elapsed}ms with no compositor to wait for"
+fi
+check "the session is still stopped" "$(grep -c '^uwsm stop' "$LOG")" "1"
+check "and no window is blamed, none having been counted" \
+  "$(grep -c 'did not close' "$LOG")" "0"
+
+# The reading itself, separately from what the script does with it, because the
+# empty string and the number zero behave identically in every check above.
+count=$(CALL_LOG=/dev/null STATE="$TMP/state" PATH="$STUB:/usr/bin:/bin" bash -c '
+  source /dev/stdin <<<"$(sed -n "/^window_count()/,/^}/p" "$1")"
+  window_count' _ "$SCRIPT")
+check "and the count says unknown rather than coming back empty" "$count" "unknown"
+
 # --- the old shape is gone ---------------------------------------------------
 
 code_of() { sed 's/#.*//' "$1"; }


### PR DESCRIPTION
## The bug

`window_count` in `hypr-logout.sh` ended:

    hyprctl clients -j 2>/dev/null | jq 'length' 2>/dev/null || echo 0

That fallback could never run. A pipeline's exit status is its last command's, and jq handed an empty stream prints nothing and exits 0:

    $ printf "" | jq length
    jq exit=0

So with hyprctl unavailable the count came back empty, not `0`. `[[ "" == 0 ]]` is false, so the wait loop never broke, the logout sat through the whole eight second `CLOSE_TIMEOUT_MS`, and then

    [[ "" != 0 ]]

was true and it announced *Some windows did not close in time* on a session where no window had been counted at all. Both symptoms are the ones the fallback was written to prevent.

This is the same shape as the `| tail -n 300 || echo "(unavailable)"` lines in `hyprsimple-debug.sh`, which I found in the same sweep and have not touched here.

## The fix

`window_count` prints a number, or `unknown` when it could not read one. `unknown` is neither something to wait on nor a window to blame, so the loop breaks and the notification stays quiet. A real count of zero and a count that could not be taken now behave differently, which is the distinction the old code could not make.

Waiting was the wrong response to an unanswerable question: it only delayed the logout by the length of the timeout and then guessed.

## Evidence

Four checks in `test/logout-test.sh`, driven by an hyprctl stub that fails the way a missing socket does (`Couldn't connect to the socket. (3)` on stderr, exit 3). The fourth extracts `window_count` from the script and calls it directly, because the empty string and the number zero are indistinguishable in every behavioural check above it.

Sabotage A puts the original pipeline back verbatim and reproduces all three symptoms at once:

    not ok - waited 8305ms with no compositor to wait for
    not ok - and no window is blamed, none having been counted (want 0, got 1)
    not ok - and the count says unknown rather than coming back empty (want unknown, got )

Fixed, the same case takes **16ms** and says nothing. Sabotage B, treating `unknown` as a window, turns the blame check red on its own.

51 suites, 0 failing, three consecutive runs. shellcheck clean at `style`. Committed content confirmed with `git show HEAD:` before sabotaging, and the live Hyprland session was still up afterwards, every `uwsm` and `hyprctl` call in the suite being a stub.