### PR TITLE
Keep the mirror through a theme switch, and drop it on unplug

### DIFF
--- a/.local/bin/monitor-mirror-toggle.sh
+++ b/.local/bin/monitor-mirror-toggle.sh
@@ -3,11 +3,13 @@
 # Toggle between extended and mirror mode
 # Auto-detects primary (built-in) and external monitors
 #
-# Usage: monitor-mirror-toggle.sh [on|off|toggle] [quiet]
-#   on     - force mirror mode
-#   off    - force extended mode
-#   toggle - flip current mode (default)
-#   quiet  - say nothing, for a caller that is not a keypress
+# Usage: monitor-mirror-toggle.sh [on|off|toggle|restore|recover] [quiet]
+#   on      - force mirror mode
+#   off     - force extended mode
+#   toggle  - flip current mode (default)
+#   restore - re-apply mirroring if it was asked for, after a config reload
+#   recover - forget mirroring once the external display has gone
+#   quiet   - say nothing, for a caller that is not a keypress
 #
 # "on quiet" is what the monitor.added handler in default/hypr/autostart.lua
 # runs, so plugging in an external display (a projector) mirrors the laptop
@@ -31,15 +33,44 @@ notify() {
 }
 
 case "$MODE" in
-on | off | toggle) ;;
+on | off | toggle | restore | recover) ;;
 *)
-  echo "Usage: $(basename "$0") [on|off|toggle]" >&2
+  echo "Usage: $(basename "$0") [on|off|toggle|restore|recover] [quiet]" >&2
   exit 2
   ;;
 esac
 
+# Whether mirroring is wanted, which is a different question from whether it is
+# in force right now.
+#
+# hyprctl eval applies a monitor at runtime, and a runtime monitor does not
+# survive hyprctl reload: the reload re-runs monitors.lua, whose hl.monitor call
+# covers every output, and the mirror is gone. theme-switcher.sh reloads on
+# every theme switch, so changing theme un-mirrored a projector mid
+# presentation and said nothing.
+#
+# The intent is recorded here instead and re-applied on config.reloaded. It
+# sits beside live_wallpaper_enabled, which records the same kind of thing the
+# same way.
+FLAG="${HYPRSIMPLE_MIRROR_FLAG:-${XDG_CACHE_HOME:-$HOME/.cache}/monitor_mirror_enabled}"
+
 PRIMARY=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^eDP")) | .name' | head -1)
 EXTERNAL=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^eDP") | not) | .name' | head -1)
+
+# recover runs when a display is unplugged, so it has to work with no external
+# monitor present. That is the state the checks below refuse, hence its place
+# above them.
+if [[ $MODE == recover ]]; then
+  [[ -n $EXTERNAL ]] || rm -f "$FLAG"
+  exit 0
+fi
+
+# restore does nothing unless mirroring was asked for, and is never a keypress.
+if [[ $MODE == restore ]]; then
+  [[ -f $FLAG ]] || exit 0
+  MODE=on
+  QUIET=quiet
+fi
 
 if [[ -z $EXTERNAL ]]; then
   notify "Monitor Mode" "No external monitor detected"
@@ -76,11 +107,14 @@ apply_monitor() {
 
 mirror_on() {
   apply_monitor "hl.monitor({ output = \"$EXTERNAL\", mode = \"preferred\", position = \"auto\", scale = 1, mirror = \"$PRIMARY\" })" || return 1
+  mkdir -p "$(dirname "$FLAG")"
+  : >"$FLAG"
   notify "Monitor Mode" "Mirror mode enabled"
 }
 
 mirror_off() {
   apply_monitor "hl.monitor({ output = \"$EXTERNAL\", mode = \"preferred\", position = \"auto\", scale = 1 })" || return 1
+  rm -f "$FLAG"
   notify "Monitor Mode" "Extended display enabled"
 }
 

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -34,6 +34,30 @@ end)
 -- there, which is one source of truth rather than two, and it exits quietly
 -- when there is no external display. That matters because this also fires for
 -- the built-in panel at startup.
