### PR TITLE
Deliver every generated file on update, not two of the eight

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,6 +244,9 @@ jobs:
       - name: env-block-test
         run: bash test/env-block-test.sh
 
+      - name: theme-delivery-test
+        run: bash test/theme-delivery-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-theme-deliver.sh
+++ b/.local/bin/hyprsimple-theme-deliver.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Puts a theme's generated files where the programs that read them look.
+#
+# Sourced by both callers, because there are two and they disagreed. A theme
+# switch delivered all eight generated files. hyprsimple-update.sh re-rendered
+# every theme when a template changed and then copied two of them, so a change
+# to btop.theme.tpl or ghostty.conf.tpl was rendered, stamped as done, and
+# never reached the program it was for until the user happened to switch theme.
+# The update's own comment said "a template change now reaches every theme on
+# the next update, so no future template needs a migration to deliver it",
+# which was true of six templates out of eight.
+#
+# One function, so a template added later is delivered by both or by neither.
+#
+# Delivery only. The wallpaper, the GTK and icon settings and the reloads stay
+# with their callers: switching theme should change the wallpaper, and an
+# update should not.
+
+deliver_theme_configs() {
+  local THEME_PATH="$1"
+  local GEN="$THEME_PATH/generated"
+
+  # 2. Update Hyprland colors
+  if [[ -f "$GEN/hyprland-colors.lua" ]]; then
+    ln -sf "$GEN/hyprland-colors.lua" "$HOME/.config/hypr/theme-active.lua"
+  elif [[ -f "$THEME_PATH/hypr/colors.lua" ]]; then
+    ln -sf "$THEME_PATH/hypr/colors.lua" "$HOME/.config/hypr/theme-active.lua"
+  fi
+
+  # 3. Update Waybar colors
+  if [[ -f "$GEN/waybar-colors.css" ]]; then
+    ln -sf "$GEN/waybar-colors.css" "$HOME/.config/waybar/theme-active.css"
+  elif [[ -f "$THEME_PATH/waybar/colors.css" ]]; then
+    ln -sf "$THEME_PATH/waybar/colors.css" "$HOME/.config/waybar/theme-active.css"
+  fi
+
+  # 3b. Update Waybar clock module (themed calendar)
+  if [[ -f "$GEN/theme-clock.jsonc" ]]; then
+    ln -sf "$GEN/theme-clock.jsonc" "$HOME/.config/waybar/theme-clock.jsonc"
+  elif [[ -f "$THEME_PATH/waybar/theme-clock.jsonc" ]]; then
+    ln -sf "$THEME_PATH/waybar/theme-clock.jsonc" "$HOME/.config/waybar/theme-clock.jsonc"
+  fi
+
+  # 4. Update Rofi colors
+  if [[ -f "$GEN/rofi-colors.rasi" ]]; then
+    ln -sf "$GEN/rofi-colors.rasi" "$HOME/.config/rofi/rofi-colors.rasi"
+  fi
+
+  # 5. Update Ghostty theme
+  local GHOSTTY_CONFIG="$HOME/.config/ghostty/config"
+  if [[ -f "$GHOSTTY_CONFIG" ]]; then
+    # Remove old color/palette/theme lines, keep non-color settings.
+    #
+    # The whitespace is matched the way ghostty matches it, not the way
+    # hyprsimple happens to write it. This pattern required exactly "key = ", so
+    # a line written any other way ghostty accepts survived every theme switch:
+    #
+    #   theme=gruvbox        kept, and "theme = kanagawa" appended after it
+    #   theme  =  gruvbox    kept
+    #     theme = gruvbox    kept
+    #
+    # All three validate, checked with `ghostty +validate-config`. The header of
+    # the shipped config promises these lines are removed and rewritten, so
+    # someone who set their own theme was told it would be replaced and instead
+    # kept a dead line they could no longer see taking effect.
+    grep -vE '^[[:space:]]*(background|foreground|cursor-color|cursor-text|selection-background|selection-foreground|palette|theme)[[:space:]]*=' "$GHOSTTY_CONFIG" > "$GHOSTTY_CONFIG.tmp"
+
+    if [[ -f "$THEME_PATH/ghostty-theme" ]]; then
+      # Use Ghostty's built-in theme
+      echo "theme = $(cat "$THEME_PATH/ghostty-theme")" >> "$GHOSTTY_CONFIG.tmp"
+    elif [[ -f "$GEN/ghostty.conf" ]]; then
+      # Fallback to template-generated colors
+      cat "$GEN/ghostty.conf" >> "$GHOSTTY_CONFIG.tmp"
+    fi
+
+    mv "$GHOSTTY_CONFIG.tmp" "$GHOSTTY_CONFIG"
+
+    # Reload Ghostty config
+    busctl --user call com.mitchellh.ghostty /com/mitchellh/ghostty org.gtk.Actions Activate "sava{sv}" "reload-config" 0 0 2>/dev/null
+  fi
+
+  # 6. Update Hyprlock theme colors
+  if [[ -f "$GEN/hyprlock.conf" ]]; then
+    cp "$GEN/hyprlock.conf" "$HOME/.config/hypr/theme-hyprlock.conf"
+  fi
+
+  # 7. Update Dunst colors
+  # generated/dunst-colors is already valid dunst config, so it drops straight in
+  # as an override. Drop-ins outrank the base dunstrc, and lexical order decides
+  # between them, so 90-theme sits above hyprsimple's default and below the user's.
+  local DUNST_DROPIN="$HOME/.config/dunst/dunstrc.d/90-theme.conf"
+  mkdir -p "$(dirname "$DUNST_DROPIN")"
+  if [[ -f "$GEN/dunst-colors" ]]; then
+    cp "$GEN/dunst-colors" "$DUNST_DROPIN"
+  else
+    # This theme has no colors.toml, so there are no colours to apply. Drop the
+    # previous theme's file rather than leaving its colours in force.
+    rm -f "$DUNST_DROPIN"
+  fi
+
+  # 8. Update btop theme
+  #
+  # Copying the theme into place was never enough: btop only reads the file its
+  # own config names, and nothing set that. hyprsimple installs btop, install.sh
+  # creates the themes directory, every theme renders a btop.theme and every
+  # switch copied one here, and btop.conf still said color_theme = "Default",
+  # which is what btop writes for itself on first run. The themed btop has never
+  # worked on any install.
+  #
+  # btop names a theme by its filename without the extension, so the file written
+  # below is selected as "current".
+  if [[ -f "$GEN/btop.theme" ]]; then
+    mkdir -p "$HOME/.config/btop/themes"
+    cp "$GEN/btop.theme" "$HOME/.config/btop/themes/current.theme"
+
+    local BTOP_CONF="$HOME/.config/btop/btop.conf"
+    if [[ ! -f $BTOP_CONF ]]; then
+      # btop fills in every key it does not find, so naming the theme is enough.
+      printf 'color_theme = "current"\n' >"$BTOP_CONF"
+    elif grep -q '^color_theme = ' "$BTOP_CONF"; then
+      # Replaced rather than appended: btop reads the file top to bottom and a
+      # second assignment would win, and the file would grow a line per switch.
+      sed -i 's|^color_theme = .*|color_theme = "current"|' "$BTOP_CONF"
+    else
+      printf 'color_theme = "current"\n' >>"$BTOP_CONF"
+    fi
+  fi
+}

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -305,23 +305,25 @@ if [[ -d $TEMPLATES_DIR && -x $RENDERER ]]; then
     # state here rather than an error.
     active=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null || true)
     if [[ -n $active ]]; then
