### PR TITLE
List a keybinding the viewer cannot name, instead of hiding it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           # files. shellcheck cannot read either dialect, which is how both
           # went unchecked: zsh.sh is excluded from the lint step by name, and
           # fish.fish never matched its *.sh glob at all.
-          sudo apt-get install -y lua5.4 imagemagick shellcheck fish zsh
+          sudo apt-get install -y lua5.4 imagemagick shellcheck fish zsh gawk
           # The suites invoke `lua`. Ubuntu installs `lua5.4`, so make the
           # plain name exist rather than relying on the package to register it.
           sudo ln -sf /usr/bin/lua5.4 /usr/bin/lua
@@ -219,6 +219,9 @@ jobs:
 
       - name: readme-keybindings-test
         run: bash test/readme-keybindings-test.sh
+
+      - name: keybinding-viewer-test
+        run: bash test/keybinding-viewer-test.sh
 
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.

--- a/.local/bin/show-keybindings.sh
+++ b/.local/bin/show-keybindings.sh
@@ -29,10 +29,17 @@ hyprctl binds |
       if (key == "" && keycode != "" && keycode != "0") key = "code:" keycode
       if (key == "") return
       d = desc
-      # Lua-backed binds carry no readable dispatcher text, so skip undescribed ones.
+      # A non-lua bind has readable dispatcher text, so use that.
       if (d == "" && dispatcher != "__lua")
         d = dispatcher (arg != "" ? " " arg : "")
-      if (d == "") return
+      # A lua bind has none, and one with no description used to be dropped
+      # here. Every bind hyprsimple ships carries a description, so that only
+      # ever hid a key someone added themselves: it worked, and it was missing
+      # from the one list that is supposed to say what the keys are, with
+      # nothing anywhere to explain the gap. Listed with a note instead, which
+      # says both that the key is real and how to name it.
+      if (d == "")
+        d = "(no description; add { description = \"...\" } to the bind)"
       printf "%-30s  %s\n", modstr(modmask) keyname(key), d
     }
 

--- a/migrations/1788699662.sh
+++ b/migrations/1788699662.sh
@@ -1,0 +1,40 @@
+echo "Say in your keybind file that a bind wants a description"
+
+# applications.lua showed { description = ... } in both of its examples and
+# never said what it is for. The key works without one, so it is easy to skip,
+# and SUPER + / reads its list from Hyprland rather than from the file: a bind
+# with no description had nothing to show there but the key itself, and until
+# the change this migration accompanies it was left out of the list entirely.
+#
+# This is a comment change and nothing else. No binding is altered.
+#
+# The file is yours, so it is replaced only where it is still byte-identical to
+# the version hyprsimple shipped before this change. Anything you have edited,
+# which for this file is the likely case, is left exactly as it is and named at
+# the end.
+
+REL="hypr/bindings/applications.lua"
+SHIPPED_SUM="f36b11db5b69aedd332bb4131b572281"
+
+user="$HOME/.config/$REL"
+shipped="$HYPRSIMPLE_PATH/.config/$REL"
+
+if [[ ! -f $user || ! -f $shipped ]]; then
+  echo "  Nothing to do."
+  exit 0
+fi
+
+if cmp -s "$user" "$shipped"; then
+  exit 0
+fi
+
+if [[ $(md5sum "$user" | cut -d' ' -f1) == "$SHIPPED_SUM" ]]; then
+  cp -f "$shipped" "$user"
+  echo "  Added the note to $user."
+else
+  echo "  Left $user alone, because you have your own version."
+  echo "  The note it would have added:"
+  echo "    Give every bind a description, or it has nothing to show in SUPER + /"
+  echo "  To take hyprsimple's version and lose your edits:"
+  echo "    hyprsimple-refresh-config.sh $REL"
+fi

