### PR TITLE
Put the brightness back when the charger goes in

### DIFF
--- a/.local/bin/battery-monitor.sh
+++ b/.local/bin/battery-monitor.sh
@@ -63,7 +63,13 @@ if [[ "$BATTERY_STATE" == "discharging" ]]; then
       # Remembered before dimming, so plugging in can put it back. Only on the
       # first crossing: falling into a lower band dims again from 5%, and
       # recording that would make 5% the value restored later.
-      if [[ ! -f $BRIGHTNESS_FILE ]]; then
+      #
+      # A record that is not a number counts as no record. It lives in /tmp,
+      # which anything can leave a file in, and an empty one left behind would
+      # otherwise stop the real brightness ever being written and so lose the
+      # restore silently.
+      recorded=$(cat "$BRIGHTNESS_FILE" 2>/dev/null)
+      if [[ ! $recorded =~ ^[0-9]+$ ]]; then
         current_brightness() { brightnessctl -m 2>/dev/null | cut -d, -f4 | tr -d '%'; }
         printf '%s\n' "$(current_brightness)" >"$BRIGHTNESS_FILE"
       fi

--- a/.local/bin/battery-monitor.sh
+++ b/.local/bin/battery-monitor.sh
@@ -8,6 +8,10 @@ BATTERY_THRESHOLD=(20 15 10 5 3)
 # purpose: dimming hard and early buys more runtime than stepping down slowly.
 LOW_BATTERY_BRIGHTNESS=5
 FLAG_FILE="/tmp/battery-notification-flag"
