### PR TITLE
Hold the battery monitor until there is a session to notify

### DIFF
--- a/.config/systemd/user/battery-monitor.service
+++ b/.config/systemd/user/battery-monitor.service
@@ -5,6 +5,9 @@
 [Unit]
 Description=Battery Monitor Service
 After=graphical-session.target
+# Stops with the session. Without this the last run could outlive the
+# compositor and dim a panel nobody is looking at.
+PartOf=graphical-session.target
 
 [Service]
 Type=oneshot
@@ -12,5 +15,7 @@ ExecStart=%h/.local/bin/battery-monitor.sh
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 
-[Install]
-WantedBy=default.target
+# No [Install] section. The timer starts this and nothing else should: it was
+# WantedBy=default.target, which invites `systemctl --user enable
+# battery-monitor.service` to run it at login, which is the thing this change
+# exists to stop. install.sh has only ever enabled the timer.

--- a/.config/systemd/user/battery-monitor.timer
+++ b/.config/systemd/user/battery-monitor.timer
@@ -6,10 +6,30 @@
 Description=Battery Monitor Timer
 Requires=battery-monitor.service
 
+# Tied to the graphical session, not to the user manager.
+#
+# This used to be WantedBy=timers.target with OnBootSec and Persistent, which
+# starts the timer as soon as the user manager does, before any compositor
+# exists. Measured on a login: the service ran at 11:54:23 and Hyprland was
+# selected in the same second, after it. With a low battery that meant
+# battery-monitor.sh dimmed the panel to 5% at the greeter, and its
+# notify-send activated dunst over D-Bus into a session with no Wayland
+# display, where dunst aborted on "Couldn't initialize X11 output" five times
+# and burned its start limit.
+#
+# battery-monitor.service already said After=graphical-session.target, which
+# is ordering only and does nothing when that target is not part of the same
+# job. Being wanted by the target is what makes it wait.
+After=graphical-session.target
+PartOf=graphical-session.target
+
 [Timer]
-OnBootSec=30s
+# Relative to the timer starting rather than to boot, since it now starts with
+# the session. Persistent is gone with OnBootSec: it exists to catch up a run
+# missed while powered off, and a battery reading from before the machine was
+# on is not worth acting on.
+OnActiveSec=30s
 OnUnitActiveSec=30s
-Persistent=true
 
 [Install]
-WantedBy=timers.target
+WantedBy=graphical-session.target

--- a/install.sh
+++ b/install.sh
@@ -721,7 +721,13 @@ systemctl --user enable --now pipewire pipewire-pulse wireplumber || true
 if [ -f "$HOME/.config/systemd/user/battery-monitor.timer" ]; then
   echo -e "${YELLOW}Enabling battery monitor timer...${NC}"
   systemctl --user daemon-reload
-  systemctl --user enable --now battery-monitor.timer
+  # enable, not enable --now. The timer is wanted by graphical-session.target,
+  # and the install runs from a TTY or another session where that target is not
+  # up, so --now started a timer that would fire battery-monitor.sh with no
+  # compositor: on a low battery that dims the panel and sends a notification
+  # into a bus with no display, which is the case this ordering exists to
+  # avoid. The session starts it.
+  systemctl --user enable battery-monitor.timer
   echo -e "${GREEN}Battery monitor enabled${NC}"
 fi
 