-      gen="${active%/*}"
-      # Plain if blocks, because each of these files is legitimately absent on
-      # some themes and the intent reads better than a chain of && lists.
+      # The same delivery a theme switch performs, out of the same function.
       #
-      # Not for the reason an earlier version of this comment gave. It claimed
-      # `[[ test ]] && cmd` aborts the script under set -e when the test is
-      # false. It does not: bash exempts a command that is not the last in an
-      # && list, and a standalone list of that shape leaves set -e alone. What
-      # actually took the update down was `x=$(cmd)` where cmd fails, which is
-      # why the two assignments above carry `|| true` and these do not need it.
-      if [[ -f $gen/hyprlock.conf ]]; then
-        cp "$gen/hyprlock.conf" "$HOME/.config/hypr/theme-hyprlock.conf"
-      fi
-      if [[ -f $gen/dunst-colors ]]; then
-        mkdir -p "$HOME/.config/dunst/dunstrc.d"
-        cp "$gen/dunst-colors" "$HOME/.config/dunst/dunstrc.d/90-theme.conf"
-      fi
+      # This used to be its own shorter list, and copied two of the eight
+      # generated files: a change to btop.theme.tpl or ghostty.conf.tpl was
+      # rendered here, stamped as done, and never reached btop or ghostty until
+      # the user happened to switch theme. Five of the sixteen shipped themes
+      # have no ghostty-theme file and so depend on the generated one, and
+      # every theme depends on the generated btop.theme.
+      gen="${active%/*}"
+      source "$HOME/.local/bin/hyprsimple-theme-deliver.sh"
+      deliver_theme_configs "${gen%/*}"
+
+      # And restarted, or the freshly written colours sit on disk unread.
+      # waybar reads its stylesheet at startup and dunst its drop-ins at load,
+      # so delivering without this is the same invisibility in a new place.
+      # Both are no-ops when the program is not running. ghostty is reloaded
+      # inside the delivery itself, over its own dbus interface.
+      "$HOME/.local/bin/hyprsimple-restart-waybar.sh" --if-running || true
+      "$HOME/.local/bin/hyprsimple-restart-dunst.sh" --if-running || true
     fi
 
     mkdir -p "$STAMP_DIR"

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -280,6 +280,7 @@ TEMPLATES_DIR="$HYPRSIMPLE_PATH/.config/hypr/themes/templates"
 STAMP_DIR="$HOME/.local/state/hyprsimple"
 STAMP="$STAMP_DIR/templates.stamp"
 RENDERER="$HOME/.local/bin/theme-apply-templates.sh"
