### PR TITLE
Wait for the recorder to exit before refreshing the bar indicator

### DIFF
--- a/.local/bin/screen-record.sh
+++ b/.local/bin/screen-record.sh
@@ -100,7 +100,29 @@ stop_screenrecording() {
   pkill -x wl-screenrec
   pkill -x wf-recorder
   notify-send "Screen recording saved to $OUTPUT_DIR" -t 2000
-  sleep 0.2
+
+  # Waited for, not slept past.
+  #
+  # This was `sleep 0.2`, and the indicator is driven by a signal with no
+  # interval behind it: waybar re-runs the module when RTMIN+8 arrives and at
+  # no other time. So the module sampled pgrep once, 0.2 seconds after the
+  # TERM, and whatever it saw then stood until the next recording started.
+  #
+  # A recorder does not always exit inside that window. Both are asked to
+  # finalise an mp4 written with +faststart, which rewrites the file to move
+  # the index to the front, and that takes longer the longer the recording is.
+  # Every stop slower than 0.2s left the bar claiming to be recording, with
+  # nothing scheduled to correct it.
+  local waited=0
+  local limit="${HYPRSIMPLE_RECORDER_STOP_WAIT:-100}"
+  while screenrecording_active && ((waited < limit)); do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  # Outside the loop, so the indicator is refreshed even when the wait ran out.
+  # A recorder still alive after ten seconds is a different problem, and
+  # leaving the bar untouched would not help with it either.
   toggle_screenrecording_indicator
 }
 

--- a/test/screen-record-test.sh
+++ b/test/screen-record-test.sh
@@ -199,6 +199,85 @@ run_record nvidia region none
 check "a recorder that exits at once is reported rather than ignored" \
   "$(grep -c 'failed to start' "$NLOG")" "1"
 
+# --- stopping waits for the recorder to actually go ------------------------
+#
+# The waybar indicator is driven by RTMIN+8 and nothing else: that module has a
+# signal and no interval, so whatever the module sees when the signal arrives
+# stands until the next recording starts. The stop path used to sleep 0.2s and
+# then signal, so a recorder still finalising its mp4 left the bar claiming to
+# be recording with nothing scheduled to correct it.
+#
+# Modelled with a pgrep that reports the recorder alive until a marker file
+# appears, and a pkill that creates that marker after a delay. The order of the
+# two events is what matters, so the check reads which came first rather than
+# timing anything.
+
+ORDER="$TMP/stop-order"
+GONE="$TMP/recorder-gone"
+
+cat >"$STUB/pgrep" <<'STUBEOF'
+#!/bin/bash
+# Alive until the marker says the recorder finished exiting.
+[[ -e $RECORDER_GONE ]] && exit 1
+exit 0
+STUBEOF
+
+cat >"$STUB/pkill" <<'STUBEOF'
+#!/bin/bash
+if [[ $* == *RTMIN+8* ]]; then
+  printf 'signalled\n' >>"$STOP_ORDER"
+  exit 0
+fi
+# The TERM to the recorder. It goes away only after finalising, which is what
+# the delay stands for: long enough that a fixed 0.2s sleep would signal first.
+#
+# Once, not once per recorder: the script TERMs both names and only one of them
+# was ever running.
+if [[ $* == *wl-screenrec* || $* == *wf-recorder* ]] && mkdir "$RECORDER_GONE.once" 2>/dev/null; then
+  ( sleep 0.8; printf 'exited\n' >>"$STOP_ORDER"; : >"$RECORDER_GONE" ) &
+fi
+exit 0
+STUBEOF
+chmod +x "$STUB/pgrep" "$STUB/pkill"
+
+: >"$ORDER"; rm -f "$GONE"; rm -rf "$GONE.once"; : >"$NLOG"
+CALL_LOG="$LOG" NOTIFY_LOG="$NLOG" HOME="$HOME_DIR" STUB_PIDS="$PIDFILE" \
+  STOP_ORDER="$ORDER" RECORDER_GONE="$GONE" \
+  PATH="$STUB:/usr/bin:/bin" bash "$BIN/screen-record.sh" stop >/dev/null 2>&1
+
+check "the recorder is gone before waybar is told to re-read" \
+  "$(tr '\n' ' ' <"$ORDER")" "exited signalled "
+check "and waybar is told exactly once" \
+  "$(grep -c '^signalled$' "$ORDER")" "1"
+
+# A recorder that never exits must not hang the stop for good.
+: >"$ORDER"; rm -f "$GONE"; rm -rf "$GONE.once"
+cat >"$STUB/pkill" <<'STUBEOF'
+#!/bin/bash
+[[ $* == *RTMIN+8* ]] && printf 'signalled\n' >>"$STOP_ORDER"
+exit 0
+STUBEOF
+chmod +x "$STUB/pkill"
+CALL_LOG="$LOG" NOTIFY_LOG="$NLOG" HOME="$HOME_DIR" STUB_PIDS="$PIDFILE" \
+  STOP_ORDER="$ORDER" RECORDER_GONE="$GONE" HYPRSIMPLE_RECORDER_STOP_WAIT=3 \
+  PATH="$STUB:/usr/bin:/bin" bash "$BIN/screen-record.sh" stop >/dev/null 2>&1
+check "a recorder that never exits still ends with waybar being told" \
+  "$(grep -c '^signalled$' "$ORDER")" "1"
+
+# And the wait is bounded by something, or the check above proves only that
+# this run happened to finish.
+check "the stop wait has a limit rather than looping forever" \
+  "$(sed 's/#.*//' "$BIN/screen-record.sh" | grep -c 'HYPRSIMPLE_RECORDER_STOP_WAIT')" "1"
+check "and the fixed sleep it replaced is gone" \
+  "$(sed 's/#.*//' "$BIN/screen-record.sh" | grep -c 'sleep 0.2')" "0"
+
+# The module really does have no interval, which is why the sample has to be
+# taken at the right moment.
+check "the waybar recording module is signal driven with no interval" \
+  "$(sed -n '/custom\/screenrecording/,/}/p' "$REPO/.config/waybar/config.jsonc" | grep -c 'interval')" "0"
+check "and it really does carry the signal this script sends" \
+  "$(sed -n '/custom\/screenrecording/,/}/p' "$REPO/.config/waybar/config.jsonc" | grep -c '"signal": 8')" "1"
+
 # This suite once left four processes named wf-recorder running, which made
 # waybar-refresh-test and notification-idiom-test see a recording in progress.
 # Assert the cleanup rather than trust it.