+local mirror_script = os.getenv("HOME") .. "/.local/bin/monitor-mirror-toggle.sh"
+
 hl.on("monitor.added", function()
-  hl.exec_cmd(os.getenv("HOME") .. "/.local/bin/monitor-mirror-toggle.sh on quiet")
+  hl.exec_cmd(mirror_script .. " on quiet")
+end)
+
+-- A mirror set through hyprctl eval is a runtime setting, and a reload re-runs
+-- monitors.lua, whose hl.monitor call covers every output, so the mirror was
+-- lost. theme-switcher.sh reloads on every theme switch, which meant changing
+-- theme un-mirrored a projector in the middle of a presentation and said
+-- nothing about it.
+--
+-- restore re-applies it only when it was asked for, so this is a no-op on the
+-- ordinary reload. It runs here rather than from a require in the config,
+-- because the config applies monitors.lua after hyprsimple's own modules and
+-- would overwrite anything set earlier.
+hl.on("config.reloaded", function()
+  hl.exec_cmd(mirror_script .. " restore")
+end)
+
+-- And when the external display goes, the request to mirror it goes with it.
+-- Otherwise the next reload would try to mirror onto a monitor that is not
+-- there. This is the one hotplug case omarchy handles, in its
+-- omarchy-hyprland-monitor-watch.
+hl.on("monitor.removed", function()
+  hl.exec_cmd(mirror_script .. " recover")
 end)

