### PR TITLE
Strip the ghostty lines ghostty accepts, not just the ones we write

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,6 +223,9 @@ jobs:
       - name: keybinding-viewer-test
         run: bash test/keybinding-viewer-test.sh
 
+      - name: ghostty-theme-test
+        run: bash test/ghostty-theme-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -56,8 +56,21 @@ fi
 # 5. Update Ghostty theme
 GHOSTTY_CONFIG="$HOME/.config/ghostty/config"
 if [[ -f "$GHOSTTY_CONFIG" ]]; then
-  # Remove old color/palette/theme lines, keep non-color settings
-  grep -vE '^(background|foreground|cursor-color|cursor-text|selection-background|selection-foreground|palette|theme) =' "$GHOSTTY_CONFIG" > "$GHOSTTY_CONFIG.tmp"
+  # Remove old color/palette/theme lines, keep non-color settings.
+  #
+  # The whitespace is matched the way ghostty matches it, not the way
+  # hyprsimple happens to write it. This pattern required exactly "key = ", so
+  # a line written any other way ghostty accepts survived every theme switch:
+  #
+  #   theme=gruvbox        kept, and "theme = kanagawa" appended after it
+  #   theme  =  gruvbox    kept
+  #     theme = gruvbox    kept
+  #
+  # All three validate, checked with `ghostty +validate-config`. The header of
+  # the shipped config promises these lines are removed and rewritten, so
+  # someone who set their own theme was told it would be replaced and instead
+  # kept a dead line they could no longer see taking effect.
+  grep -vE '^[[:space:]]*(background|foreground|cursor-color|cursor-text|selection-background|selection-foreground|palette|theme)[[:space:]]*=' "$GHOSTTY_CONFIG" > "$GHOSTTY_CONFIG.tmp"
 
   if [[ -f "$THEME_PATH/ghostty-theme" ]]; then
     # Use Ghostty's built-in theme

