### PR TITLE
Stop the installer's backup from destroying the thing it backs up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,6 +232,9 @@ jobs:
       - name: window-rules-test
         run: bash test/window-rules-test.sh
 
+      - name: install-backup-test
+        run: bash test/install-backup-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/install.sh
+++ b/install.sh
@@ -640,14 +640,39 @@ done
 echo ""
 echo -e "${YELLOW}Copying configuration files...${NC}"
 
-# Backup function: moves any existing target (file, dir, or symlink) to <target>.backup.
-# Always copy-based; no symlink-install paths exist anymore.
+# Move an existing target (file, dir, or symlink) aside before writing over it.
+#
+# This began with `rm -rf "$1.backup"`, which destroyed the thing the backup
+# existed for. The first install moves your own config to <target>.backup. A
+# second install, run months later to repair something, deleted that and put
+# hyprsimple's own previous copy there instead. Demonstrated on a fixture:
+# after two installs the original was gone, with zero copies left anywhere, and
+# .backup held hyprsimple v1.
+#
+# The first backup is the one worth keeping, because it is the only one holding
+# what was there before hyprsimple ever ran. Anything after it gets a
+# timestamped name, so nothing is ever destroyed.
+#
+# hyprsimple-muslimtify.sh already learned this and says so in its own backup
+# function. install.sh is where it costs the most.
 backup_if_exists() {
-  if [ -e "$1" ] || [ -L "$1" ]; then
-    echo -e "${YELLOW}Backing up existing $1 to $1.backup${NC}"
-    rm -rf "$1.backup"
-    mv "$1" "$1.backup"
+  local target="$1" source="${2-}"
+  [ -e "$target" ] || [ -L "$target" ] || return 0
+
+  # Nothing worth preserving when what is there is already what is about to be
+  # written. Without this, re-running the installer files a timestamped backup
+  # of hyprsimple's own unchanged scripts every time.
+  if [ -n "$source" ] && [ -f "$source" ] && [ -f "$target" ] && cmp -s "$source" "$target"; then
+    return 0
   fi
+
+  local backup="$target.backup"
+  if [ -e "$backup" ] || [ -L "$backup" ]; then
+    backup="$target.backup.$(date +%s)"
+  fi
+
+  echo -e "${YELLOW}Backing up existing $target to $backup${NC}"
+  mv "$target" "$backup"
 }
 
 # Copy .config directories and files