--- a/test/fixtures/hyprctl/binds.txt
+++ b/test/fixtures/hyprctl/binds.txt
@@ -1,0 +1,70 @@
+bindd
+	modmask: 64
+	submap: 
+	key: Q
+	keycode: 0
+	catchall: false
+	description: Close Window
+	dispatcher: __lua
+	arg: 5
+
+bindd
+	modmask: 64
+	submap: 
+	key: W
+	keycode: 0
+	catchall: false
+	description: Toggle Floating
+	dispatcher: __lua
+	arg: 7
+
+bindd
+	modmask: 64
+	submap: 
+	key: H
+	keycode: 0
+	catchall: false
+	description: Focus Left
+	dispatcher: __lua
+	arg: 9
+
+bindd
+	modmask: 64
+	submap: 
+	key: L
+	keycode: 0
+	catchall: false
+	description: Focus Right
+	dispatcher: __lua
+	arg: 11
+
+
+bindd
+	modmask: 64
+	submap: 
+	key: O
+	keycode: 0
+	catchall: false
+	description: 
+	dispatcher: __lua
+	arg: 99
+
+bind
+	modmask: 4
+	submap: 
+	key: F1
+	keycode: 0
+	catchall: false
+	description: 
+	dispatcher: exec
+	arg: kitty
+
+bindm
+	modmask: 64
+	submap: 
+	key: mouse:272
+	keycode: 0
+	catchall: false
+	description: Move Window
+	dispatcher: __lua
+	arg: 40

