### PR TITLE
Stop the tests writing to the battery monitor's real state files

### DIFF
--- a/.local/bin/battery-monitor.sh
+++ b/.local/bin/battery-monitor.sh
@@ -7,7 +7,10 @@ BATTERY_THRESHOLD=(20 15 10 5 3)
 # Brightness to drop to once the battery reaches the first threshold. Fixed on
 # purpose: dimming hard and early buys more runtime than stepping down slowly.
 LOW_BATTERY_BRIGHTNESS=5
-FLAG_FILE="/tmp/battery-notification-flag"
+# The threshold last acted on, so a crossing acts once. Overridable for the
+# same reason as the record below: a suite that ran against the real path
+# deleted the live flag out from under the running service.
+FLAG_FILE="${HYPRSIMPLE_BATTERY_FLAG:-/tmp/battery-notification-flag}"
 # Where the brightness was before a low battery dimmed the screen, so charging
 # can put it back. Beside the flag, and overridable so the suite never writes
 # to the real one.

--- a/test/notification-idiom-test.sh
+++ b/test/notification-idiom-test.sh
@@ -125,12 +125,16 @@ chmod +x "$STUB/upower"
 # remembers the last one written. That is a real defect, it predates the
 # notification substitution, and fixing it is a behaviour change this suite
 # has no mandate for. Pinning the count here would pin the bug.
-rm -f /tmp/battery-notification-flag
+# Both state files under this suite's own temp directory. These used to be
+# left at their real paths, so running the suite deleted the live notification
+# flag and left a bogus brightness record for the next charge to restore.
 : >"$LOG"
-NOTIFY_LOG="$LOG" PATH="$STUB:$PATH" bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
+NOTIFY_LOG="$LOG" PATH="$STUB:$PATH" \
+  HYPRSIMPLE_BATTERY_FLAG="$STUB/battery-flag" \
+  HYPRSIMPLE_BRIGHTNESS_FILE="$STUB/battery-record" \
+  bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
 check "battery-monitor reaches its low battery notification" \
   "$( (( $(grep -c 'Battery Low' "$LOG") >= 1 )) && echo reached )" "reached"
-rm -f /tmp/battery-notification-flag
 
 # capslock-notify polls a sysfs LED when one exists and falls back to hyprctl
 # when it does not. This exercises the fallback, which is the path CI takes,

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -127,10 +127,15 @@ STUBEOF
   chmod +x "$STUB/upower"
 }
 
-FLAG=/tmp/battery-notification-flag
+# Both under the suite's own temp directory. These used to be the real paths,
+# so running the suite deleted the live notification flag out from under the
+# running service and left a record of 500 behind it, which the next charge
+# would have restored the screen to.
+FLAG="$TMP/battery-flag"
 run_battery() {
   battery_at "$1"
-  NOTIFY_LOG="$NLOG" BRIGHT_LOG="$BLOG" PATH="$STUB:$PATH" \
+  HYPRSIMPLE_BATTERY_FLAG="$FLAG" HYPRSIMPLE_BRIGHTNESS_FILE="$TMP/record" \
+    NOTIFY_LOG="$NLOG" BRIGHT_LOG="$BLOG" PATH="$STUB:$PATH" \
     bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
 }
 
@@ -189,7 +194,8 @@ echo "    percentage:          80%"
 echo "    state:               charging"
 STUBEOF
 chmod +x "$STUB/upower"
-NOTIFY_LOG="$NLOG" BRIGHT_LOG="$BLOG" PATH="$STUB:$PATH" \
+HYPRSIMPLE_BATTERY_FLAG="$FLAG" HYPRSIMPLE_BRIGHTNESS_FILE="$TMP/record" \
+  NOTIFY_LOG="$NLOG" BRIGHT_LOG="$BLOG" PATH="$STUB:$PATH" \
   bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
 check "charging clears the flag" \
   "$([[ -f $FLAG ]] && echo present || echo gone)" "gone"
@@ -245,6 +251,7 @@ run_at() {
   local pct="$1" state="${2:-discharging}"
   if [[ $state == charging ]]; then charging_at "$pct"; else battery_at "$pct"; fi
   LEVEL_FILE="$LEVEL" HYPRSIMPLE_BRIGHTNESS_FILE="$BF" \
+    HYPRSIMPLE_BATTERY_FLAG="$FLAG" \
     NOTIFY_LOG="$NLOG" BRIGHT_LOG="$BLOG" PATH="$STUB:$PATH" \
     bash "$BIN/battery-monitor.sh" >/dev/null 2>&1
 }

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -208,6 +208,82 @@ else
   check "and every one of them exists" "$absent_str" ""
 fi
 
