### PR TITLE
Keep ssh reachable when the installer is running over it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,6 +235,9 @@ jobs:
       - name: install-backup-test
         run: bash test/install-backup-test.sh
 
+      - name: firewall-test
+        run: bash test/firewall-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/install.sh
+++ b/install.sh
@@ -498,6 +498,27 @@ setup_firewall() {
     # Allow LocalSend (LAN file sharing)
     sudo ufw allow 53317/tcp
     sudo ufw allow 53317/udp
+
+    # `ufw enable` normally asks
+    #
+    #   Command may disrupt existing ssh connections. Proceed with operation (y|n)?
+    #
+    # and --force is exactly what skips that question. Skipping it is right for
+    # a local install, where there is no ssh session to disrupt, and wrong when
+    # this installer is itself running over one: "deny incoming" blocks the
+    # next connection, so the machine becomes unreachable the moment the
+    # session ends, and the one warning that would have said so was suppressed.
+    #
+    # SSH_CONNECTION is set by sshd for the session it serves, so this fires
+    # only when the installer is running over the connection it would cut. A
+    # local install is unchanged, and nobody's chosen posture is widened: the
+    # port is opened only for a machine that is already being reached on it.
+    if [[ -n ${SSH_CONNECTION-} ]]; then
+      echo -e "${YELLOW}Installing over SSH, so ssh is kept reachable.${NC}"
+      echo -e "${YELLOW}Close it later with: sudo ufw delete allow ssh${NC}"
+      sudo ufw allow ssh
+    fi
+
     sudo ufw --force enable
     echo -e "${GREEN}Firewall enabled (deny incoming, allow outgoing, LocalSend allowed)${NC}"
   else

--- a/test/firewall-test.sh
+++ b/test/firewall-test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# The installer enables a deny-incoming firewall and skipped the one warning
+# that exists for it.
+#
+#   sudo ufw --force enable
+#
+# `ufw enable` normally asks
+#
+#   Command may disrupt existing ssh connections. Proceed with operation (y|n)?
+#
+# and --force is exactly what skips that question, which is checked below
+# against ufw's own source rather than taken on trust. Skipping it is right for
+# a local install. It is wrong when the installer is itself running over ssh:
+# "deny incoming" blocks the next connection, so the machine becomes
+# unreachable the moment the session ends, and the warning that would have said
+# so was the thing suppressed.
+#
+# The firewall itself is a documented feature, so the posture is not changed
+# here. Only the case where the installer cuts its own connection.
+#
+# Nothing here runs ufw or sudo. setup_firewall is taken out of the installer
+# and run with both stubbed to a log.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$REPO/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+fn=$(sed -n '/^setup_firewall() {/,/^}/p' "$INSTALL")
+if [[ $(printf '%s\n' "$fn" | grep -c .) -lt 10 ]]; then
+  fail "extracted $(printf '%s\n' "$fn" | grep -c .) lines of setup_firewall, so this is reading the wrong thing"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "extracted setup_firewall from the installer"
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+cat >"$STUB/sudo" <<'STUBEOF'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$CALL_LOG"
+STUBEOF
+cat >"$STUB/ufw" <<'STUBEOF'
+#!/bin/bash
+printf 'ufw %s\n' "$*" >>"$CALL_LOG"
+STUBEOF
+chmod +x "$STUB"/*
+
+LOG="$TMP/calls"
+run_firewall() {
+  : >"$LOG"
+  env -u SSH_CONNECTION CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" "$@" bash -c "
+    GREEN=; YELLOW=; NC=
+    $fn
+    setup_firewall
+  " >/dev/null 2>&1
+}
+
+# --- a local install is unchanged ---------------------------------------------
+
+run_firewall
+check "a local install denies incoming" \
+  "$(grep -c 'ufw default deny incoming' "$LOG")" "1"
+check "and allows outgoing" \
+  "$(grep -c 'ufw default allow outgoing' "$LOG")" "1"
+check "and opens LocalSend" "$(grep -c 'ufw allow 53317' "$LOG")" "2"
+check "and enables the firewall" "$(grep -c 'ufw --force enable' "$LOG")" "1"
+check "and does not open ssh, nobody having asked for it" \
+  "$(grep -c 'ufw allow ssh' "$LOG")" "0"
+
+# --- an install running over ssh keeps its own way back in --------------------
+
+run_firewall env SSH_CONNECTION="10.0.0.5 51234 10.0.0.9 22"
+check "an install over ssh keeps ssh reachable" \
+  "$(grep -c 'ufw allow ssh' "$LOG")" "1"
+check "before enabling, not after, or the gap is the whole problem" \
+  "$(( $(grep -n 'ufw allow ssh' "$LOG" | cut -d: -f1) < $(grep -n 'ufw --force enable' "$LOG" | cut -d: -f1) ? 1 : 0 ))" "1"
+check "and the rest of the posture is the same" \
+  "$(grep -c 'ufw default deny incoming' "$LOG")" "1"
+check "and it still enables the firewall" \
+  "$(grep -c 'ufw --force enable' "$LOG")" "1"
+
+# --- the reason the warning matters -------------------------------------------
+#
+# Read out of ufw itself, so this suite is not asserting a claim about ufw that
+# ufw does not make.
+# A glob rather than parsing ls, which is the one finding class this project
+# has actually shipped as a bug.
+UFW_SRC=""
+for candidate in /usr/lib/python3*/site-packages/ufw/frontend.py; do
+  [[ -f $candidate ]] && { UFW_SRC="$candidate"; break; }
+done
+if [[ -z $UFW_SRC ]]; then
+  pass "ufw's source is not here, so its prompt cannot be quoted"
+else
+  # At least once, not exactly once: ufw wraps the sentence across two source
+  # lines and grep -c counts both.
+  hits=$(grep -c 'disrupt existing ssh connections' "$UFW_SRC")
+  check "ufw does warn about disrupting ssh, which --force skips" \
+    "$(( hits >= 1 ? 1 : 0 ))" "1"
+fi
+
+# --- and the installer still says what it did ---------------------------------
+
+code_of() { sed 's/#.*//' "$1"; }
+CODE="$TMP/install.code"
+code_of "$INSTALL" >"$CODE"
+check "stripping comments leaves the installer's code behind" \
+  "$(grep -c '^setup_firewall()' "$CODE")" "1"
+check "the ssh case is guarded on SSH_CONNECTION, not on sshd running" \
+  "$(grep -c 'SSH_CONNECTION' "$CODE")" "1"
+check "and tells the user how to close it again" \
+  "$(grep -c 'ufw delete allow ssh' "$CODE")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
## The bug

`setup_firewall` ends with

    sudo ufw --force enable

after setting `default deny incoming`. `ufw enable` normally asks:

    Command may disrupt existing ssh connections. Proceed with operation (y|n)?

and `--force` is exactly what skips that question. Confirmed against ufw's own `frontend.py` rather than assumed, and the suite quotes it from there so the claim stays true if ufw changes.

Skipping it is right for a local install, where there is no ssh session to disrupt. It is wrong when the installer is itself running over one: `deny incoming` blocks the next connection, so the machine becomes unreachable the moment the session ends, and the single warning that would have said so was the thing suppressed.

The timing is the unkind part. ufw keeps established connections, so the install finishes normally and looks fine. The lockout arrives on the next connection, by which point nothing on screen connects it to the installer.

`ufw` is in `packages.txt`, so the `command -v ufw` guard always passes and this always runs.

## The fix

The firewall is a documented feature and its posture is unchanged. Only the case where the installer cuts its own connection: with `SSH_CONNECTION` set, ssh is allowed before the firewall comes up, and the installer says so and how to close it again.

`SSH_CONNECTION` rather than "is sshd running" on purpose. It is set by sshd for the session it serves, so this fires only when the installer is running over the connection it would cut. A local install on a machine that happens to run sshd is untouched, and nobody's chosen posture is widened: the port is opened only on a machine that is already being reached on it.

## Evidence

New suite `test/firewall-test.sh`, 14 checks, wired into CI. `setup_firewall` is taken out of the installer so it cannot drift from it, and run with `sudo` and `ufw` stubbed to a log. Nothing here touches a real firewall.

Three sabotages:

- the ssh guard removed: 3 red
- ssh allowed after `--force enable` rather than before: `before enabling, not after, or the gap is the whole problem`
- ssh opened on every install: `and does not open ssh, nobody having asked for it`

That second sabotage needed redoing. The exact-string edit did not match and threw rather than reporting a pass, so it proved nothing until I moved the line by number instead.

## Test runs

Related suites only, per your note: the new one, `suite-hygiene-test.sh` for the CI wiring, and the twenty-one others that read `install.sh`. All pass. shellcheck clean at `style` after it caught an `ls` glob in my new suite, which is the finding class this project shipped as a bug in #52, replaced with a plain glob.
