### PR TITLE
Keep both ends of a long debug section, not just the last lines

### DIFF
--- a/.local/bin/hyprsimple-debug.sh
+++ b/.local/bin/hyprsimple-debug.sh
@@ -66,6 +66,35 @@ or_note() {
   if [[ -n $out ]]; then printf '%s\n' "$out"; else printf '%s\n' "$1"; fi
 }
 
+# Prints at most twice its argument: that many lines from each end, with a note
+# between them saying how many were left out.
+#
+# The two sections below used to end in tail alone, which keeps the most recent
+# lines and drops the beginning. The beginning is where a failure at boot or at
+# session start lives, so on a machine with a noisy background service that is
+# the wrong half to keep. Measured here: a Waydroid container put over 300
+# lines of its own init and libprocessgroup errors into this boot's journal,
+# more than the whole cap, so anything Hyprland had said at startup was already
+# gone by the time the report was written.
+#
+# Both ends, and the gap is named rather than left to be inferred from a jump
+# in the timestamps.
+head_tail_excerpt() {
+  local keep="$1" total tmp
+  tmp=$(mktemp) || { cat; return; }
+  cat >"$tmp"
+  total=$(wc -l <"$tmp")
+  if (( total <= keep * 2 )); then
+    cat "$tmp"
+  else
+    head -n "$keep" "$tmp"
+    printf '\n... %s lines omitted from the middle of this section ...\n\n' \
+      "$((total - keep * 2))"
+    tail -n "$keep" "$tmp"
+  fi
+  rm -f "$tmp"
+}
+
 hyprsimple_version() {
   local version branch
   version=$(cat "$HYPRSIMPLE_PATH/version" 2>/dev/null || echo "unknown")
@@ -126,7 +155,7 @@ hyprsimple_version() {
   fi
 
   section "JOURNAL (this boot, warnings and errors)"
-  journalctl -b -p 4..1 --no-pager 2>/dev/null | tail -n 300 | or_note "(unavailable)"
+  journalctl -b -p 4..1 --no-pager 2>/dev/null | head_tail_excerpt 150 | or_note "(unavailable)"
 
   section "DMESG"
   # dmesg is readable without sudo where kernel.dmesg_restrict is 0, so it is
@@ -137,16 +166,19 @@ hyprsimple_version() {
   if [[ $NO_SUDO == "true" ]]; then
     echo "(skipped - --no-sudo)"
   elif out=$(dmesg 2>&1); then
-    printf '%s\n' "$out" | tail -n 200 | or_note "(empty)"
+    printf '%s\n' "$out" | head_tail_excerpt 100 | or_note "(empty)"
   elif out=$(sudo dmesg 2>&1); then
-    printf '%s\n' "$out" | tail -n 200 | or_note "(empty)"
+    printf '%s\n' "$out" | head_tail_excerpt 100 | or_note "(empty)"
   else
     echo "(unavailable - $(printf '%s' "$out" | head -n 1))"
   fi
 
   section "HYPRSIMPLE INSTALL LOG"
   if [[ -f $INSTALL_LOG ]]; then
-    tail -n 400 "$INSTALL_LOG"
+    # Same treatment. The end of an install log is where it failed, the start
+    # is what it decided about this machine, and tail kept only the first of
+    # those two.
+    head_tail_excerpt 200 <"$INSTALL_LOG"
   else
     echo "(no install log at $INSTALL_LOG)"
   fi

--- a/test/debug-report-test.sh
+++ b/test/debug-report-test.sh
@@ -76,6 +76,7 @@ cat >"$STUB/journalctl" <<'STUBEOF'
 #!/bin/bash
 case "$(cat "$STATE/journal-mode" 2>/dev/null)" in
   ok)   printf 'a real journal line\n' ;;
+  long) seq 1 1000 | sed 's/^/journal line /' ;;
   *)    echo "journalctl: no journal" >&2; exit 1 ;;
 esac
 STUBEOF
@@ -196,6 +197,57 @@ check "with no password prompt, sudo never being called" \
 report --no-sudo
 check "--no-sudo still skips the section by name" \
   "$(section_body DMESG)" "(skipped - --no-sudo)"