+DELIVER="$HOME/.local/bin/hyprsimple-theme-deliver.sh"
 
 if [[ -d $TEMPLATES_DIR && -x $RENDERER ]]; then
   # `|| true` on both: under set -e an assignment whose command substitution
@@ -314,16 +315,29 @@ if [[ -d $TEMPLATES_DIR && -x $RENDERER ]]; then
       # have no ghostty-theme file and so depend on the generated one, and
       # every theme depends on the generated btop.theme.
       gen="${active%/*}"
-      source "$HOME/.local/bin/hyprsimple-theme-deliver.sh"
-      deliver_theme_configs "${gen%/*}"
 
-      # And restarted, or the freshly written colours sit on disk unread.
-      # waybar reads its stylesheet at startup and dunst its drop-ins at load,
-      # so delivering without this is the same invisibility in a new place.
-      # Both are no-ops when the program is not running. ghostty is reloaded
-      # inside the delivery itself, over its own dbus interface.
-      "$HOME/.local/bin/hyprsimple-restart-waybar.sh" --if-running || true
-      "$HOME/.local/bin/hyprsimple-restart-dunst.sh" --if-running || true
+      # Tested for rather than sourced blind. This script runs under set -e, so
+      # sourcing a file that is not there aborts the whole update, and the
+      # update would fail on the run that was meant to install that very file.
+      # The refresh above copies it in, so this is only reachable when the
+      # refresh was skipped or something removed it by hand.
+      if [[ -r $DELIVER ]]; then
+        # shellcheck source=/dev/null
+        source "$DELIVER"
+        deliver_theme_configs "${gen%/*}"
+
+        # And restarted, or the freshly written colours sit on disk unread.
+        # waybar reads its stylesheet at startup and dunst its drop-ins at
+        # load, so delivering without this is the same invisibility in a new
+        # place. Both are no-ops when the program is not running. ghostty is
+        # reloaded inside the delivery itself, over its own dbus interface.
+        "$HOME/.local/bin/hyprsimple-restart-waybar.sh" --if-running || true
+        "$HOME/.local/bin/hyprsimple-restart-dunst.sh" --if-running || true
+      else
+        # Said rather than skipped quietly. Rendered output that never reaches
+        # the program it was for is the bug this whole block exists to prevent.
+        echo -e "${YELLOW}Themes were re-rendered but not delivered: $DELIVER is missing. Switch theme once to apply them.${NC}"
+      fi
     fi
 
     mkdir -p "$STAMP_DIR"

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "$HOME/.local/bin/hypr-helpers.sh"
+source "$HOME/.local/bin/hyprsimple-theme-deliver.sh"
 
 # Usage: theme-switcher.sh [theme-name]
 #   No argument: show rofi picker
@@ -25,113 +26,12 @@ if [[ -f "$THEME_PATH/colors.toml" ]]; then
   "$HOME/.local/bin/theme-apply-templates.sh" "$THEME_PATH"
 fi
 
