### PR TITLE
Report what systemd thinks, which the debug log never asked

### DIFF
--- a/.local/bin/hyprsimple-debug.sh
+++ b/.local/bin/hyprsimple-debug.sh
@@ -154,6 +154,54 @@ hyprsimple_version() {
     pacman -Qi hyprland 2>/dev/null | grep -E '^(Name|Version)' || true
   fi
 
+  section "SERVICES"
+  # The report asked systemd nothing at all, which on a systemd desktop leaves
+  # out the first thing anyone would look at. Found while reading this machine's
+  # journal: dunst.service had been activated over D-Bus before a Wayland
+  # display existed, aborted with "Couldn't initialize X11 output" five times,
+  # hit its start limit and been sitting in failed ever since. Notifications
+  # worked the whole time, because hyprsimple starts its own dunst from
+  # autostart, so nothing on screen said so and the report would not have
+  # either: the evidence was a handful of lines inside a journal section that
+  # is capped at 300 and shared with everything else on the machine.
+  #
+  # Names taken from what install.sh enables, so this list and that one are the
+  # same list.
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "(systemctl not available)"
+  else
+    echo "Failed user units:"
+    systemctl --user --failed --no-pager --plain --no-legend 2>/dev/null |
+      or_note "  (none)"
+
+    echo ""
+    echo "Failed system units:"
+    systemctl --failed --no-pager --plain --no-legend 2>/dev/null |
+      or_note "  (none)"
+
+    # is-active and is-enabled both answer for a unit that does not exist, so
+    # a missing one reads as inactive/not-found rather than as a blank line.
+    unit_state() {
+      printf '  %-36s %-10s %s\n' "$2" \
+        "$($1 is-active "$2" 2>&1)" "$($1 is-enabled "$2" 2>&1)"
+    }
+
+    echo ""
+    printf '  %-36s %-10s %s\n' "USER UNIT" "ACTIVE" "ENABLED"
+    for unit in hyprpaper.service hyprpolkitagent.service battery-monitor.timer \
+      pipewire.service pipewire-pulse.service wireplumber.service \
+      dunst.service xdg-desktop-portal-hyprland.service; do
+      unit_state "systemctl --user" "$unit"
+    done
+
+    echo ""
+    printf '  %-36s %-10s %s\n' "SYSTEM UNIT" "ACTIVE" "ENABLED"
+    for unit in bluetooth.service systemd-resolved.service thermald.service \
+      cups.service power-profiles-daemon.service; do
+      unit_state systemctl "$unit"
+    done
+  fi
+
   section "JOURNAL (this boot, warnings and errors)"
   journalctl -b -p 4..1 --no-pager 2>/dev/null | head_tail_excerpt 150 | or_note "(unavailable)"
 

--- a/test/debug-report-test.sh
+++ b/test/debug-report-test.sh
@@ -67,6 +67,37 @@ done
 # re-added per case rather than left as failing stubs.
 rm -f "$STUB/inxi" "$STUB/fastfetch" "$STUB/hyprctl" "$STUB/expac"
 
+# systemctl was not stubbed before the SERVICES section existed, so the report
+# under test would have queried the real user session: the maintainer's units
+# would decide whether the checks passed, and on a CI runner with no session
+# they would answer differently again. Answers come from files here.
+set_failed_user() { printf '%s' "$1" >"$TMP/failed-user"; }
+set_failed_system() { printf '%s' "$1" >"$TMP/failed-system"; }
+cat >"$STUB/systemctl" <<'STUBEOF'
+#!/bin/bash
+user=0
+[[ ${1:-} == "--user" ]] && { user=1; shift; }
+case "${1:-}" in
+  --failed)
+    if (( user )); then cat "$STATE/failed-user" 2>/dev/null
+    else cat "$STATE/failed-system" 2>/dev/null; fi
+    ;;
+  is-active)
+    case "$2" in
+      absent.service) echo inactive; exit 4 ;;
+      broken.service) echo failed; exit 3 ;;
+      *) echo active ;;
+    esac
+    ;;
+  is-enabled)
+    case "$2" in
+      absent.service) echo not-found; exit 4 ;;
+      *) echo enabled ;;
+    esac
+    ;;
+esac
+STUBEOF
+
 printf '#!/bin/bash\nexit 0\n' >"$STUB/lspci"; chmod +x "$STUB/lspci"
 printf '#!/bin/bash\necho "pacman $*"\n' >"$STUB/pacman"; chmod +x "$STUB/pacman"
 printf '#!/bin/bash\necho "git $*"\n' >"$STUB/git"; chmod +x "$STUB/git"
@@ -140,8 +171,11 @@ STATE="$TMP" HOME="$FAKEHOME" HYPRSIMPLE_PATH="$TMP/install" \
   PATH="$STUB:/usr/bin:/bin" bash "$SCRIPT" --print >"$TMP/out" 2>&1
 check "an empty applied list says (none)" \
   "$(grep -c '^Applied:$' "$TMP/out")" "1"
