### PR TITLE
Re-assert the three links install-owned defaults arrive through

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,6 +226,9 @@ jobs:
       - name: ghostty-theme-test
         run: bash test/ghostty-theme-test.sh
 
+      - name: default-links-test
+        run: bash test/default-links-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -181,6 +181,48 @@ for script in "$HYPRSIMPLE_PATH/.local/bin"/*.sh "$HYPRSIMPLE_PATH/.local/bin"/*
   fi
 done
 
+# ---- The three links install-owned defaults arrive through ----------------
+#
+# hyprlock, hypridle and xdph read ~/.config/hypr/hyprsimple; the rofi stubs
+# import ~/.config/rofi/hyprsimple; dunst reads the drop-in symlinked into
+# dunstrc.d. install.sh makes all three and nothing ever re-made them, so a
+# link deleted, or left pointing at an old HYPRSIMPLE_PATH, stayed broken
+# through every update.
+#
+# It stays broken quietly. hyprlang ignores a `source =` naming a file that is
+# not there, and rofi ignores a missing @import, both without a word: measured
+# with hyprsunset and `rofi -dump-theme`, each exits 0 and says nothing. So a
+# missing hypr link leaves hypridle.conf with no listeners at all, which means
+# the screen stops dimming, locking and suspending on idle, and nothing
+# anywhere says why.
+#
+# Re-asserted here every run, which is what the helper scripts above already
+# get.
+ensure_link() {
+  local target="$1" link="$2" name="$3"
+
+  if [[ -L $link ]]; then
+    # Right target already, including the case where it is simply intact.
+    [[ $(readlink "$link") == "$target" ]] && return 0
+  elif [[ -e $link ]]; then
+    # A real file or directory someone put there. Replacing it would throw
+    # their work away, and `ln -sfn` onto an existing directory writes the link
+    # *inside* it, which is the accident install.sh once shipped.
+    echo -e "${YELLOW}$link is not a symlink, so hyprsimple's $name defaults are not reaching it.${NC}"
+    echo "  Move it aside and run hyprsimple-update again to restore the link."
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$link")"
+  ln -sfn "$target" "$link"
+  echo -e "${GREEN}Relinked:${NC} $link"
+}
+
+ensure_link "$HYPRSIMPLE_PATH/default/hypr" "$HOME/.config/hypr/hyprsimple" hypr
+ensure_link "$HYPRSIMPLE_PATH/default/rofi" "$HOME/.config/rofi/hyprsimple" rofi
+ensure_link "$HYPRSIMPLE_PATH/default/dunst/10-hyprsimple.conf" \
+  "$HOME/.config/dunst/dunstrc.d/10-hyprsimple.conf" dunst
+
 # ---- Packages ------------------------------------------------------------
 
 install_missing_packages() {

--- a/test/default-links-test.sh
+++ b/test/default-links-test.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Three symlinks carry every install-owned default into ~/.config, and only
+# install.sh ever made them.
+#
+#   ~/.config/hypr/hyprsimple                  hyprlock, hypridle, xdph
+#   ~/.config/rofi/hyprsimple                  the rofi stubs
+#   ~/.config/dunst/dunstrc.d/10-hyprsimple.conf   dunst's drop-in
+#
+# hyprsimple-update refreshed the helper scripts on every run and never looked
+# at these, so a link deleted, or left pointing at an old HYPRSIMPLE_PATH,
+# stayed broken through every update there would ever be.
+#
+# It stays broken quietly. hyprlang ignores a `source =` naming a file that is
+# not there and rofi ignores a missing @import, both without a word: measured
+# with hyprsunset and `rofi -dump-theme`, each exits 0 and prints nothing. So a
+# missing hypr link leaves hypridle.conf with nothing but five ignored source
+# lines, which is no listeners at all, which is a screen that stops dimming,
+# locking and suspending on idle with nothing anywhere to say why.
+#
+# The dangling-link case is not hypothetical: migration 1788620441 exists
+# because rofi links had already been left dangling once.
+#
+# Nothing here runs the updater. ensure_link is taken out of it and exercised
+# against throwaway directories.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE="$REPO/.local/bin/hyprsimple-update.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the function, taken from the updater so it cannot drift from it ---------
+
+fn=$(sed -n '/^ensure_link() {/,/^}/p' "$UPDATE")
+if [[ $(printf '%s\n' "$fn" | grep -c .) -lt 10 ]]; then
+  fail "extracted $(printf '%s\n' "$fn" | grep -c .) lines of ensure_link, so this is reading the wrong thing"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "extracted ensure_link from the updater"
+
+TARGET="$TMP/install/default/hypr"
+mkdir -p "$TARGET"
+: >"$TARGET/hyprlock.conf"
+
+# Runs ensure_link with colours emptied, so the messages are plain text.
+run_link() {
+  bash -c "
+    GREEN=; YELLOW=; NC=
+    $fn
+    ensure_link \"\$1\" \"\$2\" \"\$3\"
+  " _ "$1" "$2" "${3:-hypr}" 2>&1
+}
+
+LINK="$TMP/home/.config/hypr/hyprsimple"
+reset_home() { rm -rf "${TMP:?}/home"; mkdir -p "$TMP/home/.config"; }
+
+# --- absent ------------------------------------------------------------------
+
+reset_home
+out=$(run_link "$TARGET" "$LINK")
+check "a missing link is created" \
+  "$([[ -L $LINK ]] && echo yes || echo no)" "yes"
+check "pointing where it should" "$(readlink "$LINK")" "$TARGET"
+check "and it resolves, so the defaults are actually reachable" \
+  "$([[ -e $LINK/hyprlock.conf ]] && echo yes || echo no)" "yes"
+check "and it says what it did" "$(printf '%s\n' "$out" | grep -c '^Relinked:')" "1"
+
+# --- already correct ---------------------------------------------------------
+
+out=$(run_link "$TARGET" "$LINK")
+check "an intact link is left alone" "$(readlink "$LINK")" "$TARGET"
+check "and says nothing, an ordinary update having nothing to report" \
+  "$(printf '%s\n' "$out" | grep -c .)" "0"
+
+# --- dangling, the case the rofi migration was written for -------------------
+
+reset_home
+mkdir -p "$(dirname "$LINK")"
+ln -sfn "$TMP/gone/default/hypr" "$LINK"
+check "the fixture really is dangling, or this proves nothing" \
+  "$([[ -e $LINK ]] && echo resolves || echo dangling)" "dangling"
+out=$(run_link "$TARGET" "$LINK")
+check "a dangling link is repaired" "$(readlink "$LINK")" "$TARGET"
+check "and resolves afterwards" \
+  "$([[ -e $LINK/hyprlock.conf ]] && echo yes || echo no)" "yes"
+
+# --- pointing at an old install path ------------------------------------------
+
+reset_home
+mkdir -p "$(dirname "$LINK")" "$TMP/oldinstall/default/hypr"
+ln -sfn "$TMP/oldinstall/default/hypr" "$LINK"
+check "a link to somewhere that exists but is not the install still resolves" \
+  "$([[ -e $LINK ]] && echo resolves || echo dangling)" "resolves"
+run_link "$TARGET" "$LINK" >/dev/null
+check "and is still repointed at the install" "$(readlink "$LINK")" "$TARGET"
+
+# --- a real directory in the way ----------------------------------------------
+#
+# `ln -sfn` onto an existing directory writes the link inside it, which is the
+# accident install.sh once shipped as ~/.config/rofi/launcher/launcher. Nothing
+# is replaced here, because whatever is there is somebody's.
+
+reset_home
+mkdir -p "$LINK"
+: >"$LINK/mine.conf"
+out=$(run_link "$TARGET" "$LINK")
+check "a real directory is not replaced" \
+  "$([[ -L $LINK ]] && echo link || echo directory)" "directory"
+check "and what is in it is untouched" \
+  "$([[ -f $LINK/mine.conf ]] && echo yes || echo no)" "yes"
+# The link ln -sfn would leave inside the directory is named after the target,
+# not after the link, so that is what this looks for. Checking for the link's
+# own name found nothing whether the bug was present or not, which sabotage
+# showed by leaving this green while the guard was deleted.
+check "and no link is written inside it, which is what ln -sfn would do" \
+  "$([[ -e "$LINK/$(basename "$TARGET")" ]] && echo nested || echo none)" "none"
+check "and the user is told their defaults are not arriving" \
+  "$(printf '%s\n' "$out" | grep -c 'not reaching it')" "1"
+
+# --- a real file in the way ---------------------------------------------------
+
+reset_home
+mkdir -p "$(dirname "$LINK")"
+printf 'mine\n' >"$LINK"
+out=$(run_link "$TARGET" "$LINK")
+check "a real file is not replaced either" "$(cat "$LINK")" "mine"
+check "and is reported the same way" \
+  "$(printf '%s\n' "$out" | grep -c 'not reaching it')" "1"
+
+# --- the updater asks for all three -------------------------------------------
+
+calls=$(grep -c '^ensure_link ' "$UPDATE")
+check "the updater re-asserts three links" "$calls" "3"
+for want in "default/hypr" "default/rofi" "default/dunst/10-hyprsimple.conf"; do
+  check "including $want" \
+    "$(grep -c "ensure_link .*$want" "$UPDATE")" "1"
+done
+
+# The same three install.sh creates, so the two cannot drift apart.
+for want in "default/hypr\"" "default/rofi\"" "default/dunst/10-hyprsimple.conf\""; do
+  check "and install.sh links $want too" \
+    "$(grep -c "ln -sfn .*$want" "$REPO/install.sh")" "1"
+done
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
## The bug

Three symlinks carry every install-owned default into `~/.config`:

    ~/.config/hypr/hyprsimple                      hyprlock, hypridle, xdph
    ~/.config/rofi/hyprsimple                      the rofi stubs
    ~/.config/dunst/dunstrc.d/10-hyprsimple.conf   dunst's drop-in

Only `install.sh` ever made them. `hyprsimple-update` refreshes the helper scripts on every run and never looked at these, so a link deleted, or left pointing at an old `HYPRSIMPLE_PATH`, stayed broken through every update there would ever be.

It stays broken quietly, which is what makes it worth fixing rather than documenting. Both readers ignore a missing include without a word:

- hyprlang, probed with hyprsunset against a config sourcing a file that is not there: `Loaded 1 profiles`, exit 0, no complaint.
- rofi, probed with `rofi -dump-theme` against a stub importing a missing file: exit 0, nothing on stderr.

So a missing hypr link leaves `~/.config/hypr/hypridle.conf` as five `source =` lines pointing at nothing, which is **no listeners at all**: the screen stops dimming, stops locking and stops suspending on idle, and nothing anywhere says why. A missing rofi link silently drops back to rofi's built-in theme. A missing dunst drop-in silently drops hyprsimple's notification styling.

This is not hypothetical. Migration `1788620441` exists because rofi links had already been left dangling once.

## The fix

The updater re-asserts all three, the same treatment the helper scripts already get. A link that is already correct is left alone and says nothing, so an ordinary update is unchanged.

Anything that is *not* a symlink is reported rather than replaced. `ln -sfn` onto an existing directory writes the link **inside** it, which is the accident install.sh once shipped as `~/.config/rofi/launcher/launcher`, and whatever is there is somebody's.

## Evidence

New suite `test/default-links-test.sh`, 26 checks, wired into CI. `ensure_link` is taken out of the updater so it cannot drift from it, and exercised against throwaway directories: absent, already correct, dangling, pointing at an old install that still exists, a real directory in the way, a real file in the way. Your three live links are untouched.

Three sabotages:

- the three calls removed: 4 red
- the not-a-symlink guard removed: 4 red, including `and no link is written inside it, which is what ln -sfn would do (want none, got nested)`
- an intact link relinked every run: `and says nothing, an ordinary update having nothing to report (want 0, got 1)`

Both of the last two exposed problems in my own checks first. The nested-link check looked for a file named after the *link*, and the link `ln -sfn` leaves behind is named after the *target*, so it stayed green while the guard was deleted. And the sabotage that should have caught a noisy relink did not apply at all the first time, so it reported nothing rather than reporting a pass; redone against real line numbers, it fails correctly.

57 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.