+
+# --- a long section keeps both ends ------------------------------------------
+#
+# The journal and dmesg sections ended in tail, which keeps the most recent
+# lines and drops the beginning. The beginning is where a failure at boot or at
+# session start lives, so on a machine with a noisy background service that is
+# the wrong half to keep. Measured on this one: a Waydroid container put over
+# 300 lines of its own init and libprocessgroup errors into a single boot's
+# journal, more than the whole 300 line cap, so anything Hyprland said at
+# startup was gone before the report was written.
+#
+# The helper is exercised directly as well as through the report, because a
+# section long enough to truncate is awkward to arrange from a stub and the
+# boundary is where this kind of thing goes wrong.
+excerpt() {
+  bash -c "source <(sed -n '/^head_tail_excerpt()/,/^}/p' '$SCRIPT'); head_tail_excerpt $1"
+}
+
+check "input shorter than the cap is passed through whole" \
+  "$(seq 1 10 | excerpt 200 | wc -l)" "10"
+check "input exactly twice the cap is still whole" \
+  "$(seq 1 400 | excerpt 200 | wc -l)" "400"
+check "and says nothing about omitting anything, having omitted nothing" \
+  "$(seq 1 400 | excerpt 200 | grep -c 'omitted')" "0"
+
+long=$(seq 1 1000 | excerpt 200)
+check "one line over the cap does truncate" \
+  "$(seq 1 401 | excerpt 200 | grep -c 'omitted from the middle')" "1"
+check "the first line survives, which tail alone dropped" \
+  "$(printf '%s\n' "$long" | head -n 1)" "1"
+check "and so does the last" \
+  "$(printf '%s\n' "$long" | tail -n 1)" "1000"
+check "the gap is named rather than left silent" \
+  "$(printf '%s\n' "$long" | grep -c '600 lines omitted from the middle')" "1"
+check "and the whole excerpt stays bounded" \
+  "$(printf '%s\n' "$long" | wc -l)" "403"
+
+# Empty input still reaches or_note rather than being reported as a gap.
+check "empty input produces nothing for or_note to replace" \
+  "$(printf '' | excerpt 200 | wc -c)" "0"
+
+# And through the report itself, on a journal long enough to be cut.
+set_journalctl long
+report
+body=$(section_body 'JOURNAL (this boot, warnings and errors)')
+check "a long journal keeps its first line through the report" \
+  "$(printf '%s\n' "$body" | head -n 1)" "journal line 1"
+check "and its last" \
+  "$(printf '%s\n' "$body" | tail -n 1)" "journal line 1000"
+check "and says how many it left out" \
+  "$(printf '%s\n' "$body" | grep -c 'omitted from the middle')" "1"
 
 # --- the old shape is gone ---------------------------------------------------
 


### PR DESCRIPTION
## The bug

The journal and dmesg sections ended in `tail`:

    journalctl -b -p 4..1 --no-pager | tail -n 300
    dmesg | tail -n 200

`tail` keeps the most recent lines and drops the beginning, and the beginning is where a failure at boot or at session start lives. On a machine with a noisy background service that is the wrong half to keep.

Measured on this one: a Waydroid container put over 300 lines of its own `init:` and `libprocessgroup:` errors into a single boot's journal, more than the whole cap, so anything Hyprland said at startup was already gone by the time the report was written. Nothing marked the gap either, so the only clue available to a reader was a jump in the timestamps.

## The fix

A helper keeps that many lines from each end and names what it dropped in between:

    1
    2

    ... 996 lines omitted from the middle of this section ...

    999
    1000

Applied to the journal, to dmesg, and to the install log, where the same reasoning holds: the end is where it failed, the start is what it decided about the machine, and `tail` kept only one of those.

## Evidence

Twelve checks added to `test/debug-report-test.sh`. The helper is exercised directly at the boundary as well as through the whole report against a stub journal of 1000 lines, because a section long enough to truncate is awkward to arrange from a stub and off-by-one at the cap is where this kind of thing goes wrong. The cases: shorter than the cap passes through whole, exactly twice the cap is still whole and says nothing about omitting, one line over does truncate, empty input still produces nothing so `or_note` can replace it.

Three sabotages:

- `tail -n 300` restored: `a long journal keeps its first line through the report (want journal line 1, got journal line 701)`
- the tail half dropped, keeping only the head: `and its last (want journal line 1000, got ... 700 lines omitted ...)`
- truncating with no note: 4 checks red, including `the gap is named rather than left silent`

One of my own expectations was wrong first and failed loudly: I asserted the exactly-at-cap case *does* mention omitting. It does not, and should not. Corrected rather than adjusted around.

53 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass. On this machine the journal section is 231 lines, well under the cap, so the new path and the old agree here and the difference only shows on a noisy boot.