### PR TITLE
Keep the README keybindings in step with the keys hyprsimple binds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,6 +217,9 @@ jobs:
       - name: migration-naming-test
         run: bash test/migration-naming-test.sh
 
+      - name: readme-keybindings-test
+        run: bash test/readme-keybindings-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Press **`SUPER + /`** for interactive viewer with fuzzy search.
 |-----|--------|
 | `SUPER + Q` | Kill active window |
 | `SUPER + W` | Toggle floating |
-| `SUPER + SHIFT + J` | Toggle split (dwindle) |
 | `SUPER + H / J / K / L` | Move focus left / down / up / right |
 | `SUPER + SHIFT + Arrow` | Resize window |
 | `SUPER + LMB drag` | Move window |
@@ -203,6 +202,7 @@ Press **`SUPER + /`** for interactive viewer with fuzzy search.
 | `SUPER + [1-9, 0]` | Switch to workspace 1-10 |
 | `SUPER + SHIFT + [1-9, 0]` | Move window to workspace 1-10 |
 | `SUPER + SHIFT + S` | Move window to scratchpad |
+| `SUPER + CTRL + Arrow` | Move the whole workspace to the monitor in that direction |
 | `SUPER + Scroll` | Cycle through workspaces |
 
 ### Theming & Wallpaper
@@ -221,7 +221,7 @@ Press **`SUPER + /`** for interactive viewer with fuzzy search.
 | `Print` | Screenshot current monitor |
 | `SUPER + Print` | Screenshot active window |
 | `SUPER + ALT + Print` | Screenshot selected region |
-| `SUPER + CTRL + Print` | Screenshot region to clipboard |
+| `SUPER + CTRL + Print` | Screenshot current monitor to clipboard |
 
 ### Screen Recording
 

