### PR TITLE
Make monitor mirroring work at all, and mirror a projector on hotplug

### DIFF
--- a/.local/bin/monitor-mirror-toggle.sh
+++ b/.local/bin/monitor-mirror-toggle.sh
@@ -3,16 +3,32 @@
 # Toggle between extended and mirror mode
 # Auto-detects primary (built-in) and external monitors
 #
-# Usage: monitor-mirror-toggle.sh [on|off|toggle]
+# Usage: monitor-mirror-toggle.sh [on|off|toggle] [quiet]
 #   on     - force mirror mode
 #   off    - force extended mode
 #   toggle - flip current mode (default)
+#   quiet  - say nothing, for a caller that is not a keypress
 #
-# "on" is used by the monitor.added handler in hypr/autostart.lua so an
-# external display (projector) mirrors the laptop screen by default.
+# "on quiet" is what the monitor.added handler in default/hypr/autostart.lua
+# runs, so plugging in an external display (a projector) mirrors the laptop
+# screen rather than extending onto it. SUPER + SHIFT + M flips it afterwards.
+#
+# That handler did not exist until now. This comment claimed it did from the
+# moment on|off|quiet were added, and nothing called any of them, so the modes
+# were unreachable and quiet was never exercised. It did not work either: it
+# suppressed the two error notifications and neither of the success ones, so
+# the one caller it was written for would have popped a notification on every
+# hotplug.
 
 MODE="${1:-toggle}"
 QUIET="${2:-}"
+
+# Every notification goes through here. Putting the check in the two error
+# paths only was what left quiet half done.
+notify() {
+  [[ $QUIET == "quiet" ]] && return 0
+  notify-send "$@"
+}
 
 case "$MODE" in
 on | off | toggle) ;;
@@ -26,23 +42,46 @@ PRIMARY=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^eDP")) | .nam
 EXTERNAL=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^eDP") | not) | .name' | head -1)
 
 if [[ -z $EXTERNAL ]]; then
-  [[ $QUIET == "quiet" ]] || notify-send "Monitor Mode" "No external monitor detected"
+  notify "Monitor Mode" "No external monitor detected"
   exit 1
 fi
 
 if [[ -z $PRIMARY ]]; then
-  [[ $QUIET == "quiet" ]] || notify-send "Monitor Mode" "No built-in (eDP) display detected"
+  notify "Monitor Mode" "No built-in (eDP) display detected"
   exit 1
 fi
 
