### PR TITLE
Anchor the AGENTS.md pointer on code, not on a line number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,16 @@ the contract:
   directly, like `hyprsimple-update` or `hyprsimple-debug`.
 - `hyprsimple-dev-` for contributor tooling, not something an end user needs.
 
-The directory matters too, separately from the prefix. `install.sh:437` copies
-everything in `.local/bin/` to the user's `~/.local/bin`, so anything there
-ships to every install. Scripts in `bin/` do not ship. They stay in the repo
-for contributors only.
+The directory matters too, separately from the prefix. `install.sh` copies
+everything in `.local/bin/` to the user's `~/.local/bin`, in the loop that
+begins `for script in "$DOTFILES_DIR/.local/bin"`, so anything there ships to
+every install. Scripts in `bin/` do not ship. They stay in the repo for
+contributors only.
+
+The anchor there is a line of code, not a line number. A line number in prose
+goes wrong the moment anything above it moves, and nothing announces that, so
+cite code you can grep for. `test/suite-hygiene-test.sh` checks that the quoted
+line is still in `install.sh` and that this file names no line numbers at all.
 
 ## Image policy
 

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -18,6 +18,30 @@ SELF="$(basename "${BASH_SOURCE[0]}")"
 failures=0
 pass() { printf 'ok - %s\n' "$1"; }
 fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# set -e is not on here, so calling a helper that does not exist prints
+# "command not found" and carries on, and the suite still ends with "all checks
+# passed". That happened while this file was being edited: five calls to check
+# ran before check existed, and the run reported success.
+#
+# An ERR trap was the first attempt and was worse than nothing. This suite uses
+# `grep -c` inside command substitutions, and grep exits 1 when a count is zero,
+# so the trap fired on an ordinary result and reported a failure that had not
+# happened. A guard that cries wolf on correct code trains people to ignore it.
+#
+# Naming the helpers instead. It catches the case that actually occurred and
+# cannot misfire on an exit status.
+for helper in pass fail check; do
+  if ! declare -F "$helper" >/dev/null; then
+    printf 'not ok - helper %s is not defined, so calls to it would pass silently\n' \
+      "$helper" >&2
+    exit 1
+  fi
+done
 
 suites=()
 while IFS= read -r f; do