--- a/default/hypr/bindings/workspaces.lua
+++ b/default/hypr/bindings/workspaces.lua
@@ -17,22 +17,22 @@ hl.bind(
 
 -- Move the whole workspace to another monitor (external display / presentations)
 hl.bind(
-	"SUPER + SHIFT + ALT + LEFT",
+	"SUPER + CTRL + LEFT",
 	hl.dsp.workspace.move({ monitor = "l" }),
 	{ description = "Move Workspace to Left Monitor" }
 )
 hl.bind(
-	"SUPER + SHIFT + ALT + RIGHT",
+	"SUPER + CTRL + RIGHT",
 	hl.dsp.workspace.move({ monitor = "r" }),
 	{ description = "Move Workspace to Right Monitor" }
 )
 hl.bind(
-	"SUPER + SHIFT + ALT + UP",
+	"SUPER + CTRL + UP",
 	hl.dsp.workspace.move({ monitor = "u" }),
 	{ description = "Move Workspace to Up Monitor" }
 )
 hl.bind(
-	"SUPER + SHIFT + ALT + DOWN",
+	"SUPER + CTRL + DOWN",
 	hl.dsp.workspace.move({ monitor = "d" }),
 	{ description = "Move Workspace to Down Monitor" }
 )

--- a/test/readme-keybindings-test.sh
+++ b/test/readme-keybindings-test.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# The README's keybinding tables are what someone reads before pressing a key,
+# and nothing checked them against the keys hyprsimple actually binds.
+#
+# One had already drifted. SUPER + CTRL + Print was documented as
+#
+#   | `SUPER + CTRL + Print` | Screenshot region to clipboard |
+#
+# and it is bound to `screenshot.sh clipboard`, which runs
+#
+#   hyprshot -m output --clipboard-only --silent
+#
+# `-m output` is the whole monitor. So the key documented as taking a region
+# silently copied the entire screen, which is the wrong surprise to get in the
+# middle of a meeting.
+#
+# This compares the two sets of keys in both directions. It does not try to
+# match the prose, which is a judgement rather than a fact, so a description
+# can still go stale. What it catches is a key documented and not bound, or
+# bound and not documented, which is the drift that made the above possible.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README="$REPO/README.md"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- what is bound -----------------------------------------------------------
+#
+# Comments stripped first. applications.lua carries two commented examples,
+# SUPER + O and SUPER + S, and counting them would demand README rows for keys
+# nobody has bound. The stripper is anchored to the start of the line so that
+# `uwsm app -- waybar` keeps its dashes, which is the mistake the lua stripper
+# in another suite made once.
+lua_files=(
+  "$REPO/default/hypr/bindings.lua"
+  "$REPO/default/hypr/bindings"/*.lua
+  "$REPO/.config/hypr/bindings"/*.lua
+)
+
+# Flattened to one line before matching, because several binds put the key on
+# the line after hl.bind( and a line-at-a-time grep sees none of them. That
+# missed SUPER + SHIFT + S, which is bound, and reported it as documented but
+# unbound.
+bound_all=$(
+  for f in "${lua_files[@]}"; do
+    [[ -f $f ]] || continue
+    sed 's/^[[:space:]]*--.*//' "$f"
+  done | tr '\n' ' ' | grep -oE 'hl\.bind\([[:space:]]*"[^"]*"' |
+    sed 's/hl\.bind([[:space:]]*"//; s/"$//' | LC_ALL=C sort -u
+)
+
+# workspaces.lua builds ten pairs of keys in a loop, so what a literal match
+# sees there is the prefix "SUPER + " with nothing after it. Those are dropped
+# here and the loop is checked on its own below, rather than pretending a
+# prefix is a key.
+bound=$(printf '%s\n' "$bound_all" | grep -vE '\+ $' | grep -v '^$')
+bound_count=$(printf '%s\n' "$bound" | grep -c .)
+
+if (( bound_count < 40 )); then
+  fail "found only $bound_count bindings, so the extractor is not reading the files"
+else
+  pass "read $bound_count bindings from the config"
+fi
+
+# The stripper has to remove the commented examples and nothing else.
+check "a commented-out example is not counted as a binding" \
+  "$(printf '%s\n' "$bound" | grep -cx 'SUPER + O')" "0"
+check "and a real binding beside it still is" \
+  "$(printf '%s\n' "$bound" | grep -cx 'SUPER + A')" "1"
+
+# --- what the README documents -----------------------------------------------
+#
+# Only the rows between the Keybindings heading and the Scripts one. The
+# Scripts tables use the same row shape for filenames, and reading those as
+# keys is how a check like this quietly stops meaning anything.
+start=$(grep -n '^## Keybindings' "$README" | head -1 | cut -d: -f1)
+end=$(grep -n '^## Scripts' "$README" | head -1 | cut -d: -f1)
+if [[ -z $start || -z $end ]] || (( end <= start )); then
+  fail "could not find the Keybindings section in README.md"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+
+documented=$(
+  sed -n "${start},${end}p" "$README" |
+    grep -oE '^\| `[^`]+`' | sed 's/^| `//; s/`$//' | LC_ALL=C sort -u
+)
+documented_count=$(printf '%s\n' "$documented" | grep -c .)
+if (( documented_count < 30 )); then
+  fail "found only $documented_count documented keys, so the section was not read"
+else
+  pass "read $documented_count keys from the README"
+fi
+check "and stopped before the Scripts tables, which look the same" \
+  "$(printf '%s\n' "$documented" | grep -c '\.sh$')" "0"
+
+# --- the shorthands the README uses on purpose -------------------------------
+#
+# One row standing for several keys is easier to read than ten rows, so these
+# are expanded rather than treated as drift. Written out rather than pattern
+# matched, so adding a shorthand is a deliberate act and a typo in one shows up
+# as a missing key instead of being absorbed.
+expand() {
+  case "$1" in
+    # The two workspace rows stand for keys workspaces.lua generates in a loop,
+    # so there is no literal to match. They are dropped here and the loop is
+    # checked directly.
+    'SUPER + [1-9, 0]' | 'SUPER + SHIFT + [1-9, 0]') ;;
+    'SUPER + H / J / K / L')   printf 'SUPER + %s\n' H J K L ;;
+    'SUPER + SHIFT + Arrow')   printf 'SUPER + SHIFT + %s\n' UP DOWN LEFT RIGHT ;;
+    'SUPER + CTRL + Arrow')    printf 'SUPER + CTRL + %s\n' UP DOWN LEFT RIGHT ;;
+    'SUPER + LMB drag')        printf 'SUPER + mouse:272\n' ;;
+    'SUPER + RMB drag')        printf 'SUPER + mouse:273\n' ;;
+    'SUPER + Scroll')          printf 'SUPER + mouse_up\nSUPER + mouse_down\n' ;;
+    'SUPER + /')               printf 'SUPER + slash\n' ;;
+    'SUPER + ESC')             printf 'SUPER + ESCAPE\n' ;;
+    'CTRL + ESC')              printf 'CTRL + ESCAPE\n' ;;
+    'Volume Up / Down')        printf 'XF86AudioRaiseVolume\nXF86AudioLowerVolume\n' ;;
+    'Mute')                    printf 'XF86AudioMute\n' ;;
+    'Mic Mute')                printf 'XF86AudioMicMute\n' ;;
+    'Play / Pause')            printf 'XF86AudioPlay\nXF86AudioPause\n' ;;
+    'Next / Prev')             printf 'XF86AudioNext\nXF86AudioPrev\n' ;;
+    'Brightness Up / Down')    printf 'XF86MonBrightnessUp\nXF86MonBrightnessDown\n' ;;
+    'Kbd Brightness Up / Down') printf 'XF86KbdBrightnessUp\nXF86KbdBrightnessDown\n' ;;
+    *)                         printf '%s\n' "$1" ;;
+  esac
+}
+
+expanded=$(while IFS= read -r row; do [[ -n $row ]] && expand "$row"; done <<<"$documented" | LC_ALL=C sort -u)
+
+# A shorthand that stops matching anything is drift too, so the expansion has
+# to actually grow the list.
+expanded_count=$(printf '%s\n' "$expanded" | grep -c .)
+if (( expanded_count > documented_count )); then
+  pass "the shorthand rows expand to $expanded_count keys"
+else
+  fail "expansion produced $expanded_count keys from $documented_count rows, so it is doing nothing"
+fi
+
+# --- the two sets have to agree ----------------------------------------------
+
+# LC_ALL=C on comm as well as on the sorts. Without it comm collates by the
+# runner's locale, decides the input it was just handed is unsorted, and says
+# so on stderr while still producing an answer.
+undocumented=$(LC_ALL=C comm -23 <(printf '%s\n' "$bound") <(printf '%s\n' "$expanded") | tr '\n' ' ')
+check "every key hyprsimple binds is in the README" "$undocumented" ""
+
+unbound=$(LC_ALL=C comm -13 <(printf '%s\n' "$bound") <(printf '%s\n' "$expanded") | tr '\n' ' ')
+check "and every key the README documents is bound" "$unbound" ""
+
+# --- the generated workspace keys --------------------------------------------
+#
+# Checked by shape rather than by key, since there is no literal to compare.
+
+WS="$REPO/default/hypr/bindings/workspaces.lua"
+# Flattened for the same reason as the extractor above: the shifted bind spans
+# four lines, so a line-at-a-time grep reports it missing from a file that has
+# it.
+ws_flat=$(tr '\n' ' ' <"$WS")
+check "workspaces are bound in a loop over all ten" \
+  "$(grep -c 'for ws = 1, 10 do' "$WS")" "1"
+check "which binds a plain key per workspace" \
+  "$(printf '%s' "$ws_flat" | grep -c 'hl.bind("SUPER + " .. key')" "1"
+check "and a shifted one to move a window there" \
+  "$(printf '%s' "$ws_flat" | grep -oc 'hl.bind([[:space:]]*"SUPER + SHIFT + " .. key')" "1"
+check "and the README documents both rows" \
+  "$(printf '%s\n' "$documented" | grep -cE '^SUPER \+ (SHIFT \+ )?\[1-9, 0\]$')" "2"
+
+# --- the row that was wrong --------------------------------------------------
+#
+# The key sets agreed while this was wrong, because both sides named the key.
+# Only the description differed, and descriptions are not compared. So the one
+# case that prompted the suite is pinned by name.
+clip_mode=$(grep -A1 'hl.bind("SUPER + CTRL + Print"' "$REPO/default/hypr/bindings/screenshot.lua" |
+  grep -oE 'screenshot\.sh [a-z]+' | awk '{print $2}')
+check "SUPER + CTRL + Print runs the clipboard mode" "$clip_mode" "clipboard"
+check "and that mode captures the whole output, not a region" \
+  "$(sed -n '/^clipboard)/,/;;/p' "$REPO/.local/bin/screenshot.sh" | grep -c -- '-m output')" "1"
+check "so the README says monitor rather than region" \
+  "$(sed -n "${start},${end}p" "$README" | grep -c 'SUPER + CTRL + Print` | Screenshot current monitor to clipboard')" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
## The bugs