+# Both of these used to be `hyprctl keyword monitor "..."`, and Hyprland refuses
+# that outright when the config is lua rather than hyprlang:
+#
+#   $ hyprctl keyword monitor "HDMI-A-1,preferred,auto,1"
+#   keyword can't work with non-legacy parsers. Use eval.
+#
+# hyprsimple's config has been lua since the config split, so both calls have
+# always failed, and the notifications below announced a change that had not
+# happened. SUPER + SHIFT + M has never mirrored anything on any install.
+#
+# hyprctl eval runs a lua string against the same config, and hl.monitor takes
+# the mirror as a field. It answers "ok", so a failure is visible rather than
+# assumed away.
+apply_monitor() {
+  local lua="$1" out
+  out=$(hyprctl eval "$lua" 2>&1)
+  if [[ $out != "ok" ]]; then
+    echo "hyprctl rejected the monitor change: $out" >&2
+    notify -u critical "Monitor Mode" "Hyprland rejected the change"
+    return 1
+  fi
+}
+
 mirror_on() {
-  hyprctl keyword monitor "$EXTERNAL,preferred,auto,1,mirror,$PRIMARY"
-  notify-send "Monitor Mode" "Mirror mode enabled"
+  apply_monitor "hl.monitor({ output = \"$EXTERNAL\", mode = \"preferred\", position = \"auto\", scale = 1, mirror = \"$PRIMARY\" })" || return 1
+  notify "Monitor Mode" "Mirror mode enabled"
 }
 
 mirror_off() {
-  hyprctl keyword monitor "$EXTERNAL,preferred,auto,1"
-  notify-send "Monitor Mode" "Extended display enabled"
+  apply_monitor "hl.monitor({ output = \"$EXTERNAL\", mode = \"preferred\", position = \"auto\", scale = 1 })" || return 1
+  notify "Monitor Mode" "Extended display enabled"
 }
 
 is_mirrored() {

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -21,3 +21,19 @@ hl.on("hyprland.start", function()
   hl.exec_cmd([[sh -c 'systemctl --user import-environment $(env | cut -d= -f1)']])
   hl.exec_cmd("dbus-update-activation-environment --systemd --all")
 end)
+
+-- Mirror the laptop screen onto an external display as soon as one appears,
+-- so plugging into a projector shows the same picture without a keypress.
+-- SUPER + SHIFT + M switches to extended afterwards.
+--
+-- monitor-mirror-toggle.sh has documented this handler as its caller since the
+-- day its on|off|quiet modes were added, and the handler was never written, so
+-- those modes had no caller at all and a hotplug did nothing.
+--
+-- The event's payload is not read. The script asks hyprctl which monitors are
+-- there, which is one source of truth rather than two, and it exits quietly
+-- when there is no external display. That matters because this also fires for
+-- the built-in panel at startup.
+hl.on("monitor.added", function()
+  hl.exec_cmd(os.getenv("HOME") .. "/.local/bin/monitor-mirror-toggle.sh on quiet")
+end)

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -39,6 +39,12 @@ LOG="$TMP/calls"
 
 # One hyprctl stub for every script here. It answers from files the test names,
 # so a case is set up by pointing at a fixture rather than by editing the stub.
+# `keyword` answers the way Hyprland answers a lua config, which is by refusing.
+# The old stub returned 0 for every unmatched call, so `hyprctl keyword monitor`
+# looked like it worked here while failing on every real install, and these
+# checks passed against a script that had never mirrored anything. A fixture
+# that resembles the real thing without being it is the failure class
+# suite-hygiene-test.sh exists for, and this is one.
 cat >"$STUB/hyprctl" <<'STUBEOF'
 #!/bin/bash
 printf 'hyprctl %s\n' "$*" >>"$CALL_LOG"
@@ -46,6 +52,8 @@ case "$*" in
   "monitors -j") cat "$MONITORS_JSON" ;;
   "monitors") cat "$MONITORS_TXT" ;;
   "hyprpaper listactive") cat "$LISTACTIVE" ;;
+  keyword*) echo "keyword can't work with non-legacy parsers. Use eval." ;;
+  eval*) printf '%s\n' "${HYPRCTL_EVAL_REPLY:-ok}" ;;
   *) exit 0 ;;
 esac
 STUBEOF
