### PR TITLE
Hide only the sharing bar, not every window that mentions sharing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,6 +229,9 @@ jobs:
       - name: default-links-test
         run: bash test/default-links-test.sh
 
+      - name: window-rules-test
+        run: bash test/window-rules-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/default/hypr/windows.lua
+++ b/default/hypr/windows.lua
@@ -43,8 +43,33 @@ hl.window_rule({
 	tag = "-default-opacity",
 })
 
--- Hide the "<app> is sharing your screen" notification bar
-hl.window_rule({ match = { title = ".*is sharing.*" }, workspace = "special silent" })
+-- Hide the "<site> is sharing your screen" bar a browser shows while a call
+-- has your screen.
+--
+-- The pattern used to be ".*is sharing.*", which is a workspace rule and so is
+-- applied when a window opens. Any window whose title happened to contain
+-- those two words was moved to a hidden workspace and appeared not to open at
+-- all. Measured: a terminal titled "How Netflix is sharing your data" went
+-- straight to special:special and was gone.
+--
+-- The six titles a chromium browser can give this bar, read out of Brave's own
+-- en-US.pak, are
+--
+--   $1 is sharing your screen.            $1 is sharing a window.
+--   $1 is sharing your screen and audio.  $1 is sharing a window and audio.
+--   $1 is sharing a Brave tab.            $1 is sharing a Brave tab and audio.
+--
+-- so the object and the full stop are what tell the bar apart from prose. All
+-- six still match. "is sharing your data" and "is sharing a document" no
+-- longer do.
+--
+-- Narrowing rather than widening on purpose: if some browser words this
+-- differently the bar reappears, which is visible and harmless, where the old
+-- pattern lost you a window with no explanation.
+hl.window_rule({
+	match = { title = ".*is sharing (your screen|a window|a [A-Za-z]+ tab)( and audio)?\\..*" },
+	workspace = "special silent",
+})
 
 -- Force chromium-based browsers into a tile (chromium --app bug workaround)
 hl.window_rule({ match = { tag = "chromium-based-browser" }, tile = true })

--- a/test/window-rules-test.sh
+++ b/test/window-rules-test.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# The rule that hides a browser's screen-sharing bar hid ordinary windows too.
+#
+#   hl.window_rule({ match = { title = ".*is sharing.*" }, workspace = "special silent" })
+#
+# workspace is applied when a window opens, so any window whose title happened
+# to contain those two words went straight to a hidden workspace and appeared
+# not to open at all. Measured on a live session, with a terminal:
+#
+#   How Netflix is sharing your data -> ws=special:special
+#
+# The six titles a chromium browser gives that bar, read out of Brave's own
+# locales/en-US.pak, are
+#
+#   $1 is sharing your screen.            $1 is sharing a window.
+#   $1 is sharing your screen and audio.  $1 is sharing a window and audio.
+#   $1 is sharing a Brave tab.            $1 is sharing a Brave tab and audio.
+#
+# so the object and the full stop are what separate the bar from prose.
+#
+# Nothing here opens a window. The pattern is read out of windows.lua and run
+# against titles, which is the same question Hyprland asks of it.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RULES="$REPO/default/hypr/windows.lua"
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+# --- the pattern, taken from the rule -----------------------------------------
+#
+# Read from the file rather than repeated here, so a change to the rule is
+# tested rather than shadowed by a copy that still says what it used to.
+pattern=$(grep -oE 'title = "[^"]*is sharing[^"]*"' "$RULES" |
+  head -1 | sed 's/^title = "//; s/"$//; s/\\\\\./\\./g')
+
+if [[ -z $pattern ]]; then
+  fail "no sharing rule found in windows.lua, so this suite is reading the wrong file"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "read the pattern: $pattern"
+
+matches() { printf '%s' "$1" | grep -qE "$pattern" && echo yes || echo no; }
+
+# --- every title the bar can actually have ------------------------------------
+
+for title in \
+  "meet.google.com is sharing your screen." \
+  "meet.google.com is sharing your screen and audio." \
+  "zoom.us is sharing a window." \
+  "zoom.us is sharing a window and audio." \
+  "app.slack.com is sharing a Brave tab." \
+  "app.slack.com is sharing a Chrome tab and audio."; do
+  check "hidden: $title" "$(matches "$title")" "yes"
+done
+
+# --- and the ordinary titles that used to be caught ---------------------------
+
+for title in \
+  "How Netflix is sharing your data" \
+  "Alice is sharing a document" \
+  "is sharing data with partners" \
+  "Who is sharing my screen? - Reddit" \
+  "A guide to sharing your screen" \
+  "This tab is sharing your screen"; do
+  check "left alone: $title" "$(matches "$title")" "no"
+done
+
+# --- the rule is still the one Hyprland will apply ---------------------------
+
+# Comments stripped before counting. The rule now explains itself in a comment
+# that quotes all six titles, and an unanchored grep counted those explanations
+# as rules: eight, against the one that exists. Anchored to the start of the
+# line so a lua `--` inside a string or an arithmetic minus survives, which is
+# the mistake the lua stripper in another suite made once.
+code_of() { sed 's/^[[:space:]]*--.*//' "$1"; }
+CODE=$(code_of "$RULES")
+
+check "the rule still sends the bar to a silent special workspace" \
+  "$(printf '%s\n' "$CODE" | grep -c 'workspace = "special silent"')" "1"
+check "and there is exactly one sharing rule, not two competing ones" \
+  "$(printf '%s\n' "$CODE" | grep -c 'is sharing')" "1"
+check "stripping comments leaves the rules behind" \
+  "$(printf '%s\n' "$CODE" | grep -c '^hl\.window_rule(')" "$(grep -c '^hl\.window_rule(' "$RULES")"
+
+# The old pattern must not come back. Stated by name, because a widening edit
+# would still pass every check above.
+check "the bare two-word pattern is gone" \
+  "$(printf '%s\n' "$CODE" | grep -c 'title = ".\*is sharing.\*"')" "0"
+
+# --- windows.lua still loads --------------------------------------------------
+
+if command -v luac >/dev/null 2>&1; then
+  if luac -p "$RULES" >/dev/null 2>&1; then
+    pass "windows.lua still parses as lua"
+  else
+    fail "windows.lua no longer parses as lua"
+  fi
+else
+  fail "luac is not installed, so windows.lua cannot be checked"
+fi
+
+# A rule file that had been emptied would pass everything above except this.
+rules=$(grep -c '^hl\.\(window\|layer\)_rule(' "$RULES")
+if (( rules >= 40 )); then
+  pass "windows.lua still holds $rules rules"
+else
+  fail "windows.lua holds only $rules rules, which is too few to be intact"
+fi
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Found while reading `windows.lua`, and it lands on the thing you asked about earlier: screen sharing in meetings.