+# A suite must not touch the state a shipped script keeps on the real machine.
+#
+# Two of them ran battery-monitor.sh against its real /tmp paths. Running the
+# tests deleted the live notification flag out from under the running service,
+# so the next tick notified and dimmed again, and left a brightness record of
+# 500 behind, which the next charge would have restored the screen to. Both
+# were found on the maintainer's own machine, by a file reappearing after it
+# was deleted.
+#
+# The paths are read out of the script rather than listed here. A list written
+# down in this file would keep passing after the script renamed its paths,
+# which is the shape of failure this whole suite exists to catch.
+monitor="$REPO/.local/bin/battery-monitor.sh"
+mapfile -t state_paths < <(
+  grep -oE '\$\{HYPRSIMPLE_[A-Z_]+:-[^}]+\}' "$monitor" |
+    sed 's/.*:-//; s/}$//' |
+    LC_ALL=C sort -u
+)
+mapfile -t state_vars < <(
+  grep -oE 'HYPRSIMPLE_[A-Z_]+' "$monitor" | LC_ALL=C sort -u
+)
+
+if [[ ${#state_paths[@]} -lt 2 || ${#state_vars[@]} -lt 2 ]]; then
+  fail "read ${#state_paths[@]} state paths and ${#state_vars[@]} overrides out of battery-monitor.sh, so this check is not reading it"
+else
+  pass "read ${#state_paths[@]} overridable state paths out of battery-monitor.sh"
+
+  named=()
+  unisolated=()
+  runners=()
+  for suite in "${suites[@]}"; do
+    for path in "${state_paths[@]}"; do
+      grep -qF -- "$path" "$suite" && named+=("$(basename "$suite"):$path")
+    done
+    # Comments stripped, and matching an invocation rather than the name.
+    # Two suites name the script only to explain something and one names
+    # battery-monitor.service throughout, and counting those made this read as
+    # a failure in files that never run it.
+    #
+    # Every invocation is checked, not the file as a whole. The first version
+    # asked whether the suite mentioned the overrides anywhere, and a suite
+    # that isolated two of its three runs passed while the third wrote to the
+    # real paths. Continuations are joined first, so the environment in front
+    # of the command is on the same line as the command.
+    while IFS= read -r invocation; do
+      runners+=("$(basename "$suite")")
+      for var in "${state_vars[@]}"; do
+        [[ $invocation == *"$var"* ]] ||
+          unisolated+=("$(basename "$suite") runs it without $var")
+      done
+    done < <(
+      sed 's/#.*//' "$suite" |
+        sed -e :a -e '/\\$/N; s/\\\n//; ta' |
+        grep -E 'bash [^|;&]*battery-monitor\.sh'
+    )
+  done
+
+  # Or the loop above would report nothing wrong by never reaching a run.
+  # A floor, not the current count. Pinning the exact number would fail the
+  # day a suite gained or dropped a run, which says nothing about isolation.
+  if (( ${#runners[@]} < 2 )); then
+    fail "found ${#runners[@]} runs of battery-monitor.sh in the suites, so the isolation check is reading none of them"
+  else
+    pass "found ${#runners[@]} runs of battery-monitor.sh across the suites"
+  fi
+
+  named_str=""
+  (( ${#named[@]} > 0 )) && named_str="$(printf '%s ' "${named[@]}")"
+  check "no suite names a real state path of a shipped script" "$named_str" ""
+
+  unisolated_str=""
+  (( ${#unisolated[@]} > 0 )) && unisolated_str="$(printf '%s; ' "${unisolated[@]}")"
+  check "and every suite running battery-monitor.sh overrides all of them" \
+    "$unisolated_str" ""
+fi
+
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
Two suites ran `battery-monitor.sh` against its real `/tmp` paths. Running the tests on any machine:

- deleted the live `/tmp/battery-notification-flag` out from under the running service, so its next tick treated the crossing as new and dimmed the screen again;
- left `/tmp/battery-brightness-before-dim` holding `500`, which the next charge would have restored the screen to.

The `500` comes from a stub that answers every `brightnessctl` call with `500`. It is a valid number, so the validity guard added in #116 does not catch it.

## How it was found

A file deleted by hand on a live machine reappeared minutes later, while the installed copy of the script held no reference to that path. The writer was the test suite.

Demonstrated before the fix:

```
before: flag=PLACEHOLDER-real-flag  record=(absent)
after notification-idiom-test:
  flag:   No such file or directory
  record: 500
```

## The fix

- `FLAG_FILE` gains the `HYPRSIMPLE_BATTERY_FLAG` override that `BRIGHTNESS_FILE` already had.
- All four runs across `screenshot-and-battery-test.sh` and `notification-idiom-test.sh` now point both files at their own temp directory.

## The guard

A check in `suite-hygiene-test.sh` reads the overridable paths out of the script itself, rather than holding its own copy, and refuses any suite that names one of them or runs the script without every override.

It checks each invocation rather than the file as a whole. The first version asked only whether the suite mentioned the overrides anywhere, and passed a suite that isolated two of its three runs while the third wrote to the real paths. That third run is fixed here too.

## Tests

Three sabotages, all of which turn `suite-hygiene-test.sh` red:

| sabotage | result |
| --- | --- |
| one invocation loses its overrides | 1 red |
| a suite names the real path | 1 red |
| the script drops its `FLAG_FILE` override | 1 red, on the anti-vacuity check |

The second of those initially passed. The path extraction was keeping the trailing `}` of `${VAR:-/tmp/...}`, so it compared against a string no suite could ever contain. Fixed, and the sabotage bites now.

Verified end to end: with a placeholder written to the real flag, all five related suites pass and the placeholder is still there afterwards with no record planted beside it.
