### PR TITLE
Name a real file in the last thing an install says, and log out gently

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -835,15 +835,32 @@ echo "Log saved to $INSTALL_LOG"
 echo ""
 echo "Next steps:"
 echo "1. Log out and log back in to Hyprland"
-echo "2. Customize ~/.config/hypr/monitors.conf for your setup"
+echo "2. Customize ~/.config/hypr/monitors.lua for your setup"
 echo "3. Update later with: hyprsimple-update"
 echo ""
 
 read -rp "Logout to take effect? (y/n) " logout
 if [ "$logout" == "y" ]; then
-    echo "Logging out..."
-    hyprctl dispatch exit
+  echo "Logging out..."
+  # hyprsimple's own logout, the same one SUPER + X and the power menu run. It
+  # closes windows and waits for them before stopping the session.
+  #
+  # This was `hyprctl dispatch exit`, which tears the compositor down at once.
+  # A browser still flushing its profile is killed, which is the single thing
+  # hypr-logout.sh was written to prevent, and the installer was the one place
+  # still doing it. It is also the wrong call under uwsm, which wants its
+  # session stopped rather than its compositor shot: `uwsm stop`, which
+  # hypr-logout.sh ends with.
+  #
+  # An install run from a TTY has no session to leave. Saying so beats
+  # hyprctl printing a socket error and the script exiting as though it worked.
+  if pgrep -x Hyprland >/dev/null 2>&1; then
+    "$HOME/.local/bin/hypr-logout.sh"
+  else
+    echo "No Hyprland session is running here, so there is nothing to log out of."
+    echo "Log in to Hyprland to pick up the changes."
+  fi
 else
-    echo "Exiting..."
-    exit
+  echo "Exiting..."
+  exit
 fi

--- a/test/named-paths-test.sh
+++ b/test/named-paths-test.sh
@@ -118,6 +118,89 @@ if command -v lua >/dev/null 2>&1; then
   fi
 fi
 