--- a/test/fixtures/pre-description-note/applications.lua
+++ b/test/fixtures/pre-description-note/applications.lua
@@ -26,11 +26,6 @@ hl.bind("SUPER + A", hl.dsp.exec_cmd(vars.menu),        { description = "App Lau
 --
 --   hl.bind("SUPER + O", hl.dsp.exec_cmd("obsidian"),       { description = "Notes" })
 --   hl.bind("SUPER + S", hl.dsp.exec_cmd("android-studio"), { description = "Android Studio" })
---
--- Give every bind a description. The key works without one, so this is easy to
--- skip, and SUPER + / reads its list from Hyprland rather than from this file:
--- a bind with no description has nothing to show there but the key itself.
--- Naming it is what puts it in the list beside everything else.
 
 hl.bind("SUPER + V", hl.dsp.exec_cmd("sh -c 'cliphist list | rofi --show dmenu | cliphist decode | wl-copy'"),  { description = "Clipboard Manager" })
 hl.bind("SUPER + M", hl.dsp.exec_cmd("sh -c '" .. vars.colorPicker .. " | wl-copy'"),                           { description = "Color Picker" })

--- a/test/icon-themes-test.sh
+++ b/test/icon-themes-test.sh
@@ -148,9 +148,13 @@ fi
 MIGRATION="$REPO/migrations/1788645000.sh"
 check "the migration that carries it exists" \
   "$([[ -f $MIGRATION ]] && echo yes || echo no)" "yes"
-check "and it sorts after every migration written before it" \
-  "$(basename "$MIGRATION" .sh)" \
-  "$(for m in "$REPO/migrations"/*.sh; do basename "$m" .sh; done | sort -n | tail -1)"
+# This used to assert the migration was the highest numbered one in the
+# repository, which was true the day it was written and false the moment
+# anything was added after it. Ordering across all migrations is checked once,
+# in migration-naming-test.sh, rather than re-asserted by each migration's own
+# suite. What matters here is only that this name can be ordered at all.
+check "its name is a ten digit timestamp, so it globs in order" \
+  "$(basename "$MIGRATION" .sh | grep -cE '^[0-9]{10}$')" "1"
 
 MHOME="$TMP/fakehome"
 mk() {

--- a/test/keybinding-viewer-test.sh
+++ b/test/keybinding-viewer-test.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# SUPER + / lists the keys, and it dropped any it could not name.
+#
+# show-keybindings.sh parses `hyprctl binds` and ended its formatter with
+#
+#   if (d == "") return
+#
+# after a branch that only fills d for a dispatcher other than __lua. Every
+# bind hyprsimple ships is __lua and every one carries a description, so that
+# line never hid anything of hyprsimple's. It hid keys people add themselves:
+#
+#   hl.bind("SUPER + O", hl.dsp.exec_cmd("obsidian"))
+#
+# works, and never appeared in the one list that is supposed to say what the
+# keys are, with nothing anywhere to explain the gap. Measured against a
+# synthetic pair, one described and one not: only the described one was
+# printed.
+#
+# The list itself is live, read from hyprctl on every press with no cache, so a
+# binding does show up as soon as the config is reloaded. That was never the
+# problem. The problem was the ones it decided not to mention.
+#
+# Nothing here runs hyprctl. The formatter is extracted from the script and fed
+# a fixture captured from a live session, with two blocks appended that a
+# working session cannot produce.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO/.local/bin/show-keybindings.sh"
+FIXTURE="$REPO/test/fixtures/hyprctl/binds.txt"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# gawk, not awk. The formatter uses and(), which is a gawk extension, and the
+# script calls gawk by name for that reason. Asserted rather than skipped: a
+# skip that fires on every CI run is a check that never runs.
+if ! command -v gawk >/dev/null 2>&1; then
+  fail "gawk is not installed, so the formatter cannot be checked"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "gawk is available, which the formatter needs for and()"
+
+check "the fixture exists" "$([[ -f $FIXTURE ]] && echo yes || echo no)" "yes"
+
+# The formatter, taken from the script so this cannot drift from it.
+program=$(sed -n '/function modstr/,/END            { flush() }/p' "$SCRIPT")
+if [[ $(printf '%s\n' "$program" | grep -c .) -lt 20 ]]; then
+  fail "extracted only $(printf '%s\n' "$program" | grep -c .) lines of the formatter, so this is reading the wrong thing"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "extracted the formatter from the script itself"
+
+out=$(gawk "$program" "$FIXTURE")
+lines=$(printf '%s\n' "$out" | grep -c .)
+if (( lines >= 5 )); then
+  pass "the fixture produced $lines rows"
+else
+  fail "produced $lines rows, too few for the checks below to mean anything"
+fi
+
+# --- the bug -----------------------------------------------------------------
+
+check "a lua bind with no description is listed rather than dropped" \
+  "$(printf '%s\n' "$out" | grep -c '^SUPER + O ')" "1"
+check "and says how to name it" \
+  "$(printf '%s\n' "$out" | grep -c 'add { description = ')" "1"
+
+# --- and everything it did right stays right ---------------------------------
+
+check "a described bind still shows its description" \
+  "$(printf '%s\n' "$out" | grep -c '^SUPER + Q  *Close Window$')" "1"
+check "a non-lua bind with no description still falls back to its dispatcher" \
+  "$(printf '%s\n' "$out" | grep -c '^CTRL + F1  *exec kitty$')" "1"
+check "and does not get the note, having a name already" \
+  "$(printf '%s\n' "$out" | grep -c '^CTRL + F1.*add { description')" "0"
+check "a mouse button is named rather than left as an evdev code" \
+  "$(printf '%s\n' "$out" | grep -c 'LEFT MOUSE BUTTON')" "1"
+# The fixture holds six SUPER binds and one CTRL, so both branches of the
+# modmask decoder are exercised rather than only the common one.
+check "the SUPER modmask is decoded into a modifier name" \
+  "$(printf '%s\n' "$out" | grep -c '^SUPER + ')" "6"
+check "and so is a modmask that is not SUPER" \
+  "$(printf '%s\n' "$out" | grep -c '^CTRL + ')" "1"
+
+# --- nothing hyprsimple ships needs the note ---------------------------------
+#
+# The note is for keys someone adds. If a shipped binding ever loses its
+# description this says so, rather than the note quietly becoming normal.
+# `grep -o | wc -l`, not `grep -oc`. With -c, grep counts matching lines and
+# ignores -o, and these files are flattened to a single line first, so both
+# counts came back as 1 whatever the file held and the difference was always
+# zero. The first version of this check passed against a binding stripped of
+# its description, which is the one thing it exists to catch.
+count_of() { sed 's/^[[:space:]]*--.*//' "$2" | tr '\n' ' ' | grep -o "$1" | wc -l; }
+
+shipped_binds=0
+shipped_descs=0
+for f in "$REPO/default/hypr/bindings"/*.lua "$REPO/default/hypr/bindings.lua" \
+  "$REPO/.config/hypr/bindings"/*.lua; do
+  [[ -f $f ]] || continue
+  shipped_binds=$((shipped_binds + $(count_of 'hl\.bind(' "$f")))
+  shipped_descs=$((shipped_descs + $(count_of 'description = ' "$f")))
+done
+if (( shipped_binds < 40 )); then
+  fail "counted only $shipped_binds shipped bindings, so this is not reading them"
+else
+  pass "counted $shipped_binds shipped bindings"
+fi
+check "and every one of them carries a description" "$shipped_descs" "$shipped_binds"
+
+# --- and the file people write binds in says so ------------------------------
+#
+# applications.lua showed { description = ... } in both of its examples and
+# never said what it is for. The key works without one, so it is the easy part
+# to drop, and the consequence is invisible: the bind simply is not in the
+# list.
+
+APPS="$REPO/.config/hypr/bindings/applications.lua"
+check "the user's keybind file says a bind wants a description" \
+  "$(grep -c 'Give every bind a description' "$APPS")" "1"
+check "and says where the missing one would have shown up" \
+  "$(grep -c 'SUPER + /' "$APPS")" "1"
+check "while both worked examples still carry one" \
+  "$(grep -c '^--   hl.bind(.*description = ' "$APPS")" "2"
+
+# --- delivered to installs that already exist --------------------------------
+#
+# .config is copied once and never overwritten, so a comment added here reaches
+# new installs only. #91 shipped a theme fix that way and it never arrived.
+
+MIGRATION="$REPO/migrations/1788699662.sh"
+check "a migration carries it" "$([[ -f $MIGRATION ]] && echo yes || echo no)" "yes"
+# Not "and it is the newest migration". #95's suite asserted that about its
+# own, which was true that day and false as soon as this one was added.
+# Ordering across all migrations belongs in migration-naming-test.sh, and does
+# not want repeating per migration.
+check "with a ten digit name, so it globs in order" \
+  "$(basename "$MIGRATION" .sh | grep -cE '^[0-9]{10}$')" "1"
+
+MTMP="$(mktemp -d)"
+# A trap rather than a delete at the end. Several checks above can exit early,
+# and suite-hygiene-test.sh fails any suite that makes a temp directory without
+# one, which is how the first version of this was caught.
+trap 'rm -rf "${MTMP:?}"' EXIT
+MHOME="$MTMP/fakehome"
+setup_home() { rm -rf "${MTMP:?}/fakehome"; mkdir -p "$MHOME/.config/hypr/bindings"; }
+run_migration() {
+  HOME="$MHOME" HYPRSIMPLE_PATH="$REPO" bash "$MIGRATION" >"$MTMP/out" 2>&1
+}
+has_note() { grep -c 'Give every bind a description' "$MHOME/.config/hypr/bindings/applications.lua" 2>/dev/null; }
+
+# The file as it stood before this change, kept as a fixture rather than read
+# out of git. CI checks out shallow, so a suite asking git for an old version
+# is handed the current one, and suite-hygiene-test.sh fails any suite that
+# tries. The first version of this did exactly that, and the check flipped from
+# passing to failing the moment the change was committed, because HEAD then
+# held the new file.
+#
+# Copied with cp, not written from a command substitution: `$(...)` drops the
+# trailing newline, which changes the checksum, and an unedited copy then reads
+# as edited.
+PRE="$REPO/test/fixtures/pre-description-note/applications.lua"
+recorded=$(grep -oE '^SHIPPED_SUM="[a-f0-9]+"' "$MIGRATION" | cut -d'"' -f2)
+check "the fixture is the version the migration records" \
+  "$(md5sum "$PRE" | cut -d' ' -f1)" "$recorded"
+check "and it is not already carrying the note, or this proves nothing" \
+  "$(grep -c 'Give every bind a description' "$PRE")" "0"
+
+setup_home
+cp "$PRE" "$MHOME/.config/hypr/bindings/applications.lua"
+run_migration
+check "an unedited copy gains the note" "$(has_note)" "1"
+check "and says so" "$(grep -c 'Added the note' "$MTMP/out")" "1"
+
+setup_home
+printf -- '-- my own file\nhl.bind("SUPER + Z", hl.dsp.exec_cmd("zed"))\n' \
+  >"$MHOME/.config/hypr/bindings/applications.lua"
+run_migration
+check "an edited copy is left alone" "$(has_note)" "0"
+check "with its own first line intact" \
+  "$(head -1 "$MHOME/.config/hypr/bindings/applications.lua")" "-- my own file"
+check "and the note is printed instead, so it is not simply lost" \
+  "$(grep -c 'The note it would have added' "$MTMP/out")" "1"
+
+setup_home
+cp "$APPS" "$MHOME/.config/hypr/bindings/applications.lua"
+run_migration
+check "a copy already carrying it says nothing beyond its title" \
+  "$(grep -vc 'Say in your keybind file' "$MTMP/out")" "0"
+
+setup_home
+run_migration
+check "and a home without the file is not given one" \
+  "$([[ -f $MHOME/.config/hypr/bindings/applications.lua ]] && echo created || echo absent)" "absent"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Answering "does SUPER + / update when a user edits their keybinds?" turned this up, and then "do we need to say so in the file?" completed it.

## The answer, and the bug

The list is live. `show-keybindings.sh` runs `hyprctl binds` on every press with no cache file, so an edited config appears as soon as it is reloaded. That was never the problem.

The problem is which binds it agrees to show. Its formatter ended with

    if (d == "") return

after a branch that only fills `d` for a dispatcher other than `__lua`. Every one of the 82 binds on this machine is `__lua` and every one carries a description, so that line never hid anything hyprsimple ships. It hid keys people add themselves. This works:

    hl.bind("SUPER + O", hl.dsp.exec_cmd("obsidian"))

and never appeared in the one list that is supposed to say what the keys are, with nothing anywhere to explain the gap. Fed a described bind and an undescribed one, the formatter printed only:

    SUPER + P                       My Notes

Such a bind is now listed with a note saying how to name it, so the reader learns both that the key is real and what to add:

    SUPER + O                       (no description; add { description = "..." } to the bind)

## And the file people write binds in now says so

`applications.lua` showed `{ description = ... }` in both of its worked examples and never said what it is for. The key works without one, so it is the easy part to drop, and the consequence was invisible. It now says what a description buys you and where the missing one would have shown up.

`.config` is copied once and never overwritten, so a comment added there reaches new installs only. #91 shipped a theme fix that way and it never arrived, which is the mistake worth not repeating. A migration carries it, replacing the file only where it is still byte-identical to the version shipped before this change. An edited copy is left exactly as it is, and the note is printed to the terminal instead so it is not simply lost.

## Evidence

New suite `test/keybinding-viewer-test.sh`, 26 checks, wired into CI. Nothing runs hyprctl: the formatter is extracted from the script, so it cannot drift from it, and fed `test/fixtures/hyprctl/binds.txt`, captured from this session with two blocks appended that a healthy session cannot produce. The migration runs against throwaway homes, never a real one.

`gawk` is added to the CI apt line. The formatter uses `and()`, a gawk extension, and Ubuntu's default awk is mawk. On Arch gawk is a dependency of `base`.

Sabotages, each red for its own reason:

- the drop restored: `a lua bind with no description is listed rather than dropped`
- the note applied to every bind: `a described bind still shows its description (want 1, got 0)`
- a shipped binding stripped of its description: `and every one of them carries a description (want 64, got 63)`
- the formatter extractor matching nothing: `extracted only 0 lines of the formatter`
- the comment removed from the shipped file: 3 red
- the migration's checksum gate removed: `an edited copy is left alone (want 0, got 1)` and its first line replaced
- the fixture pre-loaded with the note: `and it is not already carrying the note, or this proves nothing`

## Four things I got wrong first, all caught here

- The shipped-descriptions check used `grep -oc`. With `-c`, grep counts matching lines and ignores `-o`, and the input is flattened to one line first, so both counts were 1 whatever the files held and the difference was always zero. It passed against a binding stripped of its description, twice, before I noticed. It counts with `grep -o | wc -l` now.
- The pre-change fixture was read with `git show HEAD:...`. CI checks out shallow, so that returns the current file, and `suite-hygiene-test.sh` fails any suite that does it. It also flipped from passing to failing the moment the change was committed, because HEAD then held the new file. It is a committed fixture now, `test/fixtures/pre-description-note/`.
- The temp directory was removed at the end rather than by a trap, so an early exit leaked it. `suite-hygiene-test.sh` caught that.
- **A check from #95 broke.** `icon-themes-test.sh` asserted its own migration was the highest numbered one in the repository. That was true the day it was written and false the moment this migration was added. Ordering across all migrations is checked once, in `migration-naming-test.sh`; each migration's own suite now only checks that its name is a ten digit timestamp so it globs in order. I made the same mistake here and corrected it before pushing.

55 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass. The live list is unchanged: 82 rows, none carrying the note. This machine's `applications.lua` still matches the recorded checksum, so the migration will apply to it on merge.