The keybinding tables are what someone reads before pressing a key, and nothing checked them against the keys hyprsimple binds. Three had drifted.

**A key that does something else.** `SUPER + CTRL + Print` was documented as *Screenshot region to clipboard*. It runs `screenshot.sh clipboard`:

    hyprshot -m output --clipboard-only --silent

`-m output` is the whole monitor. The key advertised as taking a region silently copied the entire screen, which is the wrong surprise to get in the middle of a meeting. The README now says what it does. If you would rather the key took a region, that is one word in `screenshot.sh` and I did not assume it.

**A key that does nothing.** `SUPER + SHIFT + J` was documented as *Toggle split (dwindle)* and is commented out in `window-management.lua`:

    -- hl.bind("SUPER + SHIFT + J", hl.dsp.layout("togglesplit"), ...)

`hyprctl binds` has no entry for it. It has been commented since the lua split in #22 and nothing in the history shows it ever active, so the README row is gone rather than the comment restored. Uncommenting one line brings it back, and I did not do that because I cannot tell why it was disabled.

**Four keys documented nowhere.** The workspace-to-monitor moves were bound and absent from the README, which is a poor thing to hide on a laptop that meets a projector. They are documented now, and moved to `SUPER + CTRL + Arrow` at your request. Those four keys were free, and no key is bound twice afterwards.