+# --- and the last thing an install says -------------------------------------
+#
+# The closing message told every new user
+#
+#   2. Customize ~/.config/hypr/monitors.conf for your setup
+#
+# and there has been no monitors.conf since the config became lua. The one
+# instruction an installer leaves you with named a file that is not there.
+#
+# Every ~/.config path the installer names is checked, not just that one, since
+# the same drift can happen to any of them. Paths under a directory hyprsimple
+# creates rather than ships are exempted by name.
+
+INSTALL="$REPO/install.sh"
+# Comments stripped before any of this counts anything. install.sh explains in
+# comments what it used to do, naming both the dangling
+# ~/.config/rofi/launcher/launcher link it no longer makes and the
+# `hyprctl dispatch exit` it no longer runs, and an unanchored grep reads those
+# explanations as code. Three of these checks failed that way first.
+code_of() { sed 's/#.*//' "$1"; }
+INSTALL_CODE="$TMP/install.code"
+code_of "$INSTALL" >"$INSTALL_CODE"
+check "stripping comments leaves install.sh's code behind" \
+  "$(grep -c '^install_packages()' "$INSTALL_CODE")" "1"
+GENERATED="uwsm/env uwsm/env-hyprland btop/themes rofi/hyprsimple hypr/hyprsimple
+  dunst/dunstrc.d hypr/theme-active.lua hypr/theme-hyprlock.conf"
+
+# Both spellings. install.sh writes "$HOME/.config/..." in code and ~/.config/...
+# in the text it prints, and reading only the printed form found a single path,
+# which is not enough for the check below to mean anything.
+mapfile -t named < <(
+  {
+    # shellcheck disable=SC2088  # a grep pattern, not a path to expand
+    grep -oE '~/\.config/[A-Za-z0-9_./-]+' "$INSTALL_CODE"
+    grep -oE '\$HOME/\.config/[A-Za-z0-9_./-]+' "$INSTALL_CODE"
+  } | sed 's|~/\.config/||; s|\$HOME/\.config/||; s|[./]*$||' | LC_ALL=C sort -u
+)
+if (( ${#named[@]} < 3 )); then
+  fail "found ${#named[@]} config paths in install.sh, so this is not reading it"
+else
+  pass "checked ${#named[@]} config paths the installer names"
+fi
+
+absent=()
+for rel in "${named[@]}"; do
+  # Written by the installer or by a theme switch rather than shipped. Matched
+  # as a prefix: the exempt entries name directories, and the paths found
+  # include files inside them, such as the dunst drop-in symlink.
+  exempt=0
+  for gen in $GENERATED; do
+    [[ $rel == "$gen" || $rel == "$gen"/* ]] && { exempt=1; break; }
+  done
+  (( exempt )) && continue
+  [[ -e $REPO/.config/$rel ]] && continue
+  absent+=("$rel")
+done
+absent_str=""
+(( ${#absent[@]} > 0 )) && absent_str="$(printf '%s ' "${absent[@]}")"
+check "and every one of them is a file hyprsimple ships" "$absent_str" ""
+
+# The specific one, by name, so the reason stays readable.
+check "the closing message names monitors.lua" \
+  "$(grep -c 'hypr/monitors.lua for your setup' "$INSTALL_CODE")" "1"
+check "and no longer monitors.conf, which has not existed since the lua split" \
+  "$(grep -c 'monitors.conf' "$INSTALL_CODE")" "0"
+
+# --- and it leaves the session the way hyprsimple leaves it ------------------
+#
+# The prompt at the end ran `hyprctl dispatch exit`, which tears the compositor
+# down at once. A browser still flushing its profile is killed, which is the
+# single thing hypr-logout.sh exists to prevent, and the installer was the last
+# place still doing it. It is also the wrong call under uwsm, which wants its
+# session stopped rather than its compositor shot.
+
+check "the installer logs out through hyprsimple's own logout" \
+  "$(grep -c 'hypr-logout.sh' "$INSTALL_CODE")" "1"
+check "and not by shooting the compositor" \
+  "$(grep -c 'hyprctl dispatch exit' "$INSTALL_CODE")" "0"
+check "and says so rather than erroring when there is no session" \
+  "$(grep -c 'pgrep -x Hyprland' "$INSTALL_CODE")" "1"
+check "the script it calls is one the installer has already copied" \
+  "$([[ -f $BIN/hypr-logout.sh ]] && echo yes || echo no)" "yes"
+
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
Two bugs in the last twenty lines a new user sees.

## A file that does not exist

    Next steps:
    1. Log out and log back in to Hyprland
    2. Customize ~/.config/hypr/monitors.conf for your setup

There has been no `monitors.conf` since the config became lua. `git ls-files` has `.config/hypr/monitors.lua` and nothing else by that name. The one instruction an installer leaves someone with named a file that is not there, and it is the step about their monitors, which is the first thing anyone actually needs to edit.

Fixed, and generalised: a check reads every `~/.config` and `$HOME/.config` path the installer names and requires each to be a file hyprsimple ships. Eleven paths, with the ones hyprsimple writes rather than ships exempted by prefix.

## A logout that kills what it should be closing

    read -rp "Logout to take effect? (y/n) " logout
    if [ "$logout" == "y" ]; then
        hyprctl dispatch exit

`hyprctl dispatch exit` tears the compositor down at once. A browser still flushing its profile is killed, which is the single thing `hypr-logout.sh` was written to prevent in #88, and the installer was the last place still doing it. It is also the wrong call under uwsm, which wants its session stopped rather than its compositor shot: `uwsm stop`, which `hypr-logout.sh` ends with.

It calls `hypr-logout.sh` now, the same logout SUPER + X and the power menu use, which closes windows and waits for them before stopping the session. That script is already in `~/.local/bin` by this point in the install, and a check asserts it.

An install run from a TTY has no session to leave. That case says so, rather than letting hyprctl print a socket error while the script exits as though it had worked.

## Evidence

Twelve checks added to `test/named-paths-test.sh`, which already owns "hyprsimple named a path that nothing creates".

Four sabotages:

- `monitors.conf` restored: 3 red, including the generic path check catching it without being told about it
- `hyprctl dispatch exit` restored: 3 red
- the installer made to name an invented `hypr/nosuch.conf`: `and every one of them is a file hyprsimple ships (want , got hypr/nosuch.conf)`
- the comment stripper disabled: 3 red

55 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.

## Two things I got wrong first

Three of these checks failed against the corrected file, because `install.sh` explains in comments what it used to do, naming both the dangling `~/.config/rofi/launcher/launcher` link it no longer makes and the `hyprctl dispatch exit` it no longer runs. An unanchored grep read those explanations as code. That is the seventh time this project has caught a check reading its own comment, so it goes through the repo's `code_of` stripper, with a check that the stripper leaves real code behind.

Then the path check found exactly one path and its own guard fired. The installer writes `"$HOME/.config/..."` in code and `~/.config/...` only in the text it prints, and reading one spelling is not enough for the check to mean anything. Both are read now.

## Noticed, not fixed

`.bashrc` is tracked at the repository root and nothing copies it: `install.sh` iterates `"$DOTFILES_DIR/.config"/*` only, and `terminal.sh` appends a source line to whatever `~/.bashrc` already exists. It is dead weight rather than a bug, and deleting a tracked file someone may be using as a reference is a decision rather than a fix.
