### PR TITLE
Point the wallpaper picker at the cache the rest of the code writes

### DIFF
--- a/.local/bin/hyprsimple-wallpaper-picker.sh
+++ b/.local/bin/hyprsimple-wallpaper-picker.sh
@@ -8,11 +8,24 @@
 # the caller can apply directly.
 #
 # The theme is derived from ~/.cache/current_wallpaper_path, which is the only
-# record of which theme is applied. wallpaper-switcher.sh derives it the same
-# way at its line 12.
+# record of which theme is applied.
+#
+# ~/.cache literally, not ${XDG_CACHE_HOME:-$HOME/.cache}. This file used to
+# honour XDG_CACHE_HOME and was alone in doing so: wallpaper-switcher.sh,
+# theme-switcher.sh and live-wallpaper-toggle.sh all write the record to
+# $HOME/.cache. On a machine with XDG_CACHE_HOME set, this read a path nobody
+# writes and offered the wrong pictures. Moving the writers instead would
+# strand the record every existing install already has.
+CACHE_DIR="$HOME/.cache"
 
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 CURRENT=$(cat "$CACHE_DIR/current_wallpaper_path" 2>/dev/null)
+
+# Before dirname, not after. `dirname ""` is `.`, and `.` is a directory, so
+# the check below passed on an empty record and this listed whatever jpg and
+# png files happened to sit in the working directory, presented as the current
+# theme's wallpapers.
+[[ -n $CURRENT ]] || exit 0
+
 BG_DIR=$(dirname "$CURRENT" 2>/dev/null)
 
 [[ -d $BG_DIR ]] || exit 0

--- a/.local/bin/wallpaper-switcher.sh
+++ b/.local/bin/wallpaper-switcher.sh
@@ -8,8 +8,14 @@ source "$HOME/.local/bin/hypr-helpers.sh"
 #   pick - choose via rofi (default)
 
 CACHE_DIR="$HOME/.cache"
-# Track the actual wallpaper source path in a state file
-CURRENT=$(cat "$CACHE_DIR/current_wallpaper_path" 2>/dev/null || readlink -f "$CACHE_DIR/current_wallpaper" 2>/dev/null)
+# Track the actual wallpaper source path in a state file.
+#
+# No readlink fallback on current_wallpaper. There used to be one, and it could
+# never fire: every writer of that file, here and in theme-switcher.sh and
+# live-wallpaper-toggle.sh, copies the picture rather than linking to it, so
+# readlink -f returned the copy's own path and BG_DIR came out as
+# $HOME/backgrounds. It read as a safety net and was a dead branch.
+CURRENT=$(cat "$CACHE_DIR/current_wallpaper_path" 2>/dev/null)
 THEME_DIR=$(dirname "$(dirname "$CURRENT")" 2>/dev/null)
 BG_DIR="$THEME_DIR/backgrounds"
 

--- a/test/theme-picker-test.sh
+++ b/test/theme-picker-test.sh
@@ -376,13 +376,63 @@ mkdir -p "$wp_theme/backgrounds"
 make_wallpaper "$wp_theme/backgrounds/0-morning-breeze.jpg"
 make_wallpaper "$wp_theme/backgrounds/1-evening-glow.jpg"
 
-wp_cache="$TMP/cache-wp"
+# Fed through HOME, not XDG_CACHE_HOME. This suite used to set XDG_CACHE_HOME,
+# and passed, because the picker was the one script in the set that read it.
+# Every script that writes the record writes it to $HOME/.cache, so a machine
+# with XDG_CACHE_HOME set had the picker reading a path nobody writes. The
+# suite agreeing with the picker is what kept that invisible.
+wp_home="$TMP/home-wp"
+wp_cache="$wp_home/.cache"
 must_be_fixture "$wp_cache"
 mkdir -p "$wp_cache"
 printf '%s\n' "$wp_theme/backgrounds/0-morning-breeze.jpg" >"$wp_cache/current_wallpaper_path"
 
 wp_out="$TMP/out-wp"