@@ -655,7 +680,7 @@ for item in "$DOTFILES_DIR/.config"/*; do
   basename_item=$(basename "$item")
 
   target="$HOME/.config/$basename_item"
-  backup_if_exists "$target"
+  backup_if_exists "$target" "$item"
 
   if [ -d "$item" ]; then
     cp -r "$item" "$target"
@@ -674,7 +699,7 @@ mkdir -p "$HOME/.local/bin"
 for script in "$DOTFILES_DIR/.local/bin"/*.sh "$DOTFILES_DIR/.local/bin"/*.fish; do
   if [ -f "$script" ]; then
     target="$HOME/.local/bin/$(basename "$script")"
-    backup_if_exists "$target"
+    backup_if_exists "$target" "$script"
     cp "$script" "$target"
     chmod +x "$target"
     echo -e "${GREEN}Copied:${NC} $(basename "$script")"
@@ -690,7 +715,7 @@ if [ -d "$DOTFILES_DIR/.local/share" ]; then
     if [ -e "$item" ]; then
       basename_item=$(basename "$item")
       target="$HOME/.local/share/$basename_item"
-      backup_if_exists "$target"
+      backup_if_exists "$target" "$item"
       cp -r "$item" "$target"
       echo -e "${GREEN}Copied:${NC} .local/share/$basename_item"
     fi

--- a/test/install-backup-test.sh
+++ b/test/install-backup-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# The installer's backup destroyed the thing it existed to protect.
+#
+#   backup_if_exists() {
+#     if [ -e "$1" ] || [ -L "$1" ]; then
+#       rm -rf "$1.backup"
+#       mv "$1" "$1.backup"
+#     fi
+#   }
+#
+# The first install moves your own config to <target>.backup, which is the one
+# copy of what was there before hyprsimple ever ran. A second install, run
+# months later to repair something, deleted that and put hyprsimple's own
+# previous copy there instead. Demonstrated on a fixture: after two installs
+# the original was gone, zero copies left anywhere, and .backup held
+# hyprsimple v1.
+#
+# The same lesson is already written into hyprsimple-muslimtify.sh's own backup
+# function, which keeps the first rather than the most recent. install.sh is
+# where it costs the most, and is where it had not been applied.
+#
+# Nothing here runs the installer. backup_if_exists is taken out of it and
+# exercised against throwaway directories.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$REPO/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+fn=$(sed -n '/^backup_if_exists() {/,/^}/p' "$INSTALL")
+if [[ $(printf '%s\n' "$fn" | grep -c .) -lt 10 ]]; then
+  fail "extracted $(printf '%s\n' "$fn" | grep -c .) lines of backup_if_exists, so this is reading the wrong thing"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "extracted backup_if_exists from the installer"
+
+# Runs the function with colours emptied.
+backup() {
+  bash -c "
+    YELLOW=; NC=
+    $fn
+    backup_if_exists \"\$1\" \"\${2-}\"
+  " _ "$@" >/dev/null 2>&1
+}
+
+DIR="$TMP/work"
+reset() { rm -rf "${TMP:?}/work"; mkdir -p "$DIR"; }
+
+# --- the case that lost the original ------------------------------------------
+
+reset
+mkdir -p "$DIR/waybar"
+printf 'MY ORIGINAL\n' >"$DIR/waybar/config.jsonc"
+
+# First install.
+backup "$DIR/waybar"
+mkdir -p "$DIR/waybar"; printf 'hyprsimple v1\n' >"$DIR/waybar/config.jsonc"
+check "the first install backs the original up" \
+  "$(cat "$DIR/waybar.backup/config.jsonc")" "MY ORIGINAL"
+
+# Second install, months later.
+backup "$DIR/waybar"
+mkdir -p "$DIR/waybar"; printf 'hyprsimple v2\n' >"$DIR/waybar/config.jsonc"
+check "and a second install leaves that backup alone" \
+  "$(cat "$DIR/waybar.backup/config.jsonc")" "MY ORIGINAL"
+check "so the original still exists somewhere" \
+  "$(grep -rl 'MY ORIGINAL' "$DIR" 2>/dev/null | wc -l | tr -d ' ')" "1"
+check "and the displaced copy is kept too, under a dated name" \
+  "$(find "$DIR" -maxdepth 1 -name 'waybar.backup.*' | wc -l | tr -d ' ')" "1"
+check "which holds what the second install displaced" \
+  "$(cat "$DIR"/waybar.backup.*/config.jsonc)" "hyprsimple v1"
+
+# --- nothing is backed up when nothing changed --------------------------------
+#
+# Without this, re-running the installer files a dated backup of hyprsimple's
+# own unchanged scripts on every run.
+
+reset
+printf 'same\n' >"$DIR/script.sh"
+printf 'same\n' >"$DIR/source.sh"
+backup "$DIR/script.sh" "$DIR/source.sh"
+check "an unchanged file is not backed up at all" \
+  "$(find "$DIR" -name 'script.sh.backup*' | wc -l | tr -d ' ')" "0"
+check "and is still there to be overwritten" \
+  "$([[ -f $DIR/script.sh ]] && echo yes || echo no)" "yes"
+
+printf 'different\n' >"$DIR/source.sh"
+backup "$DIR/script.sh" "$DIR/source.sh"
+check "a changed file is backed up" \
+  "$(cat "$DIR/script.sh.backup")" "same"
+
+# --- the shapes it has to handle ----------------------------------------------
+
+reset
+printf 'a file\n' >"$DIR/thing"
+backup "$DIR/thing"
+check "a plain file is moved aside" "$(cat "$DIR/thing.backup")" "a file"
+check "and is gone from its old place" \
+  "$([[ -e $DIR/thing ]] && echo present || echo moved)" "moved"
+
+reset
+ln -s /nonexistent "$DIR/thing"
+backup "$DIR/thing"
+check "a dangling symlink is moved aside, not skipped" \
+  "$([[ -L $DIR/thing.backup ]] && echo yes || echo no)" "yes"
+
+reset
+backup "$DIR/absent"
+check "something that is not there produces no backup" \
+  "$(find "$DIR" -name 'absent*' | wc -l | tr -d ' ')" "0"
+
+# --- nothing is ever destroyed ------------------------------------------------
+
+check "the function no longer removes an existing backup" \
+  "$(printf '%s\n' "$fn" | grep -c 'rm -rf')" "0"
+
+# And every caller passes the source, so the unchanged case above is reachable
+# from the installer rather than only from this suite.
+check "every call site passes what it is about to write" \
+  "$(grep -c 'backup_if_exists "\$target" "\$' "$INSTALL")" "3"
+check "and none calls it with the target alone" \
+  "$(grep -cE 'backup_if_exists "\$target"$' "$INSTALL")" "0"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
The installer's backup destroyed the thing it existed to protect.