## The suite

`test/readme-keybindings-test.sh` compares the two sets of keys in both directions. It does not compare the prose, which is a judgement rather than a fact, so a description can still go stale. What it catches is a key documented and not bound, or bound and not documented, which is what made all three of these possible.

Three things it has to get right, each of which caught me out first:

- Binds spanning several lines. A line-at-a-time grep sees no key on `hl.bind(` followed by a newline, and reported `SUPER + SHIFT + S` as documented but unbound when it is bound. The input is flattened first, and matched with `[[:space:]]*` rather than ` *`, since those files indent with tabs.
- Keys built in a loop. `workspaces.lua` binds ten pairs as `"SUPER + " .. key`, so a literal match sees a prefix. Those are dropped and the loop is checked by shape instead of pretending a prefix is a key.
- The Scripts tables use the same row shape for filenames, so only rows between the Keybindings and Scripts headings are read, and a check asserts no `.sh` name got in.

## Evidence

Fifteen checks. Five sabotages:

- the wrong description restored: `so the README says monitor rather than region (want 1, got 0)`
- a documented key commented out: `and every key the README documents is bound (want , got SUPER + W)`
- a new binding added without a README row: `every key hyprsimple binds is in the README (want , got SUPER + Y)`
- the README heading renamed: `could not find the Keybindings section in README.md`
- the comment stripper disabled: 2 red, the commented examples `SUPER + O` and `SUPER + S` counted as bindings

54 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass. `workspaces.lua` parses under `luac -p`.

## Note

`default/hypr/bindings/` is install-owned, so the rebinding reaches every machine on the next `hyprsimple-update` with no migration. It takes effect at the next config reload or login.