--- a/migrations/1788702842.sh
+++ b/migrations/1788702842.sh
@@ -1,0 +1,81 @@
+echo "Hold the battery monitor until there is a session to notify"
+
+# battery-monitor.timer was WantedBy=timers.target, so it started with the user
+# manager, before any compositor. battery-monitor.service said
+# After=graphical-session.target, which is ordering only and does nothing when
+# that target is not part of the same job.
+#
+# Measured on a login: the service ran at 11:54:23 and Hyprland was selected in
+# the same second, after it. With a low battery that means battery-monitor.sh
+# dims the panel to 5% at the greeter, and its notify-send activates dunst over
+# D-Bus into a session with no Wayland display, where dunst aborts on
+# "Couldn't initialize X11 output", is retried five times and burns its start
+# limit. The notification is lost and dunst.service is left failed.
+#
+# Both units now belong to graphical-session.target, so the timer exists only
+# while a session does.
+#
+# The files are yours, so each is replaced only where it is still
+# byte-identical to the version shipped before this change. The enablement is
+# moved only when the timer is enabled, because that is the half that decides
+# when it runs.
+
+TIMER_SUM="891c046d10b45a0bff7c6e5f92cfcc9d"
+SERVICE_SUM="6d030dde190c60a091b60d2b2604254d"
+
+replaced=0
+skipped=()
+
+replace_unit() {
+  local name="$1" sum="$2"
+  local user="$HOME/.config/systemd/user/$name"
+  local shipped="$HYPRSIMPLE_PATH/.config/systemd/user/$name"
+
+  [[ -f $user && -f $shipped ]] || return 0
+  cmp -s "$user" "$shipped" && return 0
+
+  if [[ $(md5sum "$user" | cut -d' ' -f1) == "$sum" ]]; then
+    cp -f "$shipped" "$user"
+    replaced=$((replaced + 1))
+  else
+    skipped+=("$name")
+  fi
+}
+
+replace_unit battery-monitor.timer "$TIMER_SUM"
+replace_unit battery-monitor.service "$SERVICE_SUM"
+
+if (( replaced == 0 )); then
+  if (( ${#skipped[@]} > 0 )); then
+    echo "  Left alone, because you have your own version:"
+    printf '    %s\n' "${skipped[@]}"
+    echo "  Yours will keep running the battery monitor before the session starts."
+    echo "  To take hyprsimple's and lose your edits:"
+    echo "    hyprsimple-refresh-config.sh systemd/user/battery-monitor.timer"
+    echo "    hyprsimple-refresh-config.sh systemd/user/battery-monitor.service"
+  fi
+  exit 0
+fi
+
+systemctl --user daemon-reload 2>/dev/null || true
+
+# The unit moved from timers.target to graphical-session.target, and the
+# enabling symlink does not move on its own. Only touched when the timer was
+# already enabled, so a machine that had deliberately turned it off stays off.
+if systemctl --user is-enabled battery-monitor.timer &>/dev/null; then
+  systemctl --user disable battery-monitor.timer &>/dev/null || true
+  systemctl --user enable battery-monitor.timer &>/dev/null || true
+  # Started here only if a session is already up, which is the case when this
+  # runs from hyprsimple-update inside one. Otherwise the next login starts it.
+  if systemctl --user is-active graphical-session.target &>/dev/null; then
+    systemctl --user restart battery-monitor.timer &>/dev/null || true
+  fi
+  echo "  The battery monitor now starts with your session rather than before it."
+else
+  echo "  Updated the units. The timer is not enabled here, so nothing was started."
+fi
+
+if (( ${#skipped[@]} > 0 )); then
+  echo "  Left alone, because you have your own version:"
+  printf '    %s\n' "${skipped[@]}"
+fi

--- a/test/committed-symlinks-test.sh
+++ b/test/committed-symlinks-test.sh
@@ -86,8 +86,16 @@ check "no .wants or .target.wants directory is tracked, that is enable state" \
 
 check "install.sh enables the pipewire units" \
   "$(grep -c 'systemctl --user enable --now pipewire pipewire-pulse wireplumber' "$REPO/install.sh")" "1"
+# The battery timer is enabled without --now. It is wanted by
+# graphical-session.target, and the install runs from a TTY or another session
+# where that target is not up, so --now started a timer that would fire
+# battery-monitor.sh with no compositor: on a low battery that dims the panel
+# and sends a notification into a bus with no display. The symlink is what this
+# suite is about, and enable alone still writes it.
 check "install.sh enables the battery monitor timer" \
-  "$(grep -c 'systemctl --user enable --now battery-monitor.timer' "$REPO/install.sh")" "1"
+  "$(grep -c 'systemctl --user enable battery-monitor.timer$' "$REPO/install.sh")" "1"
+check "and does not start it there, where there is no session to notify" \
+  "$(grep -c 'enable --now battery-monitor.timer' "$REPO/install.sh")" "0"
 
 # ---- the migration --------------------------------------------------------
 

--- a/test/fixtures/pre-session-timer/battery-monitor.service
+++ b/test/fixtures/pre-session-timer/battery-monitor.service
@@ -1,0 +1,16 @@
+# This file is yours: it sets what the battery monitor runs. hyprsimple copies it once
+# and never touches it again. Run `systemctl --user daemon-reload` after
+# editing.
+
+[Unit]
+Description=Battery Monitor Service
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/bin/battery-monitor.sh
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+
+[Install]
+WantedBy=default.target

--- a/test/fixtures/pre-session-timer/battery-monitor.timer
+++ b/test/fixtures/pre-session-timer/battery-monitor.timer
@@ -1,0 +1,15 @@
+# This file is yours: it sets how often the battery monitor runs. hyprsimple copies it once
+# and never touches it again. Run `systemctl --user daemon-reload` after
+# editing.
+
+[Unit]
+Description=Battery Monitor Timer
+Requires=battery-monitor.service
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -206,6 +206,135 @@ check "and says nothing" "$(wc -l <"$NLOG" | tr -d ' ')" "0"
 
 rm -f "$FLAG"
 
+# --- the monitor waits for a session to notify -------------------------------
+#
+# battery-monitor.timer was WantedBy=timers.target, so it started with the user
+# manager, before any compositor. The service said
+# After=graphical-session.target, which is ordering only and does nothing when
+# that target is not part of the same job.
+#
+# Measured on a login: "Starting Battery Monitor Service..." at 11:54:23 and
+# "uwsm: Selected compositor ID" in the same second, after it. With a low
+# battery that means this script dims the panel to 5% at the greeter, and its
+# notify-send activates dunst over D-Bus into a session with no Wayland
+# display, where dunst aborts on "Couldn't initialize X11 output", is retried
+# five times and burns its start limit. The notification is lost and
+# dunst.service is left failed, which #106 made visible.
+
+UNITS="$REPO/.config/systemd/user"
+TIMER="$UNITS/battery-monitor.timer"
+SERVICE="$UNITS/battery-monitor.service"
+
+# Comments stripped before counting. The new timer explains in a comment what
+# it used to say, and an unanchored grep counts that explanation as the
+# setting, which is how this check first passed the wrong way round.
+unit_code() { sed 's/^[[:space:]]*#.*//' "$1"; }
+
+check "the timer is wanted by the graphical session" \
+  "$(unit_code "$TIMER" | grep -c '^WantedBy=graphical-session.target$')" "1"
+check "and not by timers.target, which starts with the user manager" \
+  "$(unit_code "$TIMER" | grep -c 'WantedBy=timers.target')" "0"
+check "stripping comments leaves the settings intact" \
+  "$(unit_code "$TIMER" | grep -c '^Requires=')" "1"
+check "and is part of the session, so it stops with it" \
+  "$(grep -c '^PartOf=graphical-session.target$' "$TIMER")" "1"
+check "the schedule counts from the session, not from boot" \
+  "$(grep -c '^OnActiveSec=' "$TIMER")" "1"
+check "so OnBootSec is gone" "$(unit_code "$TIMER" | grep -c '^OnBootSec=')" "0"
+check "and Persistent with it, there being no missed run worth catching up" \
+  "$(unit_code "$TIMER" | grep -c '^Persistent=')" "0"
+check "the service is part of the session too" \
+  "$(grep -c '^PartOf=graphical-session.target$' "$SERVICE")" "1"
+check "and has no Install section inviting it to be enabled on its own" \
+  "$(unit_code "$SERVICE" | grep -c '^\[Install\]')" "0"
+check "the timer still requires the service, or nothing would run" \
+  "$(grep -c '^Requires=battery-monitor.service$' "$TIMER")" "1"
+
+# systemd's own verdict, where it is available.
+if ! command -v systemd-analyze >/dev/null 2>&1; then
+  pass "systemd-analyze is not installed here, so its verdict is skipped"
+else
+  complaints=$(systemd-analyze --user verify "$TIMER" 2>&1 | grep -c . || true)
+  check "systemd accepts the timer with no complaint" "$complaints" "0"
+fi
+
+# install.sh must not start it during an install, where no session exists.
+check "install.sh enables the timer without starting it" \
+  "$(grep -c 'systemctl --user enable battery-monitor.timer$' "$REPO/install.sh")" "1"
+check "and no longer uses --now, which fired it with no compositor" \
+  "$(grep -c 'enable --now battery-monitor.timer' "$REPO/install.sh")" "0"
+
+# --- and the change reaches machines that already exist ----------------------
+
+MIGRATION="$REPO/migrations/1788702842.sh"
+check "a migration carries it" "$([[ -f $MIGRATION ]] && echo yes || echo no)" "yes"
+
+PRE="$REPO/test/fixtures/pre-session-timer"
+check "it records two checksums, one per unit" \
+  "$(grep -cE '^(TIMER|SERVICE)_SUM="[a-f0-9]{32}"$' "$MIGRATION")" "2"
+check "and the timer fixture is the version it records" \
+  "$(md5sum "$PRE/battery-monitor.timer" | cut -d' ' -f1)" \
+  "$(grep -oE '^TIMER_SUM="[a-f0-9]+"' "$MIGRATION" | cut -d'"' -f2)"
+check "and the service fixture likewise" \
+  "$(md5sum "$PRE/battery-monitor.service" | cut -d' ' -f1)" \
+  "$(grep -oE '^SERVICE_SUM="[a-f0-9]+"' "$MIGRATION" | cut -d'"' -f2)"
+check "and the fixture really is the old shape, or this proves nothing" \
+  "$(grep -c 'WantedBy=timers.target' "$PRE/battery-monitor.timer")" "1"
+
+BHOME="$TMP/battery-home"
+BSTUB="$TMP/battery-bin"; mkdir -p "$BSTUB"
+cat >"$BSTUB/systemctl" <<'STUBEOF'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >>"$SYSTEMCTL_LOG"
+case "$*" in
+  *"is-enabled battery-monitor.timer") exit "${TIMER_ENABLED_RC:-0}" ;;
+  *"is-active graphical-session.target") exit "${SESSION_RC:-0}" ;;
+esac
+exit 0
+STUBEOF
+chmod +x "$BSTUB/systemctl"
+
+setup_units() {
+  rm -rf "${TMP:?}/battery-home"; mkdir -p "$BHOME/.config/systemd/user"
+  cp "$PRE/battery-monitor.timer" "$PRE/battery-monitor.service" \
+    "$BHOME/.config/systemd/user/"
+}
+run_migration() {
+  : >"$TMP/systemctl.log"
+  SYSTEMCTL_LOG="$TMP/systemctl.log" HOME="$BHOME" HYPRSIMPLE_PATH="$REPO" \
+    PATH="$BSTUB:/usr/bin:/bin" "$@" bash "$MIGRATION" >"$TMP/mig-out" 2>&1
+}
+
+setup_units
+run_migration
+check "an unedited timer is replaced" \
+  "$(grep -c 'WantedBy=graphical-session.target' "$BHOME/.config/systemd/user/battery-monitor.timer")" "1"
+check "and the service with it" \
+  "$(grep -c 'PartOf=graphical-session.target' "$BHOME/.config/systemd/user/battery-monitor.service")" "1"
+check "the enabling symlink is moved, not left under timers.target" \
+  "$(grep -c 'disable battery-monitor.timer' "$TMP/systemctl.log")" "1"
+check "and re-enabled afterwards" \
+  "$(grep -c 'enable battery-monitor.timer' "$TMP/systemctl.log")" "1"
+check "with a daemon-reload, or systemd would still hold the old unit" \
+  "$(grep -c 'daemon-reload' "$TMP/systemctl.log")" "1"
+
+# A machine that turned the timer off keeps it off.
+setup_units
+run_migration env TIMER_ENABLED_RC=1
+check "a disabled timer is not enabled behind the user's back" \
+  "$(grep -c 'enable battery-monitor.timer' "$TMP/systemctl.log")" "0"
+check "but the units are still corrected" \
+  "$(grep -c 'WantedBy=graphical-session.target' "$BHOME/.config/systemd/user/battery-monitor.timer")" "1"
+
+# An edited unit is left alone and named.
+setup_units
+printf '[Unit]\nDescription=mine\n' >"$BHOME/.config/systemd/user/battery-monitor.timer"
+run_migration
+check "an edited unit is left as it is" \
+  "$(grep -c 'Description=mine' "$BHOME/.config/systemd/user/battery-monitor.timer")" "1"
+check "and named, so the user knows theirs still runs early" \
+  "$(grep -c 'battery-monitor.timer' "$TMP/mig-out")" "1"
+
 if (( failures > 0 )); then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
This is the cause of the failure #106 made visible, and it is hyprsimple's own unit.

## The bug

`battery-monitor.timer` was `WantedBy=timers.target`, so it started with the user manager, before any compositor. `battery-monitor.service` said `After=graphical-session.target`, which is ordering only and does nothing when that target is not part of the same job. systemd agrees:

    $ systemctl --user show battery-monitor.timer -p WantedBy
    WantedBy=timers.target

Measured on a login:

    11:54:23 systemd[946]: Starting Battery Monitor Service...
    11:54:23 systemd[946]: Finished Battery Monitor Service.
    11:54:23 uwsm[992]: Selected compositor ID: hyprland.desktop

The monitor ran, and Hyprland was selected afterwards. With a low battery that means two things happen before anyone has logged in to see them:

- `brightnessctl set 5%` dims the panel at the greeter, with nothing on screen to say why.
- `notify-send` activates dunst over D-Bus into a session with no Wayland display. dunst falls back to X11 and aborts on `Couldn't initialize X11 output`, is retried five times, and burns its start limit. The notification is lost and `dunst.service` is left `failed` for the rest of the boot, along with its start limit, so a later legitimate activation fails too.

That failed unit is exactly what the SERVICES section added in #106 reports on this machine. This is where it comes from.

## The fix

Both units belong to `graphical-session.target`, so the timer exists only while a session does, and the schedule counts from the session rather than from boot. `Persistent=true` goes with `OnBootSec`: it exists to catch up a run missed while powered off, and a battery reading from before the machine was on is not worth acting on.

`install.sh` enables without `--now`, for the same reason: the install runs from a TTY or another session where that target is not up, and `--now` started a timer that would fire the script with no compositor.

The service loses its `[Install]` section. It was `WantedBy=default.target`, which invites `systemctl --user enable battery-monitor.service` and would run it at login, which is the thing this change exists to stop. The timer starts it and nothing else should.

The units live in `~/.config`, so a migration carries all of it: both files replaced only where still byte-identical to the recorded checksums, `daemon-reload`, and the enabling symlink moved from `timers.target.wants` to `graphical-session.target.wants`, since `enable` state does not follow a changed `WantedBy`. A machine that had turned the timer off keeps it off.

## Evidence

Thirty checks added to `test/screenshot-and-battery-test.sh`, plus `systemd-analyze --user verify` on the timer where it is available. The migration runs against throwaway homes with `systemctl` stubbed to a log, never a real session, and this machine's units are byte-identical before and after the suites.

Four sabotages:

- the timer back on `timers.target`: 4 red
- `install.sh` starting it during the install again: 4 red across two suites
- the migration not moving the enablement: `the enabling symlink is moved, not left under timers.target`
- the migration enabling a timer the user had disabled: `a disabled timer is not enabled behind the user's back`

`committed-symlinks-test.sh` asserted the old `enable --now` line and had to be updated with it. It is about the symlink, which `enable` alone still writes, and it now also asserts the absence of `--now`.

One check of mine passed the wrong way round first. `WantedBy=timers.target` counted 1 against the corrected file, because the new timer explains in a comment what it used to say and an unanchored grep counts the explanation as the setting. That is the sixth time this project has caught a check reading its own comment, so the settings are read through a comment stripper now, with a check that the stripper leaves real settings behind.

55 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.

## What this does not fix

A notification sent by anything else before the session is up will still activate `dunst.service` into a display-less bus. hyprsimple no longer causes that itself, which was the only cause I could find on this machine, but the muslimtify daemon starts at the same moment and is another notifier. Deciding whether dunst should be started by hyprsimple or by its own unit is a separate question from stopping hyprsimple triggering it early.
