### PR TITLE
Replace the installer's env blocks rather than appending another

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,6 +241,9 @@ jobs:
       - name: removed-files-test
         run: bash test/removed-files-test.sh
 
+      - name: env-block-test
+        run: bash test/env-block-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,72 @@ echo ""
 #  Hardware Detection Functions
 # ======================================
 
+# Write a named block of exports into a uwsm env file, replacing one an earlier
+# run wrote rather than adding a second.
+#
+# All three callers were `cat >>`, which is right on a first install and wrong
+# on every one after it. Re-running the installer is a documented step: the
+# failed-packages message tells you to install the missing ones by hand and
+# re-run this script, so a second run is expected rather than unusual. Two runs
+# left
+#
+#   export AQ_DRM_DEVICES="/dev/dri/intel-gpu"
+#   export AQ_DRM_DEVICES="/dev/dri/intel-gpu"
+#
+# and a block more on each run after that. uwsm reads the file once at login
+# and the last export of a name wins, so nothing breaks visibly, which is
+# exactly how it could pile up unnoticed.
+#
+# theme-switcher.sh already replaces rather than appends for XCURSOR_THEME, and
+# says why. This is the same rule for the file the installer owns.
+#
+# Blocks written before this change carry no markers, so the export names
+# inside the new block are stripped from the file as well. Without that a
+# second install would leave the old copy sitting above the new one, which is
+# the thing being fixed.
+set_env_block() {
+  local file="$1" name="$2"
+  shift 2
+  local begin="# >>> hyprsimple $name >>>"
+  local end="# <<< hyprsimple $name <<<"
+
+  mkdir -p "$(dirname "$file")"
+  touch "$file"
+
+  local names=()
+  local line
+  for line in "$@"; do
+    [[ $line == export\ * ]] || continue
+    line=${line#export }
+    names+=("${line%%=*}")
+  done
+
+  local tmp="$file.hyprsimple.$$"
+  awk -v b="$begin" -v e="$end" -v drop="$(printf '%s\n' "${names[@]}")" '
+    BEGIN { n = split(drop, want, "\n"); for (i = 1; i <= n; i++) if (want[i] != "") skipname[want[i]] = 1 }
+    $0 == b { inblock = 1; next }
+    $0 == e { inblock = 0; next }
+    inblock { next }
+    {
+      # A bare export of a name this block owns, left by a run before the
+      # markers existed.
+      if ($0 ~ /^export [A-Za-z_][A-Za-z0-9_]*=/) {
+        split($2, kv, "=")
+        if (kv[1] in skipname) next
+      }
+      print
+    }
+  ' "$file" >"$tmp"
+
+  {
+    printf '\n%s\n' "$begin"
+    printf '%s\n' "$@"
+    printf '%s\n' "$end"
+  } >>"$tmp"
+
+  mv -f "$tmp" "$file"
+}
+
 detect_and_install_nvidia() {
   echo -e "${YELLOW}Detecting NVIDIA GPU...${NC}"
 
@@ -246,20 +312,16 @@ detect_and_install_nvidia() {
 
   # Append NVIDIA env vars to uwsm/env
   if [[ $GPU_ARCH = "turing_plus" ]]; then
-    cat >>"$HOME/.config/uwsm/env" <<'EOF'
-
-# NVIDIA (Turing+ with GSP firmware) - auto-detected by installer
-export NVD_BACKEND=direct
-export LIBVA_DRIVER_NAME=nvidia
-export __GLX_VENDOR_LIBRARY_NAME=nvidia
-EOF
+    set_env_block "$HOME/.config/uwsm/env" nvidia \
+      "# NVIDIA (Turing+ with GSP firmware) - auto-detected by installer" \
+      "export NVD_BACKEND=direct" \
+      "export LIBVA_DRIVER_NAME=nvidia" \
+      "export __GLX_VENDOR_LIBRARY_NAME=nvidia"
   elif [[ $GPU_ARCH = "maxwell_pascal_volta" ]]; then
-    cat >>"$HOME/.config/uwsm/env" <<'EOF'
-
-# NVIDIA (Maxwell/Pascal/Volta) - auto-detected by installer
-export NVD_BACKEND=egl
-export __GLX_VENDOR_LIBRARY_NAME=nvidia
-EOF
+    set_env_block "$HOME/.config/uwsm/env" nvidia \
+      "# NVIDIA (Maxwell/Pascal/Volta) - auto-detected by installer" \
+      "export NVD_BACKEND=egl" \
+      "export __GLX_VENDOR_LIBRARY_NAME=nvidia"
   fi
 
   # Rebuild initramfs
@@ -338,12 +400,9 @@ EOF
   sudo udevadm trigger
 
   # Write to env-hyprland (uwsm users should use this file per Hyprland docs)
-  mkdir -p "$HOME/.config/uwsm"
-  cat >>"$HOME/.config/uwsm/env-hyprland" <<EOF
-
-# Primary GPU: $GPU_VENDOR (priority: Intel > AMD > NVIDIA)
-export AQ_DRM_DEVICES="/dev/dri/$GPU_SYMLINK"
-EOF
+  set_env_block "$HOME/.config/uwsm/env-hyprland" gpu \
+    "# Primary GPU: $GPU_VENDOR (priority: Intel > AMD > NVIDIA)" \
+    "export AQ_DRM_DEVICES=\"/dev/dri/$GPU_SYMLINK\""
 
   echo -e "${GREEN}GPU setup complete ($GPU_VENDOR selected as primary)${NC}"
 }

--- a/test/cursor-theme-test.sh
+++ b/test/cursor-theme-test.sh
@@ -61,8 +61,13 @@ else
   fail "no theme declares a cursor, so this suite is testing nothing"
 fi
 
+# Comments stripped before counting. install.sh explains in a comment that
+# theme-switcher.sh replaces rather than appends for XCURSOR_THEME, and an
+# unanchored grep counted that explanation as code.
 check "install.sh no longer writes XCURSOR_THEME itself" \
-  "$(grep -c 'XCURSOR_THEME' "$REPO/install.sh")" "0"
+  "$(sed 's/#.*//' "$REPO/install.sh" | grep -c 'XCURSOR_THEME')" "0"
+check "and stripping comments leaves its code behind" \
+  "$(sed 's/#.*//' "$REPO/install.sh" | grep -c '^set_env_block()')" "1"
 
 # --- the switcher persists it ------------------------------------------------
 

--- a/test/env-block-test.sh
+++ b/test/env-block-test.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# The installer appended its environment blocks rather than replacing them.
+#
+# Three places wrote into ~/.config/uwsm with `cat >>`:
+#
+#   the Turing+ NVIDIA block          -> uwsm/env
+#   the Maxwell/Pascal/Volta block    -> uwsm/env
+#   the primary GPU block             -> uwsm/env-hyprland
+#
+# Right on a first install, wrong on every one after it. Re-running the
+# installer is a documented step: the failed-packages message says to install
+# the missing ones by hand and re-run, so a second run is expected. Two runs
+# left the file holding
+#
+#   export AQ_DRM_DEVICES="/dev/dri/intel-gpu"
+#   export AQ_DRM_DEVICES="/dev/dri/intel-gpu"
+#
+# and a block more on each run after that. uwsm reads the file once at login
+# and the last export of a name wins, so nothing breaks visibly, which is
+# exactly how it piles up unnoticed. theme-switcher.sh already replaces rather
+# than appends for XCURSOR_THEME and says why.
+#
+# Nothing here runs the installer. set_env_block is taken out of it and run
+# against throwaway files.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$REPO/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+
+fn=$(sed -n '/^set_env_block() {/,/^}/p' "$INSTALL")
+if [[ $(printf '%s\n' "$fn" | grep -c .) -lt 20 ]]; then
+  fail "extracted $(printf '%s\n' "$fn" | grep -c .) lines of set_env_block, so this is reading the wrong thing"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "extracted set_env_block from the installer"
+
+write_block() {
+  bash -c "
+    $fn
+    set_env_block \"\$@\"
+  " _ "$@"
+}
+
+F="$TMP/env"
+count() { grep -c "$1" "$F"; }
+
+# --- writing it twice leaves one copy -----------------------------------------
+
+: >"$F"
+write_block "$F" gpu "# Primary GPU: Intel" 'export AQ_DRM_DEVICES="/dev/dri/intel-gpu"'
+check "the first write puts the export in" "$(count '^export AQ_DRM_DEVICES=')" "1"
+check "and its comment" "$(count 'Primary GPU: Intel')" "1"
+
+write_block "$F" gpu "# Primary GPU: Intel" 'export AQ_DRM_DEVICES="/dev/dri/intel-gpu"'
+write_block "$F" gpu "# Primary GPU: Intel" 'export AQ_DRM_DEVICES="/dev/dri/intel-gpu"'
+check "and two more writes still leave one" "$(count '^export AQ_DRM_DEVICES=')" "1"
+check "with one comment, not three" "$(count 'Primary GPU: Intel')" "1"
+
+# --- a changed value replaces the old one, rather than sitting under it -------
+
+write_block "$F" gpu "# Primary GPU: AMD" 'export AQ_DRM_DEVICES="/dev/dri/amd-gpu"'
+check "a rewritten block holds the new value" "$(count 'amd-gpu')" "1"
+check "and the old value is gone, not shadowed" "$(count 'intel-gpu')" "0"
+
+# --- what the user put there is kept ------------------------------------------
+
+printf 'export MY_OWN=1\n# my note\n' >"$F"
+write_block "$F" gpu "# Primary GPU: Intel" 'export AQ_DRM_DEVICES="/dev/dri/intel-gpu"'
+write_block "$F" gpu "# Primary GPU: Intel" 'export AQ_DRM_DEVICES="/dev/dri/intel-gpu"'
+check "an unrelated export of the user's survives" "$(count '^export MY_OWN=1$')" "1"
+check "and their comment" "$(count '^# my note$')" "1"
+
+# --- a block written before the markers existed is cleaned up -----------------
+#
+# Without this a second install would leave the old copy sitting above the new
+# one, which is the thing being fixed.
+
+printf '\n# NVIDIA - auto-detected by installer\nexport NVD_BACKEND=direct\nexport LIBVA_DRIVER_NAME=nvidia\n' >"$F"
+check "the legacy fixture really has the export" "$(count '^export NVD_BACKEND=')" "1"
+write_block "$F" nvidia "# NVIDIA - auto-detected by installer" \
+  'export NVD_BACKEND=direct' 'export LIBVA_DRIVER_NAME=nvidia'
+check "an unmarked copy from an older install is removed" \
+  "$(count '^export NVD_BACKEND=')" "1"
+check "and so is its second export" "$(count '^export LIBVA_DRIVER_NAME=')" "1"
+
+# --- two different blocks live side by side -----------------------------------
+
+: >"$F"
+write_block "$F" nvidia "# NVIDIA" 'export NVD_BACKEND=direct'
+write_block "$F" gpu "# GPU" 'export AQ_DRM_DEVICES="/dev/dri/intel-gpu"'
+write_block "$F" nvidia "# NVIDIA" 'export NVD_BACKEND=direct'
+check "rewriting one block leaves the other alone" \
+  "$(count '^export AQ_DRM_DEVICES=')" "1"
+check "and does not duplicate itself" "$(count '^export NVD_BACKEND=')" "1"
+
+# --- the file is still something a shell can read -----------------------------
+
+check "the result parses as shell" \
+  "$(bash -n "$F" 2>&1 && echo ok)" "ok"
+
+# --- and the installer uses it everywhere -------------------------------------
+
+code_of() { sed 's/#.*//' "$1"; }
+CODE="$TMP/install.code"
+code_of "$INSTALL" >"$CODE"
+check "stripping comments leaves the installer's code behind" \
+  "$(grep -c '^set_env_block()' "$CODE")" "1"
+check "all three blocks go through it" \
+  "$(grep -c '^ *set_env_block "' "$CODE")" "3"
+check "and nothing appends into a home config any more" \
+  "$(grep -cE '>>[[:space:]]*"?\$HOME' "$CODE")" "0"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/hybrid-gpu-env-test.sh
+++ b/test/hybrid-gpu-env-test.sh
@@ -41,8 +41,13 @@ check() {
 
 FUNCS="$TMP/funcs.sh"
 sed -n '/^detect_and_install_nvidia() {/,/^}/p' "$REPO/install.sh" >"$FUNCS"
+# set_env_block is extracted too. detect_and_install_nvidia calls it now
+# instead of `cat >>`, and a function that is not extracted is simply absent
+# here: the block is never written and every check about the env file fails for
+# a reason that has nothing to do with what it is testing.
+sed -n '/^set_env_block() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
 sed -n '/^install_packages() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
-for marker in 'detect_and_install_nvidia() {' 'other_gpu' '__GLX_VENDOR_LIBRARY_NAME'; do
+for marker in 'detect_and_install_nvidia() {' 'set_env_block() {' 'other_gpu' '__GLX_VENDOR_LIBRARY_NAME'; do
   if grep -qF -- "$marker" "$FUNCS"; then
     pass "extracted source contains $marker"
   else

--- a/test/nvidia-install-test.sh
+++ b/test/nvidia-install-test.sh
@@ -36,11 +36,16 @@ check() {
 FUNCS="$TMP/funcs.sh"
 sed -n '/^detect_and_install_nvidia() {/,/^}/p' "$REPO/install.sh" >"$FUNCS"
 sed -n '/^install_packages() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
+# set_env_block is extracted too. detect_and_install_nvidia calls it now
+# instead of `cat >>`, and a function that is not extracted is simply absent
+# here: the block is never written and every check about the env file fails for
+# a reason that has nothing to do with what it is testing.
+sed -n '/^set_env_block() {/,/^}/p' "$REPO/install.sh" >>"$FUNCS"
 
 # An extraction that quietly produced nothing would let every check below pass
 # for the wrong reason. This is the shape that has already cost this repository
 # five vacuous checks, so assert the extraction before using it.
-for marker in 'detect_and_install_nvidia() {' 'install_packages() {' \
+for marker in 'detect_and_install_nvidia() {' 'set_env_block() {' 'install_packages() {' \
   'NVIDIA_DRIVER_PACKAGES' 'NVIDIA-MODULE' 'nvidia-580xx-dkms' \
   '__GLX_VENDOR_LIBRARY_NAME'; do
   if grep -qF -- "$marker" "$FUNCS"; then


### PR DESCRIPTION
## The bug

Three places wrote into `~/.config/uwsm` with `cat >>`: the Turing+ NVIDIA block, the Maxwell/Pascal/Volta one, and the primary GPU block.

Right on a first install, wrong on every one after it. Re-running the installer is a documented step, from install.sh's own failure message:

> Features depending on these will not work. Try installing them by hand, then re-run ./install.sh.

Two runs leave:

    # Primary GPU: Intel (priority: Intel > AMD > NVIDIA)
    export AQ_DRM_DEVICES="/dev/dri/intel-gpu"

    # Primary GPU: Intel (priority: Intel > AMD > NVIDIA)
    export AQ_DRM_DEVICES="/dev/dri/intel-gpu"

and a block more on each run after that. uwsm reads the file once at login and the last export of a name wins, so nothing breaks visibly, which is exactly how it piles up unnoticed. It also means someone reading the file to work out which GPU is selected finds the answer several times over.

`theme-switcher.sh` already replaces rather than appends for `XCURSOR_THEME` and explains why. This is the same rule for the file the installer owns.

## The fix

One helper, bounded by markers, so a rewrite replaces its own block. It also strips bare exports of the names it owns, because a block written before the markers existed carries none and would otherwise sit above the new one, which is the thing being fixed. Anything else in the file, including the user's own exports and comments, is kept.

No migration. A machine installed once has no duplicates, and on one installed twice the extra block is inert and gets cleaned up by the next install.

## Three existing suites failed, and were right to

- `nvidia-install-test.sh` and `hybrid-gpu-env-test.sh` extract `detect_and_install_nvidia` from install.sh by name and run it. It calls `set_env_block` now, which they were not extracting, so the block was never written and every check about the env file failed for a reason unrelated to what it tests. Both extract it too now, and assert the extraction the way they already assert the others.
- `cursor-theme-test.sh` asserts install.sh no longer writes `XCURSOR_THEME` itself, counted 1, and the 1 was my new comment saying theme-switcher.sh does that. It strips comments before counting now, with a companion check that stripping leaves real code behind. Ninth time this project has caught a check reading a comment.

## Evidence

New suite `test/env-block-test.sh`, 18 checks. Writing the same block three times leaves one copy; a changed value replaces the old rather than shadowing it; the user's own exports and comments survive; an unmarked block from an older install is cleaned up; two different blocks coexist; the result still parses as shell.

Two sabotages:

- the helper appending again: 6 red, `and two more writes still leave one (want 1, got 3)`
- the legacy stripper removed: `an unmarked copy from an older install is removed (want 1, got 2)`

Both did nothing on the first attempt. The sabotage script used an unquoted heredoc, so the shell expanded `$file`, `$$`, `$0` and `$2` away before python saw the strings, and neither edit applied. That is the second time in this session, so it is a script file now rather than an inline heredoc.

## Test runs

Related suites only: the new one, `suite-hygiene-test.sh`, and the twenty-three others that read `install.sh`. All pass. shellcheck clean at `style`. Your `uwsm/env` and `uwsm/env-hyprland` are byte-identical before and after.