-GEN="$THEME_PATH/generated"
-
-# 2. Update Hyprland colors
-if [[ -f "$GEN/hyprland-colors.lua" ]]; then
-  ln -sf "$GEN/hyprland-colors.lua" "$HOME/.config/hypr/theme-active.lua"
-elif [[ -f "$THEME_PATH/hypr/colors.lua" ]]; then
-  ln -sf "$THEME_PATH/hypr/colors.lua" "$HOME/.config/hypr/theme-active.lua"
-fi
-
-# 3. Update Waybar colors
-if [[ -f "$GEN/waybar-colors.css" ]]; then
-  ln -sf "$GEN/waybar-colors.css" "$HOME/.config/waybar/theme-active.css"
-elif [[ -f "$THEME_PATH/waybar/colors.css" ]]; then
-  ln -sf "$THEME_PATH/waybar/colors.css" "$HOME/.config/waybar/theme-active.css"
-fi
-
-# 3b. Update Waybar clock module (themed calendar)
-if [[ -f "$GEN/theme-clock.jsonc" ]]; then
-  ln -sf "$GEN/theme-clock.jsonc" "$HOME/.config/waybar/theme-clock.jsonc"
-elif [[ -f "$THEME_PATH/waybar/theme-clock.jsonc" ]]; then
-  ln -sf "$THEME_PATH/waybar/theme-clock.jsonc" "$HOME/.config/waybar/theme-clock.jsonc"
-fi
-
-# 4. Update Rofi colors
-if [[ -f "$GEN/rofi-colors.rasi" ]]; then
-  ln -sf "$GEN/rofi-colors.rasi" "$HOME/.config/rofi/rofi-colors.rasi"
-fi
-
-# 5. Update Ghostty theme
-GHOSTTY_CONFIG="$HOME/.config/ghostty/config"
-if [[ -f "$GHOSTTY_CONFIG" ]]; then
-  # Remove old color/palette/theme lines, keep non-color settings.
-  #
-  # The whitespace is matched the way ghostty matches it, not the way
-  # hyprsimple happens to write it. This pattern required exactly "key = ", so
-  # a line written any other way ghostty accepts survived every theme switch:
-  #
-  #   theme=gruvbox        kept, and "theme = kanagawa" appended after it
-  #   theme  =  gruvbox    kept
-  #     theme = gruvbox    kept
-  #
-  # All three validate, checked with `ghostty +validate-config`. The header of
-  # the shipped config promises these lines are removed and rewritten, so
-  # someone who set their own theme was told it would be replaced and instead
-  # kept a dead line they could no longer see taking effect.
-  grep -vE '^[[:space:]]*(background|foreground|cursor-color|cursor-text|selection-background|selection-foreground|palette|theme)[[:space:]]*=' "$GHOSTTY_CONFIG" > "$GHOSTTY_CONFIG.tmp"
-
-  if [[ -f "$THEME_PATH/ghostty-theme" ]]; then
-    # Use Ghostty's built-in theme
-    echo "theme = $(cat "$THEME_PATH/ghostty-theme")" >> "$GHOSTTY_CONFIG.tmp"
-  elif [[ -f "$GEN/ghostty.conf" ]]; then
-    # Fallback to template-generated colors
-    cat "$GEN/ghostty.conf" >> "$GHOSTTY_CONFIG.tmp"
-  fi
-
-  mv "$GHOSTTY_CONFIG.tmp" "$GHOSTTY_CONFIG"
-
-  # Reload Ghostty config
-  busctl --user call com.mitchellh.ghostty /com/mitchellh/ghostty org.gtk.Actions Activate "sava{sv}" "reload-config" 0 0 2>/dev/null
-fi
-
-# 6. Update Hyprlock theme colors
-if [[ -f "$GEN/hyprlock.conf" ]]; then
-  cp "$GEN/hyprlock.conf" "$HOME/.config/hypr/theme-hyprlock.conf"
-fi
-
-# 7. Update Dunst colors
-# generated/dunst-colors is already valid dunst config, so it drops straight in
-# as an override. Drop-ins outrank the base dunstrc, and lexical order decides
-# between them, so 90-theme sits above hyprsimple's default and below the user's.
-DUNST_DROPIN="$HOME/.config/dunst/dunstrc.d/90-theme.conf"
-mkdir -p "$(dirname "$DUNST_DROPIN")"
-if [[ -f "$GEN/dunst-colors" ]]; then
-  cp "$GEN/dunst-colors" "$DUNST_DROPIN"
-else
-  # This theme has no colors.toml, so there are no colours to apply. Drop the
-  # previous theme's file rather than leaving its colours in force.
-  rm -f "$DUNST_DROPIN"
-fi
-
-# 8. Update btop theme
+# 2 to 8. Every generated file the theme ships, put where its program reads it.
 #