+# Counted inside the MIGRATIONS section, not across the report. The SERVICES
+# section says (none) too when nothing has failed, and a whole-file count
+# turned red the moment it was added, for no reason to do with migrations.
 check "and all three migration lists do, not just the two that had a fallback" \
-  "$(grep -c '^  (none)$' "$TMP/out")" "3"
+  "$(section_body MIGRATIONS | grep -c '^  (none)$')" "3"
 
 # And the lists still carry their contents when there are any, so the note is
 # not simply printed over real output.
@@ -154,7 +188,7 @@ check "an applied migration is still listed" \
 check "a pending one is still listed" \
   "$(grep -c '^  1700000002.sh$' "$TMP/out")" "1"
 check "and only the one remaining empty list says (none)" \
-  "$(grep -c '^  (none)$' "$TMP/out")" "1"
+  "$(section_body MIGRATIONS | grep -c '^  (none)$')" "1"
 
 # --- journal -----------------------------------------------------------------
 
@@ -248,6 +282,99 @@ check "and its last" \
   "$(printf '%s\n' "$body" | tail -n 1)" "journal line 1000"
 check "and says how many it left out" \
   "$(printf '%s\n' "$body" | grep -c 'omitted from the middle')" "1"
+
+# --- the report asks systemd ------------------------------------------------
+#
+# It asked systemd nothing, which on a systemd desktop leaves out the first
+# thing anyone would look at. Found on a live machine: dunst.service had been
+# activated over D-Bus before a Wayland display existed, aborted with
+# "Couldn't initialize X11 output" five times, hit its start limit and been
+# sitting in failed ever since. Notifications kept working, because hyprsimple
+# starts its own dunst from autostart, so nothing said so on screen and the
+# report would not have either.
+
+set_failed_user ""
+set_failed_system ""
+report
+body=$(section_body SERVICES)
+check "with nothing failed, the user list says so" \
+  "$(printf '%s\n' "$body" | grep -c '(none)')" "2"
+
+set_failed_user "dunst.service loaded failed failed Dunst notification daemon"
+set_failed_system ""
+report
+body=$(section_body SERVICES)
+check "a failed user unit is named" \
+  "$(printf '%s\n' "$body" | grep -c 'dunst.service loaded failed failed')" "1"
+check "and the system list still says none, so the two are not confused" \
+  "$(printf '%s\n' "$body" | grep -c '(none)')" "1"
+
+set_failed_user ""
+set_failed_system "thermald.service loaded failed failed Thermal Daemon"
+report
+body=$(section_body SERVICES)
+check "a failed system unit is named too" \
+  "$(printf '%s\n' "$body" | grep -c 'thermald.service loaded failed failed')" "1"
+
+# --- and reports the state of the units it depends on -------------------------
+
+set_failed_system ""
+report
+body=$(section_body SERVICES)
+check "the units hyprsimple enables are listed with their state" \
+  "$(printf '%s\n' "$body" | grep -c 'hyprpaper.service .*active .*enabled')" "1"
+check "including the system ones" \
+  "$(printf '%s\n' "$body" | grep -c 'bluetooth.service .*active .*enabled')" "1"
+
+# Every unit install.sh enables has to appear, or the section reports on a
+# different set of services from the one the installer sets up.
+missing=()
+for unit in hyprpaper.service hyprpolkitagent.service battery-monitor.timer \
+  pipewire.service wireplumber.service bluetooth.service \
+  systemd-resolved.service thermald.service; do
+  printf '%s\n' "$body" | grep -q "$unit" || missing+=("$unit")
+done
+missing_str=""
+(( ${#missing[@]} > 0 )) && missing_str="$(printf '%s ' "${missing[@]}")"
+check "and none of them is left out" "$missing_str" ""
+
+# --- a machine without systemctl ---------------------------------------------
+
+# Deleting the stub is not enough: the suite's PATH ends in /usr/bin, so the
+# real systemctl is still found and the report queries the live session. The
+# first version of this check did exactly that and came back holding this
+# machine's own failed dunst.service, which is both a wrong answer and a suite
+# reading the maintainer's session.
+#
+# A PATH with no systemctl anywhere on it instead, holding links to the
+# commands the report actually runs. The list is asserted below, so a report
+# that grows a new dependency fails here rather than silently taking this
+# branch for the wrong reason.
+MINI="$TMP/minibin"; mkdir -p "$MINI"
+# bash included: a variable assignment before a command is in effect while
+# the command itself is looked up, so the interpreter has to be on this PATH
+# too or the report is never started at all.
+for tool in bash mktemp cat date hostname uname find sort grep cut xargs wc head tail sed free git basename; do
+  src=$(command -v "$tool" 2>/dev/null) || continue
+  ln -sf "$src" "$MINI/$tool"
+done
+rm -f "$STUB/systemctl"
+linked=$(find "$MINI" -maxdepth 1 -type l | wc -l)
+if (( linked >= 15 )); then
+  pass "built a PATH of $linked commands with no systemctl on it"
+else
+  fail "linked only $linked commands, so the report would fail for the wrong reason"
+fi
+check "and systemctl really is unreachable there" \
+  "$(PATH="$STUB:$MINI" command -v systemctl >/dev/null 2>&1 && echo found || echo absent)" "absent"
+
+rm -rf "${TMP:?}/fakehome"; mkdir -p "$FAKEHOME"
+STATE="$TMP" HOME="$FAKEHOME" HYPRSIMPLE_PATH="$TMP/install" \
+  PATH="$STUB:$MINI" bash "$SCRIPT" --print >"$TMP/out" 2>&1
+check "a machine with no systemctl says so rather than printing a blank table" \
+  "$(section_body SERVICES)" "(systemctl not available)"
+check "and the rest of the report still came out" \
+  "$(grep -c '^HYPRSIMPLE$' "$TMP/out")" "1"
 
 # --- the old shape is gone ---------------------------------------------------
 


### PR DESCRIPTION
Found by reading this machine's journal, which is a thing the debug report was making harder than it should be.

## The bug

`hyprsimple-debug.sh` asked systemd nothing at all. No unit states, no failed units, nothing. On a systemd desktop that leaves out the first thing anyone would look at, and it was leaving out a real failure on the machine it was written on.

`dunst.service` had been activated over D-Bus before a Wayland display existed, and aborted:

    dunst[1042]: WARNING: Cannot open X11 display.
    dunst[1042]: CRITICAL: [  get_x11_output:0077] Couldn't initialize X11 output. Aborting...
    systemd[946]: dunst.service: Failed with result 'exit-code'.

five times, then `Start request repeated too quickly` and `start-limit-hit`. It has been in `failed` ever since.

Notifications worked the whole time, because hyprsimple starts its own dunst from autostart into `app-Hyprland-dunst-bdb76e78.scope`, so nothing on screen said anything was wrong. The report would not have said so either: the only evidence was a handful of lines inside a journal section capped at 300 and shared with everything else on the machine, including a Waydroid container that on one boot filled the whole cap by itself.

It is intermittent, which is the worst kind to diagnose from a screenshot. Across the last four boots: 5 aborts on this one, 0 on the previous three.

## The fix

A SERVICES section: failed user units, failed system units, and the active and enabled state of every unit `install.sh` enables. The list is taken from what the installer enables, so the two are the same list, and a check fails if one drifts from the other.

On this machine it now names the failure on its second line:

    Failed user units:
    dunst.service loaded failed failed Dunst notification daemon

    Failed system units:
      (none)

      USER UNIT                            ACTIVE     ENABLED
      hyprpaper.service                    active     enabled
      ...
      dunst.service                        failed     static

`is-active` and `is-enabled` both answer for a unit that does not exist, so a missing one reads `inactive not-found` rather than as a blank line. That is how `cups.service` shows up here, install.sh enabling it only when cups is present.

## Evidence

Twelve checks added to `test/debug-report-test.sh`.

The suite had never stubbed `systemctl`, because nothing in the report called it. Left alone, these checks would have queried the real user session: the maintainer's units would decide whether they passed, and a CI runner with no session would answer differently again. It is stubbed now, answering from files.

The no-systemctl branch needed more than deleting that stub, since the suite's PATH ends in `/usr/bin` and the real one is still found. The first version of that check did exactly that and came back holding this machine's own failed dunst.service, which is both the wrong answer and a suite reading the maintainer's session. It now builds a PATH of links to the eighteen commands the report runs, with no systemctl on it, and asserts both that the PATH is big enough and that systemctl is genuinely unreachable. `bash` is on that list too: a variable assignment before a command is in effect while the command itself is looked up, so without it the report was never started and the check passed on empty output.

Four sabotages:

- the whole section removed: 6 red
- failed system units dropped, keeping only user ones: 3 red
- `hyprpaper.service` dropped from the list: `and none of them is left out (want , got hyprpaper.service)`
- the systemctl guard removed: the no-systemctl case prints a table instead of saying so

Two existing checks counted `(none)` across the whole report and turned red when SERVICES added two more. They count within the MIGRATIONS section now, which is what they always meant.

55 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.

## Not fixed here

The dunst race itself. hyprsimple starts dunst from autostart while the package also ships a D-Bus activated `dunst.service`, and when something asks for notifications before Hyprland has exported a Wayland display, that unit starts, fails, and burns its start limit. A notification issued in that window is lost. Fixing it means choosing which of the two starts dunst, which is a behaviour change worth its own PR. This one makes the failure visible, which it was not.