--- a/test/fixtures/hyprctl/monitors-internal-only.json
+++ b/test/fixtures/hyprctl/monitors-internal-only.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "eDP-1",
+    "focused": true,
+    "mirrorOf": "none"
+  }
+]

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -72,12 +72,14 @@ run() { CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" bash "$@"; }
 
 mirrored() { MONITORS_JSON="$FIX/monitors-mirrored.json" MONITORS_TXT="$FIX/monitors-mirrored.txt"; }
 extended() { MONITORS_JSON="$FIX/monitors-extended.json" MONITORS_TXT="$FIX/monitors-mirrored.txt"; }
+MIRROR_FLAG="$TMP/monitor_mirror_enabled"
 mirror_run() {
   : >"$LOG"
   CALL_LOG="$LOG" MONITORS_JSON="$MONITORS_JSON" MONITORS_TXT="$MONITORS_TXT" \
-    HYPRCTL_EVAL_REPLY="${HYPRCTL_EVAL_REPLY:-ok}" \
+    HYPRCTL_EVAL_REPLY="${HYPRCTL_EVAL_REPLY:-ok}" HYPRSIMPLE_MIRROR_FLAG="$MIRROR_FLAG" \
     PATH="$STUB:/usr/bin:/bin" bash "$BIN/monitor-mirror-toggle.sh" "$@" >/dev/null 2>&1
 }
+flag_state() { [[ -f $MIRROR_FLAG ]] && echo set || echo clear; }
 
 # The call has to be eval. Hyprland refuses `keyword` outright when the config
 # is lua, which hyprsimple's has been since the config split, so every one of
@@ -132,7 +134,63 @@ AUTOSTART="$REPO/default/hypr/autostart.lua"
 check "autostart registers a monitor.added handler" \
   "$(grep -c 'hl.on("monitor.added"' "$AUTOSTART")" "1"
 check "and it runs the mirror script quietly" \
-  "$(grep -c 'monitor-mirror-toggle.sh on quiet' "$AUTOSTART")" "1"
+  "$(grep -c 'mirror_script .. " on quiet"' "$AUTOSTART")" "1"
+
+# --- mirroring survives a config reload --------------------------------------
+#
+# hyprctl eval sets a monitor at runtime, and a reload re-runs monitors.lua,
+# whose hl.monitor call covers every output, so the mirror was dropped.
+# theme-switcher.sh reloads on every theme switch, which un-mirrored a
+# projector mid-presentation and said nothing.
+
+rm -f "$MIRROR_FLAG"
+extended; mirror_run restore
+check "restore does nothing when mirroring was never asked for" \
+  "$(grep -c 'eval hl.monitor' "$LOG")" "0"
+check "and leaves the flag alone" "$(flag_state)" "clear"
+
+extended; mirror_run on quiet
+check "asking for mirroring records that it was asked for" "$(flag_state)" "set"
+
+extended; mirror_run restore
+check "so a reload re-applies it" \
+  "$(grep -c 'mirror = "eDP-1"' "$LOG")" "1"
+check "without saying anything, a reload not being a keypress" \
+  "$(grep -c '^notify-send' "$LOG")" "0"
+
+extended; mirror_run off quiet
+check "turning it off forgets it" "$(flag_state)" "clear"
+extended; mirror_run restore
+check "and a later reload leaves the display extended" \
+  "$(grep -c 'eval hl.monitor' "$LOG")" "0"
+
+# --- unplugging forgets the request ------------------------------------------
+#
+# Otherwise the next reload tries to mirror onto a monitor that is not there.
+
+extended; mirror_run on quiet
+mirrored; mirror_run recover
+check "recover keeps the request while the display is still connected" \
+  "$(flag_state)" "set"
+
+MONITORS_JSON="$FIX/monitors-internal-only.json" MONITORS_TXT="$FIX/monitors-mirrored.txt"
+mirror_run recover
+check "and drops it once the display has gone" "$(flag_state)" "clear"
+check "while changing nothing about the remaining display" \
+  "$(grep -c 'eval hl.monitor' "$LOG")" "0"
+
+check "autostart registers the reload and removal handlers too" \
+  "$(grep -cE 'hl.on\("(config.reloaded|monitor.removed)"' "$AUTOSTART")" "2"
+check "and wires them to restore and recover" \
+  "$(grep -cE 'mirror_script \.\. " (restore|recover)"' "$AUTOSTART")" "2"
+
+# An unknown mode is still refused, now that there are five of them.
+extended
+mirror_run sideways
+check "an unknown mode exits non-zero rather than doing something" \
+  "$( CALL_LOG=$LOG MONITORS_JSON=$MONITORS_JSON MONITORS_TXT=$MONITORS_TXT \
+      HYPRSIMPLE_MIRROR_FLAG=$MIRROR_FLAG PATH="$STUB:/usr/bin:/bin" \
+      bash "$BIN/monitor-mirror-toggle.sh" sideways >/dev/null 2>&1; echo $? )" "2"
 
 # --- live-wallpaper-toggle.sh -----------------------------------------------
 


### PR DESCRIPTION
Follows #102, and closes the gap that PR named but did not fix.

## The bug

`hyprctl eval` applies a monitor at runtime, and a runtime monitor does not survive `hyprctl reload`: the reload re-runs `monitors.lua`, whose `hl.monitor({ output = "", ... })` covers every output, and the mirror is gone.

`theme-switcher.sh` calls `hyprctl reload` on every theme switch. So mirroring a projector and then changing theme un-mirrored it, mid-presentation, with no notification and nothing in a log.

Nothing handled a display being removed either. Without that, the request to mirror would outlive the monitor it named.

## The fix

Mirroring is recorded as an intention rather than only applied. The flag sits beside `live_wallpaper_enabled`, which records the same kind of thing the same way, and is overridable through `HYPRSIMPLE_MIRROR_FLAG` so the suite never touches a real one.

Two handlers in the install-owned `autostart.lua`, so they reach every machine on update with no migration:

- `config.reloaded` runs `monitor-mirror-toggle.sh restore`, which re-applies mirroring only when it was asked for. An ordinary reload does nothing.
- `monitor.removed` runs `recover`, which forgets the request once no external display remains. This is the one hotplug case omarchy handles, in `omarchy-hyprland-monitor-watch`.

`restore` runs on every reload and `recover` on every unplug, so neither says anything. Only a keypress does.

It has to be a handler rather than a `require` in the config: `hyprland.lua` loads hyprsimple's modules first and the user's `monitors.lua` after, so anything a module set would be overwritten by the very call that causes this bug.

## Evidence

Thirteen checks added to `test/toggle-scripts-test.sh`, covering the state machine rather than one path through it: restore with no request, on then restore, off then restore, recover with the display present, recover with it gone, and that restore stays silent. A new `monitors-internal-only.json` fixture provides the unplugged case.

Five sabotages:

- `mirror_on` stops recording the intent: 3 red, including `asking for mirroring records that it was asked for (want set, got clear)`
- `restore` ignores the flag and always mirrors: `restore does nothing when mirroring was never asked for (want 0, got 1)`
- `recover` clears the flag regardless: `recover keeps the request while the display is still connected`
- `restore` stops being quiet: `without saying anything, a reload not being a keypress (want 0, got 1)`
- both handlers deleted: `autostart registers the reload and removal handlers too (want 2, got 0)`

53 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass. `~/.cache/monitor_mirror_enabled` does not exist after the run, so the suites did not write to the real home. `hyprctl monitors` still reports `eDP-1 mirrorOf=none` and `hyprctl configerrors` is empty.

## What I could not verify

One display on this machine, so the reload case is exercised against stubs rather than a real projector. What is measured here is that the request survives, that a reload re-issues the same `hl.monitor` call #102 established Hyprland accepts, and that an unplug clears it.