-# Copying the theme into place was never enough: btop only reads the file its
-# own config names, and nothing set that. hyprsimple installs btop, install.sh
-# creates the themes directory, every theme renders a btop.theme and every
-# switch copied one here, and btop.conf still said color_theme = "Default",
-# which is what btop writes for itself on first run. The themed btop has never
-# worked on any install.
-#
-# btop names a theme by its filename without the extension, so the file written
-# below is selected as "current".
-if [[ -f "$GEN/btop.theme" ]]; then
-  mkdir -p "$HOME/.config/btop/themes"
-  cp "$GEN/btop.theme" "$HOME/.config/btop/themes/current.theme"
-
-  BTOP_CONF="$HOME/.config/btop/btop.conf"
-  if [[ ! -f $BTOP_CONF ]]; then
-    # btop fills in every key it does not find, so naming the theme is enough.
-    printf 'color_theme = "current"\n' >"$BTOP_CONF"
-  elif grep -q '^color_theme = ' "$BTOP_CONF"; then
-    # Replaced rather than appended: btop reads the file top to bottom and a
-    # second assignment would win, and the file would grow a line per switch.
-    sed -i 's|^color_theme = .*|color_theme = "current"|' "$BTOP_CONF"
-  else
-    printf 'color_theme = "current"\n' >>"$BTOP_CONF"
-  fi
-fi
+# Shared with hyprsimple-update.sh, which re-renders the templates when one
+# changes and has to deliver the result the same way. It used to carry its own
+# shorter list and so delivered two of the eight.
+deliver_theme_configs "$THEME_PATH"
 
 # 9. Wallpaper (copy so hyprpaper detects change)
 WALLPAPER=""