### PR DESCRIPTION
The waybar recording indicator is driven by `RTMIN+8` and nothing else. Its module carries a signal and **no interval**, so whatever it sees when the signal arrives stands until the next recording starts.

`stop_screenrecording` sent the TERM, slept `0.2`, then signalled:

```bash
pkill -x wl-screenrec
pkill -x wf-recorder
notify-send "Screen recording saved to $OUTPUT_DIR" -t 2000
sleep 0.2
toggle_screenrecording_indicator
```

A recorder still running at that moment left the bar claiming to be recording, with nothing scheduled to correct it. Stopping again does not help: `screen-record.sh stop` is guarded by `screenrecording_active`, so once the recorder is genuinely gone the stop path returns without signalling.

## Why 0.2 seconds is the wrong bet

Both recorders are asked to finalise an mp4 written with `movflags=+faststart`, which rewrites the file to move the index to the front. That work scales with the length of the recording, so the stops that overrun the window are exactly the long recordings, not the short ones.

I did not measure real finalisation times here, because doing so means capturing the screen. The defect does not depend on the distribution: the sample is taken once at a fixed offset with no retry and no polling behind it, so any stop slower than the sleep is wrong until the next recording.

## The fix

The stop waits for the recorder to actually go, bounded at ten seconds, and refreshes the indicator outside the loop so it still happens if the wait runs out. The bound is overridable as `HYPRSIMPLE_RECORDER_STOP_WAIT` so the suite does not wait ten seconds to test it.

## Tests

Six checks in `test/screen-record-test.sh`. Nothing is recorded: a stub `pgrep` reports the recorder alive until a marker appears, and a stub `pkill` creates that marker after a delay. The checks read the **order** of the two events rather than timing anything, so they do not depend on machine speed.

Two premise checks assert the thing that makes the timing matter: that the waybar module has a signal and no interval. If a future change gives that module an interval, the check fails rather than the fix quietly becoming pointless.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| back to the fixed `sleep 0.2` | 3 |
| the refresh moved inside the wait loop | 3 |
| the waybar module gains an interval | 1 |

The second sabotage is the useful one: it shows the loop signalling waybar eight times instead of once.

Related suites pass: `screen-record`, `waybar-refresh`, `notification-idiom`, `named-paths`, `launched-programs`, `config-ownership`, `suite-hygiene`. shellcheck clean.