-XDG_CACHE_HOME="$wp_cache" bash "$WALLPAPER_PICKER" >"$wp_out"
+HOME="$wp_home" bash "$WALLPAPER_PICKER" >"$wp_out"
+
+# And XDG_CACHE_HOME pointing somewhere else changes nothing, because the
+# writers do not read it either.
+wp_xdg_out="$TMP/out-wp-xdg"
+HOME="$wp_home" XDG_CACHE_HOME="$TMP/somewhere-else" bash "$WALLPAPER_PICKER" >"$wp_xdg_out"
+check "XDG_CACHE_HOME does not move the record out from under the picker" \
+  "$(cmp -s "$wp_out" "$wp_xdg_out" && echo same || echo diverged)" "same"
+
+# The record can be gone: a fresh install has never written one. dirname of an
+# empty string is ".", and "." is a directory, so the directory check passed
+# and the picker listed whatever jpg and png files were in the working
+# directory, offered as the current theme's wallpapers.
+norec_home="$TMP/home-norecord"
+mkdir -p "$norec_home/.cache" "$TMP/cwd-with-images"
+make_wallpaper "$TMP/cwd-with-images/not-a-wallpaper.png"
+norec_out=$(cd "$TMP/cwd-with-images" && HOME="$norec_home" bash "$WALLPAPER_PICKER")
+check "with no record, the picker emits nothing rather than the working directory" \
+  "$norec_out" ""
+
+# Anti-vacuity: the same working directory does produce rows when it is the
+# recorded theme, so the check above is about the missing record and not about
+# find coming up empty.
+canary_home="$TMP/home-canary"
+mkdir -p "$canary_home/.cache"
+printf '%s\n' "$TMP/cwd-with-images/not-a-wallpaper.png" >"$canary_home/.cache/current_wallpaper_path"
+canary_out=$(cd "$TMP/cwd-with-images" && HOME="$canary_home" bash "$WALLPAPER_PICKER")
+check "and that same directory does produce a row when it is the recorded one" \
+  "$(printf '%s' "$canary_out" | wc -l)" "0"
+check "which is one row" "$(printf '%s\n' "$canary_out" | grep -c 'not-a-wallpaper')" "1"
+
+# Neither script keeps a readlink fallback on current_wallpaper. It read as a
+# safety net and could never fire: every writer copies the picture there rather
+# than linking to it, so readlink -f returns that copy's own path and the theme
+# directory comes out as the user's home.
+fb_home="$TMP/home-fallback"
+mkdir -p "$fb_home/.cache"
+cp "$wp_theme/backgrounds/0-morning-breeze.jpg" "$fb_home/.cache/current_wallpaper"
+fb_out=$(HOME="$fb_home" bash "$WALLPAPER_PICKER")
+check "a copy at current_wallpaper with no record resolves nothing, so the picker emits nothing" \
+  "$fb_out" ""
+check "and the dead readlink fallback is gone from both scripts" \
+  "$(cat "$WALLPAPER_PICKER" "$WALLPAPER_SWITCHER" | sed 's/#.*//' | grep -c 'readlink')" "0"
+check "while the writers really do copy rather than link, which is why it was dead" \
+  "$(sed 's/#.*//' "$WALLPAPER_SWITCHER" | grep -c 'cp "$SELECTED" "$CACHE_DIR/current_wallpaper"')" "1"
 
 wp_keys_ok=yes
 while IFS=$'\t' read -r wp_key _ _; do


### PR DESCRIPTION
`hyprsimple-wallpaper-picker.sh` read `${XDG_CACHE_HOME:-$HOME/.cache}/current_wallpaper_path`. It was alone in doing so:

| script | cache dir |
| --- | --- |
| `hyprsimple-wallpaper-picker.sh` | `${XDG_CACHE_HOME:-$HOME/.cache}` |
| `wallpaper-switcher.sh` | `$HOME/.cache` |
| `theme-switcher.sh` | `$HOME/.cache` |
| `live-wallpaper-toggle.sh` | `$HOME/.cache` |

On a machine with `XDG_CACHE_HOME` pointing anywhere other than `$HOME/.cache`, the picker read a path nobody writes.

## Why that was not a quiet no-op

The guard meant to catch an empty result does not catch it:

```
$ dirname ""
.
```

`.` is a directory, so `[[ -d $BG_DIR ]]` passed and the picker listed whatever `jpg` and `png` files were in the working directory, offered as the current theme's wallpapers:

```
./not-a-wallpaper.png     not a wallpaper     ./not-a-wallpaper.png
./random-screenshot.jpg   random screenshot   ./random-screenshot.jpg
```

`wallpaper-switcher.sh` does not stop this, because it reads `$HOME/.cache` correctly, finds a valid theme, and calls the picker anyway.

## Reachability

Reachable whenever `XDG_CACHE_HOME` is set to something other than `$HOME/.cache`. It is set on the machine this was found on, but to `$HOME/.cache`, so it does not bite there. Nothing in hyprsimple sets it either way.

## The fix

- The picker reads `$HOME/.cache`, the same place the record is written. Moving the writers to `XDG_CACHE_HOME` instead would strand the record every existing install already has.
- An empty record exits before `dirname` sees it.

## The dead fallback

`wallpaper-switcher.sh` carried `|| readlink -f "$CACHE_DIR/current_wallpaper"`, and the picker's comment claimed to share it. It could never fire. All three writers **copy** the picture to that path rather than linking to it, so `readlink -f` returns the copy's own path and `BG_DIR` comes out as `$HOME/backgrounds`. Removed, with a note saying why.

## Tests

`theme-picker-test.sh` fed the picker through `XDG_CACHE_HOME` and passed, because the suite agreed with the bug. It now feeds it through `HOME` and checks `XDG_CACHE_HOME` does not move the record. Six checks added, including an anti-vacuity pair so the "emits nothing" check is about the missing record and not about `find` coming up empty.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| picker goes back to `XDG_CACHE_HOME` | 5 |
| the empty-record guard is removed | 1 |
| the dead `readlink` fallback returns | 1 |

The first sabotage also shows the suite reading the maintainer's real `~/.cache` from inside an isolated `HOME`, which is what the old feed was doing all along.

Related suites pass: `theme-picker`, `live-wallpaper-persistence`, `config-ownership`, `named-paths`, `suite-hygiene`. shellcheck clean.