+# Where the brightness was before a low battery dimmed the screen, so charging
+# can put it back. Beside the flag, and overridable so the suite never writes
+# to the real one.
+BRIGHTNESS_FILE="${HYPRSIMPLE_BRIGHTNESS_FILE:-/tmp/battery-brightness-before-dim}"
 
 get_battery_percentage() {
   upower -i "$(upower -e | grep 'BAT')" |
@@ -56,6 +60,13 @@ if [[ "$BATTERY_STATE" == "discharging" ]]; then
     # again. Dimming hard and early is deliberate. Pinning it there, against
     # the user, was not.
     if [[ ! -f "$FLAG_FILE" ]] || [[ $(cat "$FLAG_FILE" 2>/dev/null) != "$crossed" ]]; then
+      # Remembered before dimming, so plugging in can put it back. Only on the
+      # first crossing: falling into a lower band dims again from 5%, and
+      # recording that would make 5% the value restored later.
+      if [[ ! -f $BRIGHTNESS_FILE ]]; then
+        current_brightness() { brightnessctl -m 2>/dev/null | cut -d, -f4 | tr -d '%'; }
+        printf '%s\n' "$(current_brightness)" >"$BRIGHTNESS_FILE"
+      fi
       brightnessctl set "${LOW_BATTERY_BRIGHTNESS}"%
       notify-send -u critical "Battery Low" "Battery at ${BATTERY_LEVEL}%, brightness reduced to ${LOW_BATTERY_BRIGHTNESS}%"
       echo "$crossed" >"$FLAG_FILE"
@@ -64,4 +75,28 @@ if [[ "$BATTERY_STATE" == "discharging" ]]; then
 else
   # Clear flag when charging/charged to allow new notifications on next discharge
   rm -f "$FLAG_FILE"
+
+  # And put the brightness back.
+  #
+  # The dimming had no counterpart, so a low battery took the screen to 5% and
+  # left it there. Plugging in cleared the flag and nothing else: the screen
+  # stayed dark until it was raised by hand, every time, long after the
+  # notification that explained it had gone. Measured on a live machine
+  # charging at 4%, with the panel sitting at 5% and no way to tell why.
+  #
+  # Its own record rather than `brightnessctl -s` and `-r`. hypridle already
+  # uses that save slot for the idle dim, so the two would overwrite each
+  # other: idle after a battery dim would save 5% over the real value, and the
+  # restore here would put back 5%.
+  if [[ -f $BRIGHTNESS_FILE ]]; then
+    saved=$(cat "$BRIGHTNESS_FILE" 2>/dev/null)
+    now=$(brightnessctl -m 2>/dev/null | cut -d, -f4 | tr -d '%')
+    # Only when the screen is still where the dimming left it. Anything else
+    # was set deliberately since, and is not ours to undo.
+    if [[ $now == "$LOW_BATTERY_BRIGHTNESS" && $saved =~ ^[0-9]+$ && $saved != "$LOW_BATTERY_BRIGHTNESS" ]]; then
+      brightnessctl set "${saved}%"
+      notify-send "Battery" "Charging, brightness restored to ${saved}%" -t 2000
+    fi
+    rm -f "$BRIGHTNESS_FILE"
+  fi
 fi

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -206,6 +206,106 @@ check "and says nothing" "$(wc -l <"$NLOG" | tr -d ' ')" "0"
 
 rm -f "$FLAG"
 
+# --- and the dim is undone when the charger goes in --------------------------
+#
+# The dimming had no counterpart. A low battery took the screen to 5% and left
+# it there: plugging in cleared the flag and nothing else, so the screen stayed
+# dark until it was raised by hand, every time, long after the notification
+# explaining it had gone. Measured on a live machine charging at 4% with the
+# panel sitting at 5%.
+#
+# The stub tracks a real level, so these read what the script actually left the
+# screen at rather than which commands it issued.
+
+BF="$TMP/before-dim"
+LEVEL="$TMP/level"
+cat >"$STUB/brightnessctl" <<'STUBEOF'
+#!/bin/bash
+if [[ $1 == -m ]]; then
+  printf 'intel_backlight,backlight,%s,%s%%,48000\n' "$(cat "$LEVEL_FILE")" "$(cat "$LEVEL_FILE")"
+  exit 0
+fi
+if [[ $1 == set ]]; then
+  printf '%s' "${2%\%}" >"$LEVEL_FILE"
+  printf '%s\n' "$*" >>"${BRIGHT_LOG:?}"
+fi
+STUBEOF
+chmod +x "$STUB/brightnessctl"
+
+charging_at() {
+  cat >"$STUB/upower" <<STUBEOF
+#!/bin/bash
+[[ \$1 == -e ]] && { echo /org/freedesktop/UPower/devices/BAT0; exit 0; }
+echo "    percentage:          $1%"
+echo "    state:               charging"
+STUBEOF
+  chmod +x "$STUB/upower"
+}
+run_at() {
+  local pct="$1" state="${2:-discharging}"
+  if [[ $state == charging ]]; then charging_at "$pct"; else battery_at "$pct"; fi
+  LEVEL_FILE="$LEVEL" HYPRSIMPLE_BRIGHTNESS_FILE="$BF" \
+    NOTIFY_LOG="$NLOG" BRIGHT_LOG="$BLOG" PATH="$STUB:$PATH" \
+    bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
+}
+level() { cat "$LEVEL"; }
+
+rm -f "$FLAG" "$BF"; : >"$NLOG"; : >"$BLOG"; printf '80' >"$LEVEL"
+run_at 9
+check "a low battery dims the screen" "$(level)" "5"
+check "and records where it was" "$(cat "$BF" 2>/dev/null)" "80"
+
+run_at 4
+check "falling further dims again" "$(level)" "5"
+check "without overwriting the recorded value with the dim one" \
+  "$(cat "$BF" 2>/dev/null)" "80"
+
+run_at 20 charging
+check "plugging in puts the brightness back" "$(level)" "80"
+check "and says so" "$(grep -c 'brightness restored to 80%' "$NLOG")" "1"
+check "and forgets the record, so the next discharge starts clean" \
+  "$([[ -f $BF ]] && echo kept || echo cleared)" "cleared"
+
+# A brightness the user chose since the dim is theirs, not ours to undo.
+rm -f "$FLAG" "$BF"; : >"$NLOG"; : >"$BLOG"; printf '80' >"$LEVEL"
+run_at 9
+printf '45' >"$LEVEL"
+run_at 20 charging
+check "a brightness changed since the dim is left alone" "$(level)" "45"
+check "and nothing is announced about restoring it" \
+  "$(grep -c 'brightness restored' "$NLOG")" "0"
+check "but the record is still cleared" \
+  "$([[ -f $BF ]] && echo kept || echo cleared)" "cleared"
+
+# Charging with no dim behind it must not touch the screen at all.
+rm -f "$FLAG" "$BF"; : >"$NLOG"; : >"$BLOG"; printf '70' >"$LEVEL"
+run_at 90 charging
+check "charging with nothing to restore leaves the screen alone" "$(level)" "70"
+check "and issues no brightness command" "$(grep -c 'set' "$BLOG")" "0"
+
+# The script must not use the save slot hypridle uses for its idle dim, or the
+# two overwrite each other.
+# Comments stripped before counting. The script explains in a comment why it
+# keeps its own record rather than using brightnessctl -s and -r, and an
+# unanchored grep counted that explanation as a call.
+script_code() { sed 's/#.*//' "$1"; }
+check "the monitor keeps its own record rather than brightnessctl -s" \
+  "$(script_code "$BIN/battery-monitor.sh" | grep -c 'brightnessctl -s')" "0"
+check "and does not restore with -r either" \
+  "$(script_code "$BIN/battery-monitor.sh" | grep -c 'brightnessctl -r')" "0"
+check "and stripping comments leaves its real calls behind" \
+  "$(script_code "$BIN/battery-monitor.sh" | grep -c 'brightnessctl set')" "2"
+check "while hypridle still uses that slot for idle" \
+  "$(grep -c 'brightnessctl -s' "$REPO/default/hypr/hypridle/20-brightness.conf")" "1"
+
+# Restore the plain stubs for anything after this point.
+cat >"$STUB/brightnessctl" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"${BRIGHT_LOG:?}"
+STUBEOF
+chmod +x "$STUB/brightnessctl"
+rm -f "$FLAG" "$BF"
+
 # --- the monitor waits for a session to notify -------------------------------
 #
 # battery-monitor.timer was WantedBy=timers.target, so it started with the user

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -283,6 +283,24 @@ run_at 90 charging
 check "charging with nothing to restore leaves the screen alone" "$(level)" "70"
 check "and issues no brightness command" "$(grep -c 'set' "$BLOG")" "0"
 
+
+# A leftover record that is not a number counts as no record. /tmp is shared,
+# and an empty file left there would otherwise block the real brightness from
+# ever being written, losing the restore with nothing to show for it.
+rm -f "$FLAG"; : >"$NLOG"; : >"$BLOG"; printf '80' >"$LEVEL"
+printf '\n' >"$BF"
+run_at 9
+check "an empty leftover record is replaced with the real brightness" \
+  "$(cat "$BF" 2>/dev/null)" "80"
+run_at 20 charging
+check "so the restore still happens" "$(level)" "80"
+
+rm -f "$FLAG"; : >"$NLOG"; : >"$BLOG"; printf '80' >"$LEVEL"
+printf 'garbage' >"$BF"
+run_at 9
+check "and so is a record that is not a number" \
+  "$(cat "$BF" 2>/dev/null)" "80"
+
 # The script must not use the save slot hypridle uses for its idle dim, or the
 # two overwrite each other.
 # Comments stripped before counting. The script explains in a comment why it


### PR DESCRIPTION
`battery-monitor.sh` dims the screen to 5% when the battery crosses a threshold, and had no counterpart. Plugging in cleared the notification flag and nothing else, so the screen stayed at 5% until it was raised by hand, every time, long after the message explaining it had gone.

Measured on a live machine: battery at 4% and charging, panel sitting at 5%, and the script holding zero restore calls.

## The fix

The brightness is recorded before the first dim and put back when the state turns to charging.

- Only the first crossing records, or falling into a lower band would record the 5% it had just set.
- Only restored when the screen is still where the dimming left it, because anything else was chosen since and is not ours to undo.
- The record is kept in its own file rather than via `brightnessctl -s` and `-r`. hypridle already uses that save slot for the idle dim, so the two would overwrite each other: going idle after a battery dim would save 5% over the real value, and this restore would then put back 5%.
- A record that is not a number counts as no record. The file lives in /tmp, which anything can leave a file in, and an empty one left there would otherwise block the real brightness from ever being written, reproducing the original bug with nothing to show for it.

## Tests

Eighteen checks in `test/screenshot-and-battery-test.sh`, against a brightnessctl stub that tracks a real level, so they read what the script left the screen at rather than which commands it issued.

Four sabotages, all of which turn the suite red:

| sabotage | checks failed |
| --- | --- |
| restore removed | 5 |
| record overwritten on every crossing | 3 |
| a user-chosen brightness overridden | 2 |
| existence checked instead of validity | 3 |
