### PR TITLE
Name a new migration so it really does sort last

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,6 +214,9 @@ jobs:
       - name: debug-report-test
         run: bash test/debug-report-test.sh
 
+      - name: migration-naming-test
+        run: bash test/migration-naming-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-dev-add-migration.sh
+++ b/.local/bin/hyprsimple-dev-add-migration.sh
@@ -1,22 +1,49 @@
 #!/bin/bash
 
-# Create a new migration named after the unix timestamp of the last commit, so
-# it sorts after every existing migration but before anything written later.
+# Create a new migration whose name sorts after every existing one.
 #
 #   hyprsimple-dev-add-migration.sh [--no-edit]
 #
 # Run this from a hyprsimple checkout.
+#
+# The name is a unix timestamp, because hyprsimple-migrate.sh runs migrations in
+# the order the shell globs them, which for digits is numeric order. So the name
+# decides the order they run in on every machine.
+#
+# It used to be the last commit's timestamp alone, on the stated claim that this
+# sorts after everything already there. That does not hold. A migration added by
+# hand carries whatever number was typed, and 1788644900 sat about six hours
+# ahead of every commit date in the repository, so the next migration this tool
+# named would have sorted before it and run first.
+#
+# Taking the later of the last commit and the highest existing name keeps the
+# claim true whatever is already in migrations/.
 
 set -e
 
 repo_root=$(git rev-parse --show-toplevel)
-migration_file="$repo_root/migrations/$(git -C "$repo_root" log -1 --format=%cd --date=unix).sh"
 