@@ -125,6 +149,63 @@ if [[ ${#offenders[@]} -eq 0 ]]; then
   pass "every suite is listed in the workflow"
 else
   fail "these never run in CI: ${offenders[*]}"
+fi
+
+# AGENTS.md is the file a contributor reads before touching anything, so a
+# claim in it that has quietly stopped being true costs more than the same
+# claim anywhere else.
+#
+# It said install.sh:437 copies .local/bin to the user's home. Line 437 is a
+# section comment, and the copy loop is at 671. A line number in prose is wrong
+# as soon as anything above it moves and nothing announces that, so the rule is
+# that this file cites code rather than positions, and the cited code is
+# checked to still exist.
+
+AGENTS="$REPO/AGENTS.md"
+
+if [[ ! -f $AGENTS ]]; then
+  fail "AGENTS.md is missing, and it is what a contributor reads first"
+else
+  numbered=$(grep -cE '`[A-Za-z0-9_./-]+\.(sh|lua|conf|yml|jsonc|rasi|md)?:[0-9]+`' "$AGENTS")
+  check "AGENTS.md cites no line numbers, which cannot be kept true" "$numbered" "0"
+
+  # Every backticked run of code in AGENTS.md that looks like a shell fragment
+  # rather than a bare filename has to appear in the file it describes. Only
+  # the install.sh anchor qualifies today, and naming it explicitly beats a
+  # clever extractor that silently matches nothing.
+  anchor='for script in "$DOTFILES_DIR/.local/bin"'
+  check "AGENTS.md quotes the copy loop rather than pointing at a line" \
+    "$(grep -cF "$anchor" "$AGENTS")" "1"
+  check "and that line is still in install.sh, where it says it is" \
+    "$(grep -cF "$anchor" "$REPO/install.sh")" "1"
+
+  # Every repository path AGENTS.md names has to exist.
+  #
+  # Read out of the file rather than listed here. The first version of this
+  # check held its own list and skipped any entry AGENTS.md did not mention, so
+  # renaming a path in the document made the check quietly stop looking at it,
+  # which is the failure mode this whole change is about.
+  #
+  # Paths beginning with ~ or $ describe the user's machine, not this
+  # repository, and are not ours to verify.
+  mapfile -t cited < <(
+    grep -oE '`[^`]+`' "$AGENTS" |
+      tr -d '`' |
+      grep -E '^[A-Za-z0-9_.][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+$|^[A-Za-z0-9_-]+\.(sh|md|yml)$' |
+      LC_ALL=C sort -u
+  )
+  if (( ${#cited[@]} < 3 )); then
+    fail "found only ${#cited[@]} paths cited in AGENTS.md, so this check is not reading it"
+  else
+    pass "checked ${#cited[@]} repository paths cited in AGENTS.md"
+  fi
+  absent=()
+  for path in "${cited[@]}"; do
+    [[ -e $REPO/$path ]] || absent+=("$path")
+  done
+  absent_str=""
+  (( ${#absent[@]} > 0 )) && absent_str="$(printf '%s ' "${absent[@]}")"
+  check "and every one of them exists" "$absent_str" ""
 fi
 
 if [[ $failures -gt 0 ]]; then


### PR DESCRIPTION
## The bug

AGENTS.md told a contributor:

> `install.sh:437` copies everything in `.local/bin/` to the user's `~/.local/bin`

Line 437 is a section comment for bluetooth setup. The copy loop is at 671. The one file whose whole job is orienting someone sent them 234 lines off, and nothing anywhere would ever have said so.

## The fix

The paragraph quotes the loop's own first line instead, which can be grepped for and survives anything moving above it. `suite-hygiene-test.sh` now checks three things about AGENTS.md: that the quoted line is still in `install.sh`, that the file cites no line numbers at all, and that every repository path it names exists.

## Two problems found while writing the checks

**The hygiene suite reported success while five of its own lines errored.** It has `pass` and `fail` but no `check`, so my five `check` calls printed `check: command not found` and the run still ended with `all checks passed`. There is no `set -e`, so a missing name is not fatal. It now refuses to start unless its helpers are defined.

My first attempt at that guard was an `ERR` trap, and it was worse than nothing: this suite uses `grep -c` inside command substitutions, and grep exits 1 when a count is zero, so the trap fired on a correct result and reported a failure that had not happened. A guard that cries wolf on correct code trains people to ignore it. Replaced with a check that names the helpers, which catches the case that actually occurred and cannot misfire on an exit status.

**My path check skipped silently when it mattered.** It held its own list and did `grep -qF "$path" "$AGENTS" || continue`, so renaming a path in the document made the check stop looking at it rather than fail. Sabotage D found this: renaming `bin/hyprsimple-dev-optimize-images` in AGENTS.md produced no failure at all. The paths are now read out of the document, with a guard that fails if the extractor finds fewer than three.

## Evidence

Five sabotages, each red for its own reason:

- a line number put back in AGENTS.md: `cites no line numbers (want 0, got 1)`
- the quoted loop renamed in install.sh: `and that line is still in install.sh (want 1, got 0)`
- the `check` helper deleted: `helper check is not defined, so calls to it would pass silently`
- a cited path renamed in AGENTS.md: `and every one of them exists (want , got bin/hyprsimple-dev-optimise-images)`
- the extractor made to match nothing: `found only 0 paths cited in AGENTS.md, so this check is not reading it`

53 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.

## Checked and left alone

The sibling reference in `hyprsimple-wallpaper-picker.sh`, which says wallpaper-switcher.sh derives the theme "at its line 12", is correct: line 12 really is that derivation. The line references inside `migrations/` and inside test fixtures describe file states frozen at the time and are not claims about the current tree. This change covers AGENTS.md only.