## The bug

    backup_if_exists() {
      if [ -e "$1" ] || [ -L "$1" ]; then
        rm -rf "$1.backup"
        mv "$1" "$1.backup"
      fi
    }

The first install moves your own config to `<target>.backup`, which is the one copy of what was there before hyprsimple ever ran. A second install, run months later to repair something, deletes that and puts hyprsimple's own previous copy there instead.

Demonstrated on a fixture, two installs over a waybar config:

    after the first install:   backup holds "MY ORIGINAL WAYBAR CONFIG"
    after the second install:  backup holds "hyprsimple v1"
                               copies of the original left anywhere: 0

Silent, and irreversible. It applies to everything the installer copies: all of `.config/*`, every script in `.local/bin`, and `.local/share/*`.

## The fix

The first backup is kept, because it is the only one holding what was there before. Anything displaced after it gets a dated name, so nothing is destroyed.

Callers also pass what they are about to write, so a file that has not changed is not backed up at all. Without that, re-running the installer would file a dated backup of hyprsimple's own unchanged scripts on every run.

`hyprsimple-muslimtify.sh` already learned this and says so in its own backup function:

> Keeps the first backup rather than the most recent one. add saves the user's original, and a later remove used to overwrite that with the add-patched version, so the thing the backup existed to preserve was the thing it lost.

install.sh is where it costs the most, and is where it had not been applied.

## Evidence

New suite `test/install-backup-test.sh`, 16 checks, wired into CI. `backup_if_exists` is taken out of the installer so it cannot drift from it, and run against throwaway directories: the two-install sequence, an unchanged file, a changed file, a plain file, a dangling symlink, and a target that is not there.

Two sabotages:

- the `rm -rf` restored: 5 red, including `so the original still exists somewhere (want 1, got 0)`
- a call site no longer passing the source: 2 red

The first attempt at that first sabotage replaced the whole function with the old short one, which tripped the suite's own "extracted too few lines" guard and exited before reaching the behavioural checks. The guard is doing its job, but it made for weak evidence, so I redid the sabotage as a one-line change that keeps the function's shape and lets the real checks fail.

## Test runs

Per your note, this ran the suites related to the change rather than the full sweep: the new one, `suite-hygiene-test.sh` for the CI wiring, and the twenty other suites that read `install.sh`. All pass. shellcheck clean at `style`, including the `--shell=bash` migrations pass. CI runs everything.