--- a/test/ghostty-theme-test.sh
+++ b/test/ghostty-theme-test.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# A theme switch rewrites ghostty's colour lines, and it only recognised one of
+# the several spellings ghostty accepts.
+#
+# theme-switcher.sh filtered with
+#
+#   grep -vE '^(background|foreground|...|palette|theme) ='
+#
+# which requires exactly "key = ". ghostty accepts more than that, checked with
+# `ghostty +validate-config`: key=value, key  =  value and leading whitespace
+# all validate. So a line written any of those ways survived every switch:
+#
+#   theme=gruvbox        kept, and "theme = kanagawa" appended after it
+#
+# The header of the shipped ghostty config promises these lines are "removed
+# and rewritten from the active theme", so someone who set their own theme was
+# told it would be replaced, and instead kept a dead line they could no longer
+# see taking effect.
+#
+# Nothing here runs ghostty as a terminal or touches the real ~/.config. The
+# switcher runs against a temporary home with every tool it calls stubbed.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the premise: ghostty really does accept these spellings -----------------
+#
+# If it did not, there would be no bug and every check below would be about
+# nothing.
+if ! command -v ghostty >/dev/null 2>&1; then
+  pass "ghostty is not installed here, so its verdict is skipped"
+else
+  accepts() {
+    printf '%s\n' "$1" >"$TMP/probe.conf"
+    ghostty +validate-config --config-file="$TMP/probe.conf" >/dev/null 2>&1 && echo yes || echo no
+  }
+  check "ghostty accepts key = value" "$(accepts 'font-size = 12')" "yes"
+  check "and key=value with no spaces" "$(accepts 'font-size=12')" "yes"
+  check "and padding around the equals" "$(accepts 'font-size   =   12')" "yes"
+  check "and a leading tab" "$(accepts '	font-size = 12')" "yes"
+fi
+
+# --- the switch ---------------------------------------------------------------
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+for tool in gsettings hyprctl systemctl pkill busctl notify-send \
+  hyprsimple-restart-waybar.sh hyprsimple-restart-dunst.sh; do
+  printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
+done
+
+HOME_DIR="$TMP/home"
+GCONF="$HOME_DIR/.config/ghostty/config"
+
+setup_home() {
+  rm -rf "${TMP:?}/home"
+  mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.cache" \
+    "$HOME_DIR/.config/ghostty" "$HOME_DIR/.config/hypr/themes/demo"
+  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+    "$HOME_DIR/.local/bin/"
+  # A theme naming a built-in ghostty theme, which is the branch that appends
+  # a single "theme = " line.
+  printf 'Demo Theme\n' >"$HOME_DIR/.config/hypr/themes/demo/ghostty-theme"
+  # And a theme file of that name inside the fake config, so the validation at
+  # the end judges the rewrite rather than the fixture. ghostty exits 1 on a
+  # theme it cannot find, which is what a made-up name did the first time this
+  # ran.
+  mkdir -p "$HOME_DIR/.config/ghostty/themes"
+  printf 'background = #1e1e2e\nforeground = #cdd6f4\n' \
+    >"$HOME_DIR/.config/ghostty/themes/Demo Theme"
+  # Every spelling ghostty accepts, plus two settings that must survive.
+  cat >"$GCONF" <<'CFG'
+font-size=12
+theme=gruvbox
+palette=0=#111111
+  theme = indented
+background   =   #000000
+	foreground=#ffffff
+keybind = ctrl+shift+t=new_tab
+CFG
+}
+switch() {
+  HOME="$HOME_DIR" THEME_SWITCHER_NO_RELOAD=1 PATH="$STUB:/usr/bin:/bin" \
+    bash "$HOME_DIR/.local/bin/theme-switcher.sh" demo >/dev/null 2>&1
+}
+count() { grep -cE "$1" "$GCONF"; }
+
+setup_home
+switch
+
+check "one theme line remains after a switch" \
+  "$(count '^[[:space:]]*theme[[:space:]]*=')" "1"
+check "and it is the one the theme asked for" \
+  "$(count '^theme = Demo Theme$')" "1"
+check "a theme written with no spaces is removed" \
+  "$(count 'gruvbox')" "0"
+check "and an indented one" "$(count 'indented')" "0"
+check "a palette written with no spaces is removed" \
+  "$(count '^[[:space:]]*palette[[:space:]]*=')" "0"
+check "a padded background is removed" \
+  "$(count '^[[:space:]]*background[[:space:]]*=')" "0"
+check "and a tab indented foreground" \
+  "$(count '^[[:space:]]*foreground[[:space:]]*=')" "0"
+
+# The point of filtering rather than truncating: everything else is kept.
+check "the user's font-size survives" "$(count '^font-size=12$')" "1"
+check "and their keybind" "$(count 'keybind = ctrl\+shift\+t')" "1"
+
+# Switching repeatedly must not grow the file.
+before=$(wc -l <"$GCONF")
+switch; switch
+check "switching twice more does not add lines" "$(wc -l <"$GCONF")" "$before"
+check "and still leaves exactly one theme line" \
+  "$(count '^[[:space:]]*theme[[:space:]]*=')" "1"
+
+# And the result is still a config ghostty accepts.
+if command -v ghostty >/dev/null 2>&1; then
+  # XDG_CONFIG_HOME, not HOME. ghostty resolves a theme against
+  # $XDG_CONFIG_HOME/ghostty/themes and ignores HOME for it, so pointing HOME
+  # at the fixture left it looking in the real one and failing.
+  XDG_CONFIG_HOME="$HOME_DIR/.config" ghostty +validate-config --config-file="$GCONF" >/dev/null 2>&1
+  check "the rewritten config still validates" "$?" "0"
+  # And the check can fail: a config naming a theme that is not there does not
+  # validate, which is what makes the one above worth running.
+  printf 'theme = No Such Theme\n' >"$TMP/bad.conf"
+  XDG_CONFIG_HOME="$HOME_DIR/.config" ghostty +validate-config --config-file="$TMP/bad.conf" >/dev/null 2>&1
+  check "and validation does reject a missing theme, so that means something" "$?" "1"
+fi
+
+# --- the shipped config's promise matches what the filter does ---------------
+#
+# The header names the keys it says are rewritten. If the two lists drift, the
+# file is lying to whoever reads it.
+
+SHIPPED="$REPO/.config/ghostty/config"
+SWITCHER="$BIN/theme-switcher.sh"
+filter_keys=$(grep -oE '\(background\|[a-z|-]+\)' "$SWITCHER" | head -1 |
+  tr -d '()' | tr '|' '\n' | LC_ALL=C sort -u | tr '\n' ' ')
+if [[ -z ${filter_keys// /} ]]; then
+  fail "could not read the key list out of theme-switcher.sh"
+else
+  pass "the filter names: $filter_keys"
+fi
+
+missing=()
+for key in $filter_keys; do
+  grep -q -- "$key" "$SHIPPED" || missing+=("$key")
+done
+missing_str=""
+(( ${#missing[@]} > 0 )) && missing_str="$(printf '%s ' "${missing[@]}")"
+check "and the shipped config's header mentions every one of them" "$missing_str" ""
+
+# Both directions. The check above only requires the filter's keys to appear in
+# the header, so dropping one from the filter satisfied it and the header went
+# on promising a line nothing rewrote any more. Sabotage found that: removing
+# cursor-text produced no failure at all.
+#
+# The list is written out, so changing what the switcher rewrites means
+# changing this line and the header together, which is the point.
+check "the filter rewrites exactly the keys the header names" \
+  "$filter_keys" \
+  "background cursor-color cursor-text foreground palette selection-background selection-foreground theme "
+
+# The pattern has to be the tolerant one, stated by name so a narrowing edit is
+# caught even if a fixture stops covering it.
+check "the filter allows whitespace before the key" \
+  "$(grep -c "grep -vE '\^\[\[:space:\]\]\*(" "$SWITCHER")" "1"
+check "and around the equals" \
+  "$(grep -c 'theme)\[\[:space:\]\]\*=' "$SWITCHER")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
## The bug

A theme switch removes ghostty's colour lines and rewrites them from the active theme. It matched them with

    grep -vE '^(background|foreground|...|palette|theme) ='

which requires exactly `key = `. ghostty accepts more than that. Checked with `ghostty +validate-config`, all of these validate:

    font-size = 12
    font-size=12
    font-size   =   12
    	font-size = 12

So a line written any of those ways survived every switch, and the new one was appended after it. Simulated with the real filter and three switches:

    font-size=12
    theme=gruvbox
    palette=0=#111111
    theme = kanagawa

The header of the shipped ghostty config says those keys are "removed and rewritten from the active theme". Someone who set their own theme was told it would be replaced, and instead kept a dead line they could no longer see taking effect. Their `palette=` entries stayed too, mixed in with hyprsimple's.

The pattern now allows whitespace before the key and around the equals, which is what ghostty allows.

## Evidence

New suite `test/ghostty-theme-test.sh`, 22 checks, wired into CI. It runs the real `theme-switcher.sh` against a temporary home with every tool it calls stubbed, then asks ghostty whether the result is valid. Your `~/.config/ghostty/config` is byte-identical before and after.

The first four checks ask ghostty whether those spellings are accepted at all. If they were not there would be no bug, and every later check would be about nothing.

Three sabotages:

- the strict pattern restored: 9 red, and the fixture ends with **three** theme lines instead of one, which is the bug measured rather than described
- `cursor-text` dropped from the filter: `the filter rewrites exactly the keys the header names`
- the switcher writing its own line as `theme=X`: `and it is the one the theme asked for (want 1, got 0)`

That second sabotage found nothing the first time. My check only required the filter's keys to appear in the header, so removing one satisfied it and the header went on promising a line nothing rewrote. It compares both lists now.

Getting the validation honest took two goes as well. A made-up theme name fails `+validate-config` outright, so the check was judging my fixture rather than the rewrite; and ghostty resolves themes through `XDG_CONFIG_HOME`, not `HOME`, so pointing `HOME` at the fixture left it looking in the real config. There is now a companion check that validation does reject a missing theme, so the passing one means something.

56 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.

## Three things I looked at and did not report

Worth recording, because each looked like a bug and was not.

**The waybar backlight module hardcodes `"device": "intel_backlight"`**, which does not exist on an AMD laptop. That is the same shape as the keyboard backlight fixed in #93, so I expected a bug. waybar's `best_device` explicitly handles it: when "the configured name did not match" it falls back to the backlight device with the highest max brightness. It degrades to `amdgpu_bl0` on its own, and waybar's own man page uses `intel_backlight` in its example.

**hypridle dims with `brightnessctl -s set 5`**, a raw value rather than a percentage, which on this panel is 0.0104% of a maximum of 48000. The comment says "set monitor backlight to minimum, avoid 0", and a raw 5 is near-minimum on any panel with a maximum above it, so the value does what it says across hardware.

**`uwsm app --` scopes were a suspected collision** for the restart helpers, which `pkill` then immediately restart. Two scopes for the same command get different hashes, `app-Hyprland-sleep-b804ac1d` and `app-Hyprland-sleep-b0d27f9b`, so nothing collides.