## The bug

    hl.window_rule({ match = { title = ".*is sharing.*" }, workspace = "special silent" })

`workspace` is applied when a window opens, so any window whose title happened to contain those two words went to a hidden workspace and appeared not to open at all. Measured on this live session with a terminal:

    title=How Netflix is sharing your data  ->  ws=special:special

The window is gone, with no message and nothing on screen to say where it went. It is a bad failure to have while sharing a screen, which is exactly when a browser window is likely to be titled something about sharing.

## Which titles the bar actually has

Read out of Brave's own `locales/en-US.pak` rather than guessed:

    $1 is sharing your screen.            $1 is sharing a window.
    $1 is sharing your screen and audio.  $1 is sharing a window and audio.
    $1 is sharing a Brave tab.            $1 is sharing a Brave tab and audio.

So narrowing to "your screen", which was my first instinct, would have broken the window and tab cases. The object and the full stop are what separate the bar from prose, and the pattern now matches all six and none of the ordinary titles.

Verified end to end on a live session, with the rule loaded:

    meet.google.com is sharing your screen.  ->  ws=special:special
    How Netflix is sharing your data         ->  ws=1

Both test windows were closed afterwards, no window is left on any special workspace, `hyprctl configerrors` is empty, and the install tree is clean.

## Why narrow rather than widen

If some browser words this differently, the bar reappears. That is visible and harmless. The old pattern lost you a window with no explanation, which is neither.

## Evidence

New suite `test/window-rules-test.sh`, 22 checks, wired into CI. The pattern is read out of `windows.lua` rather than repeated, so a change to the rule is tested rather than shadowed by a stale copy, and it is run against the six real titles and six ordinary ones.

Three sabotages:

- the broad pattern restored: 6 red, every ordinary title caught again
- narrowed to "your screen" only, which is the mistake I nearly made: 4 red, the window and tab cases missed
- the rule deleted: `no sharing rule found in windows.lua, so this suite is reading the wrong file`

One of my own checks counted 8 sharing rules against the 1 that exists, because the new comment quotes all six titles. Comments are stripped before counting now, anchored to the start of a line so a `--` inside a string survives, with a check that stripping leaves the rules behind. That is the eighth time this project has caught a check reading its own comment.

58 suites, 0 failing, three consecutive runs. shellcheck clean at `style`, including the `--shell=bash` migrations pass.

## Note

`default/hypr/windows.lua` is install-owned, so this reaches every machine on the next `hyprsimple-update` with no migration, taking effect at the next reload or login. omarchy carries the same broad rule in `default/hypr/apps/browser.lua`, which is where hyprsimple's came from.