--- a/test/btop-theme-test.sh
+++ b/test/btop-theme-test.sh
@@ -71,6 +71,7 @@ setup_home() {
   mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.config/uwsm" "$HOME_DIR/.cache" \
     "$HOME_DIR/.config/hypr/themes/demo/generated"
   cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+    "$BIN/hyprsimple-theme-deliver.sh" \
     "$HOME_DIR/.local/bin/"
   printf 'theme[main_bg]="#191724"\n' \
     >"$HOME_DIR/.config/hypr/themes/demo/generated/btop.theme"

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -96,6 +96,9 @@ switch_home="$TMP/switch-home"
 must_be_fixture "$switch_home"
 mkdir -p "$switch_home/.local/bin" "$switch_home/.config/hypr"
 cp "$REPO/.local/bin/hypr-helpers.sh" "$switch_home/.local/bin/hypr-helpers.sh"
+# theme-switcher.sh delivers generated files through this, shared with
+# hyprsimple-update.sh so the two cannot deliver different sets.
+cp "$REPO/.local/bin/hyprsimple-theme-deliver.sh" "$switch_home/.local/bin/"
 
 withcolors="$switch_home/.config/hypr/themes/withcolors"
 mkdir -p "$withcolors/generated"

--- a/test/ghostty-theme-test.sh
+++ b/test/ghostty-theme-test.sh
@@ -68,6 +68,7 @@ setup_home() {
   mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.cache" \
     "$HOME_DIR/.config/ghostty" "$HOME_DIR/.config/hypr/themes/demo"
   cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+    "$BIN/hyprsimple-theme-deliver.sh" \
     "$HOME_DIR/.local/bin/"
   # A theme naming a built-in ghostty theme, which is the branch that appends
   # a single "theme = " line.
@@ -144,11 +145,14 @@ fi
 # file is lying to whoever reads it.
 
 SHIPPED="$REPO/.config/ghostty/config"
-SWITCHER="$BIN/theme-switcher.sh"
-filter_keys=$(grep -oE '\(background\|[a-z|-]+\)' "$SWITCHER" | head -1 |
+# The filter moved to hyprsimple-theme-deliver.sh when the delivery became one
+# function shared with hyprsimple-update.sh, which used to deliver a shorter
+# list of generated files than a theme switch did.
+FILTER_SCRIPT="$BIN/hyprsimple-theme-deliver.sh"
+filter_keys=$(grep -oE '\(background\|[a-z|-]+\)' "$FILTER_SCRIPT" | head -1 |
   tr -d '()' | tr '|' '\n' | LC_ALL=C sort -u | tr '\n' ' ')
 if [[ -z ${filter_keys// /} ]]; then
-  fail "could not read the key list out of theme-switcher.sh"
+  fail "could not read the key list out of hyprsimple-theme-deliver.sh"
 else
   pass "the filter names: $filter_keys"
 fi
@@ -175,9 +179,9 @@ check "the filter rewrites exactly the keys the header names" \
 # The pattern has to be the tolerant one, stated by name so a narrowing edit is
 # caught even if a fixture stops covering it.
 check "the filter allows whitespace before the key" \
-  "$(grep -c "grep -vE '\^\[\[:space:\]\]\*(" "$SWITCHER")" "1"
+  "$(grep -c "grep -vE '\^\[\[:space:\]\]\*(" "$FILTER_SCRIPT")" "1"
 check "and around the equals" \
-  "$(grep -c 'theme)\[\[:space:\]\]\*=' "$SWITCHER")" "1"
+  "$(grep -c 'theme)\[\[:space:\]\]\*=' "$FILTER_SCRIPT")" "1"
 
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2

--- a/test/removed-files-test.sh
+++ b/test/removed-files-test.sh
@@ -47,8 +47,11 @@ check "and the repository root ships no .bashrc" \
 # than a leftover.
 check "the btop template is still shipped" \
   "$([[ -f $REPO/.config/hypr/themes/templates/btop.theme.tpl ]] && echo yes || echo no)" "yes"
-check "and the switcher still installs the rendered one" \
-  "$(grep -c 'GEN/btop.theme' "$REPO/.local/bin/theme-switcher.sh")" "2"
+# In hyprsimple-theme-deliver.sh, which is where the delivery moved when it
+# became one function shared with hyprsimple-update.sh. The update used to
+# carry its own shorter list and never delivered btop.theme at all.
+check "and the shared delivery still installs the rendered one" \
+  "$(grep -c 'GEN/btop.theme' "$REPO/.local/bin/hyprsimple-theme-deliver.sh")" "2"
 check "and bashrc.sh, which the shell actually sources, is still shipped" \
   "$([[ -f $REPO/.local/bin/bashrc.sh ]] && echo yes || echo no)" "yes"
 check "and terminal.sh still wires it into a real ~/.bashrc" \

--- a/test/template-autorender-test.sh
+++ b/test/template-autorender-test.sh
@@ -39,6 +39,12 @@ mkdir -p "$INSTALL/.config/hypr/themes/templates" "$HOMEDIR/.local/bin" \
 
 cp "$REPO/.local/bin/theme-apply-templates.sh" "$HOMEDIR/.local/bin/"
 chmod +x "$HOMEDIR/.local/bin/theme-apply-templates.sh"
+# The update delivers the rendered output through this, shared with
+# theme-switcher.sh so the two cannot deliver different sets of files. A real
+# update copies it into ~/.local/bin itself, in the refresh step this fixture
+# stands in for.
+cp "$REPO/.local/bin/hyprsimple-theme-deliver.sh" "$HOMEDIR/.local/bin/"
+chmod +x "$HOMEDIR/.local/bin/hyprsimple-theme-deliver.sh"
 printf '#!/bin/sh\nexit 0\n' >"$HOMEDIR/.local/bin/hyprsimple-migrate.sh"
 chmod +x "$HOMEDIR/.local/bin/hyprsimple-migrate.sh"
 printf 'background = "#2d353b"\nforeground = "#d3c6aa"\n' \
@@ -92,6 +98,22 @@ check "a newly shipped template reaches an existing theme with no migration" \
   "$(grep -c 'X #2d353b' "$HOMEDIR/.config/hypr/themes/solo/generated/brand-new" 2>/dev/null)" "1"
 
 check "the update still exits 0" "$(cat "$TMP/rc")" "0"
+
+# A missing delivery helper must not take the update down with it.
+#
+# This script runs under set -e, so sourcing a file that is not there aborts
+# everything after it, including the migrations and the reload. The update is
+# also what installs that file, so the run that would have repaired a missing
+# one is exactly the run that would have died.
+mv "$HOMEDIR/.local/bin/hyprsimple-theme-deliver.sh" "$TMP/deliver.aside"
+printf 'Y {{ background }}\n' >"$INSTALL/.config/hypr/themes/templates/needs-deliver.tpl"
+run_update
+check "with the delivery helper missing, the update still exits 0" "$(cat "$TMP/rc")" "0"
+check "and says the render was not delivered rather than failing silently" \
+  "$(grep -c 'not delivered' "$TMP/out")" "1"
+check "and still finished the run, so the reload at the end was reached" \
+  "$(grep -c 'hyprsimple is up to date' "$TMP/out")" "1"
+mv "$TMP/deliver.aside" "$HOMEDIR/.local/bin/hyprsimple-theme-deliver.sh"
 
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2

--- a/test/theme-delivery-test.sh
+++ b/test/theme-delivery-test.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Checks that every generated file a theme ships is delivered, and that both
+# callers deliver through the same function.
+#
+# hyprsimple-update.sh re-rendered every theme when a template changed and then
+# copied two of the eight generated files. A change to btop.theme.tpl or
+# ghostty.conf.tpl was rendered, stamped as done, and never reached the program
+# it was for until the user happened to switch theme. Never touches the real
+# ~/.config.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DELIVER="$REPO/.local/bin/hyprsimple-theme-deliver.sh"
+SWITCHER="$REPO/.local/bin/theme-switcher.sh"
+UPDATER="$REPO/.local/bin/hyprsimple-update.sh"
+TEMPLATES="$REPO/.config/hypr/themes/templates"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+# ---- the set of templates, read out of the repository ----------------------
+#
+# Not a list kept here. A list would go stale the day a template is added,
+# which is the failure this whole file is about.
+mapfile -t tpl < <(find "$TEMPLATES" -maxdepth 1 -name '*.tpl' -printf '%f\n' | sed 's/\.tpl$//' | sort)
+if (( ${#tpl[@]} < 6 )); then
+  fail "found ${#tpl[@]} templates, which is too few to be right"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "found ${#tpl[@]} templates in the repository"
+
+# ---- a theme whose generated directory holds one file per template ---------
+
+H="$TMP/home"
+mkdir -p "$H/.local/bin" "$H/.config/ghostty" "$H/.config/waybar" "$H/.config/rofi" "$H/.config/hypr"
+THEME="$H/.config/hypr/themes/demo"
+mkdir -p "$THEME/generated"
+for name in "${tpl[@]}"; do
+  printf 'MARKER-%s\n' "$name" >"$THEME/generated/$name"
+done
+printf 'theme = something-else\nfont-size = 12\n' >"$H/.config/ghostty/config"
+
+HOME="$H" bash -c 'source "$1"; deliver_theme_configs "$2"' _ "$DELIVER" "$THEME" >/dev/null 2>&1
+
+# Where each generated file is read from. This mapping is the contract, so it
+# is spelled out, and the check below fails if a template has no entry.
+declare -A target=(
+  [hyprland-colors.lua]="$H/.config/hypr/theme-active.lua"
+  [waybar-colors.css]="$H/.config/waybar/theme-active.css"
+  [theme-clock.jsonc]="$H/.config/waybar/theme-clock.jsonc"
+  [rofi-colors.rasi]="$H/.config/rofi/rofi-colors.rasi"
+  [hyprlock.conf]="$H/.config/hypr/theme-hyprlock.conf"
+  [dunst-colors]="$H/.config/dunst/dunstrc.d/90-theme.conf"
+  [btop.theme]="$H/.config/btop/themes/current.theme"
+  [ghostty.conf]="$H/.config/ghostty/config"
+)
+
+unmapped=()
+undelivered=()
+for name in "${tpl[@]}"; do
+  dest="${target[$name]:-}"
+  if [[ -z $dest ]]; then unmapped+=("$name"); continue; fi
+  grep -qF "MARKER-$name" "$dest" 2>/dev/null || undelivered+=("$name")
+done
+
+unmapped_str=""; (( ${#unmapped[@]} > 0 )) && unmapped_str="$(printf '%s ' "${unmapped[@]}")"
+check "every template in the repository has a known destination in this suite" "$unmapped_str" ""
+
+undelivered_str=""; (( ${#undelivered[@]} > 0 )) && undelivered_str="$(printf '%s ' "${undelivered[@]}")"
+check "and the delivery puts every one of them where its program reads it" "$undelivered_str" ""
+
+# btop needs its config to name the theme, not just the file to exist.
+check "btop's own config names the delivered theme" \
+  "$(grep -c '^color_theme = "current"$' "$H/.config/btop/btop.conf" 2>/dev/null)" "1"
+
+# The ghostty line the delivery replaces has to go, not sit above the new one.
+check "and the ghostty theme line it replaced is gone" \
+  "$(grep -c 'something-else' "$H/.config/ghostty/config")" "0"
+
+# ---- both callers go through the one function ------------------------------
+#
+# The bug was two lists that disagreed. Checking the code here, not behaviour,
+# because the thing to prevent is a second list appearing again.
+code() { sed 's/#.*//' "$1"; }
+
+check "theme-switcher.sh delivers through the shared function" \
+  "$(code "$SWITCHER" | grep -c 'deliver_theme_configs')" "1"
+check "and hyprsimple-update.sh through the same one" \
+  "$(code "$UPDATER" | grep -c 'deliver_theme_configs')" "1"
+check "and both source it" \
+  "$(cat "$SWITCHER" "$UPDATER" | sed 's/#.*//' | grep -c 'hyprsimple-theme-deliver.sh')" "2"
+check "with the copies that used to live in the updater gone" \
+  "$(code "$UPDATER" | grep -cE 'cp "\$gen/')" "0"
+
+# ---- the update restarts what it just rewrote ------------------------------
+#
+# waybar reads its stylesheet at startup and dunst its drop-ins at load, so a
+# freshly written colour file is invisible until they are restarted. A theme
+# switch has always done this; the update wrote the files and did not.
+check "the update restarts waybar after delivering" \
+  "$(code "$UPDATER" | grep -cE 'restart-waybar\.sh"? --if-running')" "1"
+check "and dunst" \
+  "$(code "$UPDATER" | grep -cE 'restart-dunst\.sh"? --if-running')" "1"
+present=0
+for s in hyprsimple-restart-waybar.sh hyprsimple-restart-dunst.sh; do
+  [[ -f $REPO/.local/bin/$s ]] && present=$((present + 1))
+done
+check "and those two scripts exist to be called" "$present" "2"
+
+# ---- delivery does not move the wallpaper ----------------------------------
+#
+# The update calls this function, and an update must not change the picture on
+# the screen. That is the switch's job and it stayed with the switch.
+check "the shared delivery leaves the wallpaper alone" \
+  "$(code "$DELIVER" | grep -c 'current_wallpaper')" "0"
+check "and the switcher still handles it" \
+  "$(code "$SWITCHER" | grep -c 'current_wallpaper_path')" "1"
+
+if [[ $failures -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`hyprsimple-update.sh` re-renders every theme when a template changes, then delivered the result by copying two files. A theme switch delivers eight.

| generated file | theme switch | update (before) |
| --- | --- | --- |
| `hyprland-colors.lua` | symlink | — (already points into `generated/`) |
| `waybar-colors.css` | symlink | — (already points into `generated/`) |
| `theme-clock.jsonc` | symlink | — (already points into `generated/`) |
| `rofi-colors.rasi` | symlink | — (already points into `generated/`) |
| `hyprlock.conf` | copy | copy |
| `dunst-colors` | copy | copy |
| **`ghostty.conf`** | copy | **not delivered** |
| **`btop.theme`** | copy | **not delivered** |

A change to `btop.theme.tpl` or `ghostty.conf.tpl` was rendered, stamped as done so the block never ran again, and never reached btop or ghostty until the user happened to switch theme.

The section's own comment says:

> A template change now reaches every theme on the next update, so no future template needs a migration to deliver it.

That held for six templates out of eight.

**How live it is:** every one of the 16 shipped themes depends on the generated `btop.theme`. Five of them (`deep-sea`, `ethereal`, `hackerman`, `vantablack`, `white`) ship no `ghostty-theme` file and so depend on the generated `ghostty.conf`.

## A second gap

The update wrote `90-theme.conf` and left the waybar stylesheet regenerated, and then restarted nothing but Hyprland. waybar reads its stylesheet at startup and dunst its drop-ins at load, so the fresh colours sat on disk unread. A theme switch has always restarted both.

## The fix

Steps 2 to 8 of `theme-switcher.sh` moved unchanged into `deliver_theme_configs()` in a new `hyprsimple-theme-deliver.sh`, sourced by both callers. One function, so a template added later is delivered by both or by neither.

Delivery only. The wallpaper, the GTK and icon settings and the reloads stayed with their callers, because switching theme should change the wallpaper and an update should not.

The update now also calls `hyprsimple-restart-waybar.sh --if-running` and `hyprsimple-restart-dunst.sh --if-running`. ghostty is reloaded inside the delivery over its own dbus interface, as it always was.

## Tests

New `test/theme-delivery-test.sh`, registered in CI. It reads the template list out of the repository rather than holding its own, so a template added later must be given a destination or the suite fails.

Verified end to end against the real themes in an isolated `HOME`: switching to `deep-sea` (one of the five with no `ghostty-theme`) delivers all eight, and ghostty picks up the generated colours.

Four sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the update goes back to its own two-file list | 3 |
| btop delivery removed from the shared function | 2 |
| the update stops restarting waybar and dunst | 2 |
| a new template is added with nowhere to go | 1 |

Four existing suites needed their fixtures updated, because they run `theme-switcher.sh` in a fake `HOME` and now need the helper there too, or grepped `theme-switcher.sh` for code that moved: `btop-theme`, `ghostty-theme`, `dunst-split`, `removed-files`. All pass, along with `theme-picker`, `cursor-theme`, `icon-themes`, `config-ownership`, `config-realworld`, `generated-cleanup`, `env-block`, `rofi-theme-link`, `rofi-split-smoke`, `toggle-scripts`, `broken-override`, `named-paths`, `suite-hygiene`. shellcheck clean.