-if [[ -f $migration_file ]]; then
-  echo "Migration already exists: $migration_file" >&2
-  echo "Commit your current work first, then run this again." >&2
-  exit 1
-fi
+stamp=$(git -C "$repo_root" log -1 --format=%cd --date=unix)
+
+newest=0
+for existing in "$repo_root/migrations"/*.sh; do
+  [[ -f $existing ]] || continue
+  name=$(basename "$existing" .sh)
+  # Anything not a plain number cannot be compared, and cannot be sorted after
+  # either. Skipped rather than guessed at.
+  [[ $name =~ ^[0-9]+$ ]] || continue
+  (( name > newest )) && newest=$name
+done
+
+(( newest >= stamp )) && stamp=$((newest + 1))
+
+migration_file="$repo_root/migrations/$stamp.sh"
+
+# There is no "already exists" guard here any more. It used to be needed,
+# because two migrations written against the same commit were given the same
+# name and the second would have overwritten the first. With the name taken
+# past the highest existing one, the chosen name is by construction one nobody
+# holds, so the guard could not fire and running twice in a row now works.
 
 cat >"$migration_file" <<'TEMPLATE'
 echo "Describe what this migration does"

--- a/test/migration-naming-test.sh
+++ b/test/migration-naming-test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# hyprsimple-dev-add-migration.sh named a migration after the last commit's
+# timestamp, on the stated claim that this
+#
+#   sorts after every existing migration but before anything written later
+#
+# and the first half of that does not hold. hyprsimple-migrate.sh runs
+# migrations in glob order, which for digits is numeric order, so the name
+# decides what runs first on every machine. A migration added by hand carries
+# whatever number was typed, and 1788644900 sat about six hours ahead of every
+# commit date in the repository. The next migration this tool named would have
+# sorted before it and run first, while the tool said the opposite.
+#
+# Harmless between two migrations that do not touch the same thing. Not
+# harmless between two that do, and the tool is the only thing a contributor
+# reads before trusting the order.
+#
+# Nothing here runs a migration. The tool is pointed at throwaway git
+# repositories and only its choice of filename is measured.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOL="$REPO/.local/bin/hyprsimple-dev-add-migration.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# A repository whose single commit carries a chosen date, holding the migration
+# names it is given.
+make_repo() {
+  local commit_date="$1"; shift
+  local dir="$TMP/repo"
+  rm -rf "${TMP:?}/repo"
+  mkdir -p "$dir/migrations"
+  # git records no empty directory, so with no migrations there would be
+  # nothing to commit, no commit to date, and the tool would exit before
+  # choosing anything. The first version of this suite read that as the tool
+  # returning an empty name.
+  printf 'seed\n' >"$dir/README"
+  for name in "$@"; do printf 'echo x\n' >"$dir/migrations/$name.sh"; done
+  (
+    cd "$dir" || exit 1
+    git init -q .
+    git config user.email t@example.com
+    git config user.name t
+    git add -A
+    GIT_AUTHOR_DATE="@$commit_date +0000" GIT_COMMITTER_DATE="@$commit_date +0000" \
+      git commit -q -m seed
+  ) >/dev/null 2>&1
+  printf '%s' "$dir"
+}
+
+# Prints the basename the tool chose, without its extension.
+name_chosen() {
+  local dir="$1" out
+  out=$( cd "$dir" && bash "$TOOL" --no-edit 2>/dev/null )
+  basename "$out" .sh
+}
+
+# --- the ordinary case is unchanged ------------------------------------------
+
+dir=$(make_repo 1788000000 1787000000 1787500000)
+check "with every migration older than the commit, the commit date is used" \
+  "$(name_chosen "$dir")" "1788000000"
+
+# --- a migration ahead of every commit ---------------------------------------
+#
+# This is the case that was live in the repository.
+
+dir=$(make_repo 1788000000 1787000000 1788644900)
+chosen=$(name_chosen "$dir")
+check "a migration numbered ahead of the commit is sorted after, not before" \
+  "$chosen" "1788644901"
+if (( chosen > 1788644900 )); then
+  pass "so the tool's own claim about ordering holds"
+else
+  fail "chose $chosen, which runs before the existing 1788644900"
+fi
+
+# --- and the ordering is the one the runner actually uses --------------------
+#
+# Measured with a glob rather than assumed, because the claim is about what
+# hyprsimple-migrate.sh does, and what it does is expand *.sh.
+printf 'echo x\n' >"$dir/migrations/$chosen.sh"
+last=$(for m in "$dir/migrations"/*.sh; do basename "$m" .sh; done | tail -1)
+check "the new migration is last in the order the runner globs" "$last" "$chosen"
+
+# --- exactly equal, which the comparison has to include ----------------------
+
+dir=$(make_repo 1788000000 1788000000)
+check "a migration equal to the commit date is still sorted after" \
+  "$(name_chosen "$dir")" "1788000001"
+
+# --- names that are not numbers ----------------------------------------------
+
+dir=$(make_repo 1788000000 1787000000 notanumber)
+check "a non-numeric name is skipped rather than compared" \
+  "$(name_chosen "$dir")" "1788000000"
+
+# --- an empty migrations directory -------------------------------------------
+
+dir=$(make_repo 1788000000)
+check "with no migrations at all the commit date is used" \
+  "$(name_chosen "$dir")" "1788000000"
+
+# --- the file it writes is usable --------------------------------------------
+
+dir=$(make_repo 1788000000 1787000000)
+chosen=$(name_chosen "$dir")
+check "the migration it creates parses as bash" \
+  "$(bash -n "$dir/migrations/$chosen.sh" 2>&1 && echo ok)" "ok"
+
+# Running twice in a row must not collide. There is no commit between them, so
+# the commit date is identical and only the highest existing name moves.
+second=$(name_chosen "$dir")
+if [[ $second != "$chosen" ]] && (( second > chosen )); then
+  pass "a second run in the same commit picks a later name, not the same one"
+else
+  fail "the second run chose $second against the first's $chosen"
+fi
+
+# --- what makes glob order equal numeric order -------------------------------
+#
+# A glob sorts lexically, so 10000.sh comes before 9999.sh. Every migration
+# name being the same width is the only reason the runner's order matches the
+# numbers, and unix timestamps stay ten digits until well past any horizon
+# worth planning for. Written down because the first draft of this suite used
+# short fixtures and measured the wrong thing.
+widths=$(for m in "$REPO/migrations"/*.sh; do basename "$m" .sh; done |
+  awk '{ print length($0) }' | sort -u | tr '\n' ' ')
+check "every migration name in the repository is the same width" "$widths" "10 "
+
+newest=$(for m in "$REPO/migrations"/*.sh; do basename "$m" .sh; done |
+  grep -E '^[0-9]+$' | sort -n | tail -1)
+globbed=$(for m in "$REPO/migrations"/*.sh; do basename "$m" .sh; done | tail -1)
+check "so the highest numbered migration is also the last one globbed" \
+  "$globbed" "$newest"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
## The bug

`hyprsimple-dev-add-migration.sh` named a migration after the last commit's timestamp, and told the reader this:

    # Create a new migration named after the unix timestamp of the last commit, so
    # it sorts after every existing migration but before anything written later.

The first half does not hold. `hyprsimple-migrate.sh` runs migrations in glob order, so the name decides what runs first on every machine, and a migration added by hand carries whatever number was typed. Measured in this repository:

    HEAD commit date : 1788623263
    newest migration : 1788644900

`1788644900`, which I added in #90, sat about six hours ahead of every commit date in the repo. The next migration this tool named would have sorted **before** it and run first, while the tool promised the opposite. That is fine between two migrations that do not touch the same thing, and not fine between two that do, and the tool is the only thing a contributor reads before trusting the order.

## The fix

The name is the later of the last commit and the highest existing name, so the claim holds whatever is already in `migrations/`.

The already-exists guard goes with it. It was there because two migrations written against one commit got the same name and the second would have overwritten the first. The new name is by construction one nobody holds, so the guard could not fire, and running the tool twice in a row now works instead of erroring.

## What the suite pinned down along the way

A glob sorts lexically, not numerically:

    $ touch 9999.sh 10000.sh && for f in *.sh; do echo $f; done
    10000.sh
    9999.sh

So every migration name being the same width is the only reason the runner's order matches the numbers. All 30 are ten digits, and unix timestamps stay ten digits until 2286, so this is true rather than lucky, but nothing said it. There is now a check that says it, and a check that the highest numbered migration is also the last one globbed.

That mattered for the suite itself: my first fixtures used short names like `9999`, so the ordering check failed against correct code. The fixtures are ten digits now and measure the product rather than the fixture.

## Evidence

New suite `test/migration-naming-test.sh`, 11 checks, wired into CI. Nothing runs a migration: the tool is pointed at throwaway git repositories and only its choice of filename is measured. The repository's own `migrations/` is untouched, 30 files before and after.

Three sabotages:

- commit date alone, the original behaviour: 5 checks red, including `chose 1788000000, which runs before the existing 1788644900`
- `>` instead of `>=`, so an equal name collides: `a migration equal to the commit date is still sorted after`
- a nine digit migration dropped into the repo: `every migration name in the repository is the same width (want 10, got 10 9)` and `the highest numbered migration is also the last one globbed (want 1788645000, got 999999999)`

53 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.