@@ -62,26 +70,69 @@ run() { CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" bash "$@"; }
 
 # --- monitor-mirror-toggle.sh -----------------------------------------------
 
-: >"$LOG"
-MONITORS_JSON="$FIX/monitors-mirrored.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
-  run "$BIN/monitor-mirror-toggle.sh" toggle >/dev/null 2>&1
-check "an already mirrored display toggles back to extended" \
-  "$(grep -c 'keyword monitor HDMI-A-1,preferred,auto,1$' "$LOG")" "1"
-check "and does not re-issue the mirror keyword" \
-  "$(grep -c 'mirror,eDP-1' "$LOG")" "0"
+mirrored() { MONITORS_JSON="$FIX/monitors-mirrored.json" MONITORS_TXT="$FIX/monitors-mirrored.txt"; }
+extended() { MONITORS_JSON="$FIX/monitors-extended.json" MONITORS_TXT="$FIX/monitors-mirrored.txt"; }
+mirror_run() {
+  : >"$LOG"
+  CALL_LOG="$LOG" MONITORS_JSON="$MONITORS_JSON" MONITORS_TXT="$MONITORS_TXT" \
+    HYPRCTL_EVAL_REPLY="${HYPRCTL_EVAL_REPLY:-ok}" \
+    PATH="$STUB:/usr/bin:/bin" bash "$BIN/monitor-mirror-toggle.sh" "$@" >/dev/null 2>&1
+}
 
-: >"$LOG"
-MONITORS_JSON="$FIX/monitors-extended.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
-  run "$BIN/monitor-mirror-toggle.sh" toggle >/dev/null 2>&1
+# The call has to be eval. Hyprland refuses `keyword` outright when the config
+# is lua, which hyprsimple's has been since the config split, so every one of
+# these used to be issued and rejected while the script announced success.
+mirrored; mirror_run toggle
+check "an already mirrored display toggles back to extended" \
+  "$(grep -c 'eval hl.monitor({ output = "HDMI-A-1", mode = "preferred", position = "auto", scale = 1 })' "$LOG")" "1"
+check "and does not ask for a mirror while doing it" \
+  "$(grep -c 'mirror = ' "$LOG")" "0"
+
+extended; mirror_run toggle
 check "an extended display toggles into mirror" \
-  "$(grep -c 'keyword monitor HDMI-A-1,preferred,auto,1,mirror,eDP-1' "$LOG")" "1"
+  "$(grep -c 'eval hl.monitor({ output = "HDMI-A-1", mode = "preferred", position = "auto", scale = 1, mirror = "eDP-1" })' "$LOG")" "1"
+
+check "and never uses keyword, which this config cannot accept" \
+  "$(grep -c 'hyprctl keyword' "$LOG")" "0"
 
 # The two forced modes must ignore the current state entirely.
-: >"$LOG"
-MONITORS_JSON="$FIX/monitors-mirrored.json" MONITORS_TXT="$FIX/monitors-mirrored.txt" \
-  run "$BIN/monitor-mirror-toggle.sh" on >/dev/null 2>&1
+mirrored; mirror_run on
 check "on forces mirror even when already mirrored" \
-  "$(grep -c 'mirror,eDP-1' "$LOG")" "1"
+  "$(grep -c 'mirror = "eDP-1"' "$LOG")" "1"
+
+# --- quiet has to be quiet ---------------------------------------------------
+#
+# It suppressed the two error notifications and neither of the success ones, so
+# the hotplug handler it exists for would have popped a notification on every
+# plug.
+extended; mirror_run on
+check "a keypress says what it did" "$(grep -c '^notify-send' "$LOG")" "1"
+extended; mirror_run on quiet
+check "and quiet says nothing at all" "$(grep -c '^notify-send' "$LOG")" "0"
+check "while still making the change" "$(grep -c 'eval hl.monitor' "$LOG")" "1"
+extended; mirror_run toggle quiet
+check "quiet covers the toggle path too" "$(grep -c '^notify-send' "$LOG")" "0"
+
+# --- a refusal is reported, not announced as success -------------------------
+
+extended
+HYPRCTL_EVAL_REPLY="some error from hyprland" mirror_run on
+check "a rejected change does not claim mirror mode is on" \
+  "$(grep -c 'Mirror mode enabled' "$LOG")" "0"
+check "and says so instead" \
+  "$(grep -c 'Hyprland rejected the change' "$LOG")" "1"
+unset HYPRCTL_EVAL_REPLY
+
+# --- the hotplug handler that makes on and quiet reachable -------------------
+#
+# monitor-mirror-toggle.sh documented this handler as its caller from the day
+# on|off|quiet were added, and it was never written, so a projector did nothing
+# until a keypress.
+AUTOSTART="$REPO/default/hypr/autostart.lua"
+check "autostart registers a monitor.added handler" \
+  "$(grep -c 'hl.on("monitor.added"' "$AUTOSTART")" "1"
+check "and it runs the mirror script quietly" \
+  "$(grep -c 'monitor-mirror-toggle.sh on quiet' "$AUTOSTART")" "1"
 
 # --- live-wallpaper-toggle.sh -----------------------------------------------
 


### PR DESCRIPTION
## The bug

SUPER + SHIFT + M has never mirrored anything, on any install. Both paths ran:

    hyprctl keyword monitor "HDMI-A-1,preferred,auto,1,mirror,eDP-1"

and Hyprland refuses that outright when the config is lua rather than hyprlang. Measured on this machine, using a monitor name nothing has so nothing real could change:

    $ hyprctl keyword monitor "NOSUCH-1,preferred,auto,1"
    keyword can't work with non-legacy parsers. Use eval.

hyprsimple's config has been lua since the config split, so the call failed on every install, and the script printed "Mirror mode enabled" regardless, because nothing checked the result. It is the same shape as the volume bar and the btop theme: the whole thing built, and the one call at the end rejected in silence.

`hyprctl eval` runs lua against the same config and `hl.monitor` takes the mirror as a field (`HL.MonitorSpec.mirror?: string` in `/usr/share/hypr/stubs/hl.meta.lua`). Both paths go through it now, and it answers `ok`, so a refusal is reported rather than assumed away.

## Why the suite did not catch it

Its hyprctl stub returned 0 for every call it did not recognise, so `hyprctl keyword` looked like it worked here while failing everywhere else, and the checks asserted the exact string that has never had any effect. That is a fixture resembling the real thing without being it, which is the class `suite-hygiene-test.sh` was written for. The stub now answers `keyword` the way Hyprland does.

## Two things the script promised, now delivered

**`quiet` is quiet.** It suppressed the two error notifications and neither of the success ones:

    [on]           notifications: 1
    [on quiet]     notifications: 1     <- quiet, and it notified
    [off quiet]    notifications: 1

Every notification goes through one helper now.

**The `monitor.added` handler exists.** `monitor-mirror-toggle.sh` has named it as the caller for `on quiet` since the day those modes were added:

    # "on" is used by the monitor.added handler in hypr/autostart.lua

`git log -S` puts that comment in `f8aa35b`, which touched one file and did not write the handler. There has never been one, so `on`, `off` and `quiet` had no caller at all and plugging in a projector did nothing until someone pressed a key. `monitor.added` is a real event (`hl.meta.lua:14`), so it was one line away the whole time.

The handler ignores the event payload and lets the script ask hyprctl what is connected, which is one source of truth rather than two, and it exits quietly when there is no external display. That matters because it also fires for the built-in panel at startup.

## What omarchy does, since it came up

Its mirroring lives in `omarchy-hyprland-monitor-internal-mirror`, and it does **not** auto-mirror on hotplug. `omarchy-hyprland-monitor-watch` follows the Hyprland socket and reacts only to `monitorremoved`, calling `recover` so a mirror toggle does not stay set for a display that is gone. Mirroring on is always manual, on SUPER + CTRL + ALT + Delete.

It also writes the mirror to a state file and runs `hyprctl reload`, rather than applying it at runtime. That is worth knowing here: `hyprctl eval` is a runtime call, so a later `hyprctl reload` re-runs `monitors.lua` and drops the mirror, and `theme-switcher.sh` reloads on every theme switch. This PR does not address that. It is a real gap, it wants either a state file the config reads or a `config.reloaded` handler, and it is a separate change from making the thing work at all.

For screen sharing specifically, the two are equivalent: `xdg-desktop-portal-hyprland`, pipewire and wireplumber on both, and `allow_token_by_default = true` in `xdph.conf` on both, delivered here through `~/.config/hypr/xdph.conf` sourcing the install-owned copy, which I verified resolves. omarchy adds `custom_picker_binary = hyprland-preview-share-picker`, a nicer picker with live previews, from its own pacman repo rather than the AUR, so it is not available here without that repo. omarchy also lists `xdg-desktop-portal-gtk` explicitly where hyprsimple does not, but on Arch it arrives anyway as a dependency of gtk4 (`Required By: gtk4` on this machine), so nothing is missing.

## Evidence

Thirteen checks in `test/toggle-scripts-test.sh`, all against stubs. Four sabotages:

- back to `hyprctl keyword`: 5 red, including `and never uses keyword, which this config cannot accept (want 0, got 1)`
- the broken script plus the old permissive stub, which is the combination that shipped: still 5 red, so the new checks do not depend on the stub alone
- `quiet` no longer covering a success notification: `and quiet says nothing at all (want 0, got 1)`
- the handler deleted again: `autostart registers a monitor.added handler (want 1, got 0)`

53 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass. Every probe against the live compositor used a monitor name nothing has; `hyprctl monitors` still reports `eDP-1 mirrorOf=none scale=1` and `hyprctl configerrors` is empty.

## What I could not verify

There is one display on this machine, so the mirror actually appearing is unverified. What is verified is that Hyprland accepts the `hl.monitor` call including the `mirror` field, and that it rejected the call this replaces.
