### PR TITLE
Stop the nightlight key reporting a change it did not make

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,6 +247,9 @@ jobs:
       - name: theme-delivery-test
         run: bash test/theme-delivery-test.sh
 
+      - name: nightlight-test
+        run: bash test/nightlight-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/toggle-nightlight.sh
+++ b/.local/bin/toggle-nightlight.sh
@@ -3,18 +3,61 @@
 ON_TEMP=4000
 OFF_TEMP=6000
 
-# Ensure hyprsunset is running
+# The current temperature, or nothing when hyprsunset is not answering.
+#
+# Anchored to a bare number. This was `hyprctl hyprsunset temperature | grep
+# -oE '[0-9]+'`, and hyprctl prints its connection error on stdout rather than
+# stderr, so the redirection to /dev/null did not hide it and the scrape read
+# the digits out of the socket path instead:
+#
+#   Couldn't connect to /run/user/1000/hypr/efb5...1788756256_4119465/.hyprsunset.sock. (3)
+#
+# came back as 1000, 50993780079460, 0, 1363, 2166, 2, 1, 9, 1788756256,
+# 4119465, 3. That never equals 6000, so the script took its else branch and
+# asked for 6000, the daylight end, on a key press meant to warm the screen.
+#
+# hyprsunset answers a query with the number on its own and a set with "ok".
+current_temperature() {
+  local out
+  out=$(hyprctl hyprsunset temperature 2>/dev/null) || return 1
+  [[ $out =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$out"
+}
+
+# Waited for, not slept past. This was `sleep 1`, which is a guess about how
+# long hyprsunset takes to open its socket, and every guess that comes up short
+# landed in the branch above.
 if ! pgrep -x hyprsunset >/dev/null; then
   uwsm app -- hyprsunset &
-  sleep 1
+  waited=0
+  limit="${HYPRSIMPLE_SUNSET_WAIT:-50}"
+  while ! current_temperature >/dev/null && ((waited < limit)); do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
 fi
 
-CURRENT_TEMP=$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+')
+# Said rather than assumed. The old script reported a temperature change
+# whether or not hyprctl had accepted one, so a session with no hyprsunset in
+# it answered every press with "Daylight screen temperature (6000K)" and
+# changed nothing. Pressing again did the same, so the nightlight could not be
+# turned on at all, and nothing on screen said why.
+if ! CURRENT_TEMP=$(current_temperature); then
+  notify-send -u critical "Nightlight" "hyprsunset is not responding, so the screen temperature is unchanged"
+  exit 1
+fi
 
 if [[ $CURRENT_TEMP == "$OFF_TEMP" ]]; then
-  hyprctl hyprsunset temperature $ON_TEMP
-  notify-send "Nightlight" "Warm screen temperature (${ON_TEMP}K)"
+  TARGET=$ON_TEMP
+  LABEL="Warm screen temperature"
 else
-  hyprctl hyprsunset temperature $OFF_TEMP
-  notify-send "Nightlight" "Daylight screen temperature (${OFF_TEMP}K)"
+  TARGET=$OFF_TEMP
+  LABEL="Daylight screen temperature"
+fi
+
+if [[ $(hyprctl hyprsunset temperature "$TARGET" 2>/dev/null) == "ok" ]]; then
+  notify-send "Nightlight" "$LABEL (${TARGET}K)"
+else
+  notify-send -u critical "Nightlight" "hyprsunset would not set ${TARGET}K, so the screen temperature is unchanged"
+  exit 1
 fi

--- a/test/nightlight-test.sh
+++ b/test/nightlight-test.sh
@@ -79,7 +79,7 @@ scraped=$(PATH="$STUB:/usr/bin:/bin" HYPRCTL_LOG=/dev/null "$STUB/hyprctl-dead" 
 check "the connection error scrapes into digits, which is what the old parse read" \
   "$([[ -n ${scraped// /} ]] && echo yes || echo no)" "yes"
 check "and none of them is the daylight temperature, so the comparison could not match" \
-  "$(printf '%s\n' $scraped | grep -cx 6000)" "0"
+  "$(printf '%s' "$scraped" | tr ' ' '\n' | grep -cx 6000)" "0"
 
 # ---- a live hyprsunset toggles both ways -----------------------------------
 

--- a/test/nightlight-test.sh
+++ b/test/nightlight-test.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Checks toggle-nightlight.sh against a stubbed hyprsunset.
+#
+# The key meant to warm the screen could not warm it when hyprsunset was not
+# answering, and said it had. hyprctl prints its connection error on stdout,
+# so the old `grep -oE '[0-9]+'` read the digits out of the socket path, the
+# comparison against 6000 failed, and the script asked for 6000: the daylight
+# end, on a press meant to do the opposite. It then reported success about a
+# command that had also failed.
+#
+# Nothing here talks to a real hyprsunset or changes a real screen.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO/.local/bin/toggle-nightlight.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+HLOG="$TMP/hyprctl-calls"
+NLOG="$TMP/notifications"
+STATE="$TMP/temperature"
+
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUBEOF
+
+# A live hyprsunset: a query answers with the number alone, a set answers "ok".
+# Both formats were read off the real thing rather than assumed.
+cat >"$STUB/hyprctl-live" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+if [[ $1 == hyprsunset && $2 == temperature && -z ${3-} ]]; then cat "$TEMP_STATE"; echo; exit 0; fi
+if [[ $1 == hyprsunset && $2 == temperature && -n ${3-} ]]; then printf '%s' "$3" >"$TEMP_STATE"; echo ok; exit 0; fi
+exit 1
+STUBEOF
+
+# A dead one, printing the real message hyprctl gives, on stdout, which is what
+# defeated the redirection to /dev/null and fed the digit scrape.
+cat >"$STUB/hyprctl-dead" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+echo "Couldn't connect to /run/user/1000/hypr/efb50993780079460b0cbed1363e2166a2de1d9f_1788756256_4119465/.hyprsunset.sock. (3)"
+exit 1
+STUBEOF
+
+printf '#!/bin/bash\nexit 0\n' >"$STUB/uwsm"
+printf '#!/bin/bash\nexit 0\n' >"$STUB/pgrep"
+chmod +x "$STUB"/*
+
+use_hyprctl() { cp "$STUB/hyprctl-$1" "$STUB/hyprctl"; chmod +x "$STUB/hyprctl"; }
+press() {
+  HYPRCTL_LOG="$HLOG" NOTIFY_LOG="$NLOG" TEMP_STATE="$STATE" \
+    HYPRSIMPLE_SUNSET_WAIT=2 PATH="$STUB:/usr/bin:/bin" \
+    bash "$SCRIPT" >/dev/null 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+# ---- the premise: that error really does scrape as digits ------------------
+#
+# Asserted rather than described. If hyprctl's message ever stops carrying
+# digits, the checks below would pass for a reason that has nothing to do with
+# the fix.
+scraped=$(PATH="$STUB:/usr/bin:/bin" HYPRCTL_LOG=/dev/null "$STUB/hyprctl-dead" hyprsunset temperature |
+  grep -oE '[0-9]+' | tr '\n' ' ')
+check "the connection error scrapes into digits, which is what the old parse read" \
+  "$([[ -n ${scraped// /} ]] && echo yes || echo no)" "yes"
+check "and none of them is the daylight temperature, so the comparison could not match" \
+  "$(printf '%s\n' $scraped | grep -cx 6000)" "0"
+
+# ---- a live hyprsunset toggles both ways -----------------------------------
+
+use_hyprctl live
+printf '6000' >"$STATE"; : >"$NLOG"; : >"$HLOG"
+
+press
+check "from daylight, one press warms the screen" "$(cat "$STATE")" "4000"
+check "and says so" "$(grep -c 'Warm screen temperature (4000K)' "$NLOG")" "1"
+check "and exits 0" "$(cat "$TMP/rc")" "0"
+
+press
+check "a second press returns it to daylight" "$(cat "$STATE")" "6000"
+check "and says that" "$(grep -c 'Daylight screen temperature (6000K)' "$NLOG")" "1"
+
+press
+check "and a third warms it again, so the toggle really alternates" "$(cat "$STATE")" "4000"
+
+# A temperature that is neither end, as a hyprsunset.conf profile can leave it.
+printf '4500' >"$STATE"; : >"$NLOG"
+press
+check "from a profile temperature, a press goes to daylight" "$(cat "$STATE")" "6000"
+
+# ---- a dead hyprsunset is reported, not papered over -----------------------
+
+use_hyprctl dead
+: >"$NLOG"; : >"$HLOG"
+press
+
+check "with hyprsunset not answering, nothing is claimed about the temperature" \
+  "$(grep -c 'screen temperature (' "$NLOG")" "0"
+check "the user is told hyprsunset is not responding" \
+  "$(grep -c 'not responding' "$NLOG")" "1"
+check "and the message is critical, so it is not lost among the ordinary ones" \
+  "$(grep -c -- '-u critical' "$NLOG")" "1"
+check "and the script exits non-zero" \
+  "$([[ $(cat "$TMP/rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+
+# The heart of it: no temperature is asked for at all. The old script asked for
+# 6000 here, which is the wrong direction as well as a failed call.
+check "no temperature is set when the state could not be read" \
+  "$(grep -c 'hyprsunset temperature 6000' "$HLOG")" "0"
+check "and none at the other end either" \
+  "$(grep -c 'hyprsunset temperature 4000' "$HLOG")" "0"
+
+# ---- a set that is refused is reported too ---------------------------------
+#
+# Reading answers, setting fails. The old script sent its notification without
+# looking at the answer at all.
+cat >"$STUB/hyprctl" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+if [[ $1 == hyprsunset && $2 == temperature && -z ${3-} ]]; then echo 6000; exit 0; fi
+echo "error"
+exit 1
+STUBEOF
+chmod +x "$STUB/hyprctl"
+: >"$NLOG"; : >"$HLOG"
+press
+check "a refused set is not reported as a temperature change" \
+  "$(grep -c 'screen temperature (' "$NLOG")" "0"
+check "the user is told it would not be set" \
+  "$(grep -c 'would not set' "$NLOG")" "1"
+check "and the script exits non-zero" \
+  "$([[ $(cat "$TMP/rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+
+# ---- the shape of the parse ------------------------------------------------
+#
+# Comments stripped, because the script explains the old scrape in one.
+code() { sed 's/#.*//' "$SCRIPT"; }
+check "the unanchored digit scrape is gone" \
+  "$(code "$SCRIPT" | grep -c "grep -oE '\[0-9\]+'")" "0"
+check "and the reading is anchored to a bare number" \
+  "$(code "$SCRIPT" | grep -c '\^\[0-9\]+\$')" "1"
+check "and the fixed sleep after starting hyprsunset is gone" \
+  "$(code "$SCRIPT" | grep -c '^ *sleep 1$')" "0"
+check "while the wait that replaced it is bounded" \
+  "$(code "$SCRIPT" | grep -c 'HYPRSIMPLE_SUNSET_WAIT')" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`toggle-nightlight.sh` read the current temperature with:

```bash
CURRENT_TEMP=$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+')
```

hyprctl prints its connection error on **stdout**, not stderr, so the redirection did not hide it and the scrape read the digits out of the socket path. Measured on a machine with hyprsunset not running:

```
Couldn't connect to /run/user/1000/hypr/efb5...1788756256_4119465/.hyprsunset.sock. (3)
```

comes back as `1000 50993780079460 0 1363 2166 2 1 9 1788756256 4119465 3`.

None of those equals `6000`, so the script fell to its `else` branch and asked for **6000, the daylight end, on a key press meant to warm the screen**. That call failed too, and the notification was sent without looking at either answer.

Reproduced against the real error text:

```
=== hyprctl calls ===
hyprctl hyprsunset temperature
hyprctl hyprsunset temperature 6000
=== what the user is told ===
Nightlight Daylight screen temperature (6000K)
```

So with hyprsunset down, every press says "Daylight" and changes nothing. The nightlight cannot be turned on, and nothing on screen says why.

## The fix

- The reading is anchored to a bare number, which is what hyprsunset actually answers a query with. Both formats were read off the real thing: a query answers `6000`, a set answers `ok`.
- Both the read and the set are checked before anything is announced. A failure says so, critically, and exits non-zero.
- The `sleep 1` after starting hyprsunset became a bounded wait for it to answer, for the same reason the recording indicator stopped guessing in #120.

## Separate observation, not fixed here

On the machine this was found on, hyprsunset is started at login by `default/hypr/autostart.lua` and is not running afterwards. dunst, waybar and hypridle were started in the same second and all survived; hyprsunset did not, with no failure logged. Started by hand it runs fine and binds `hyprland-ctm-control-v1`, so the config is not the problem. That is a separate bug and needs its own investigation rather than a guess bolted onto this one. This change is what makes it visible instead of silent.

## Tests

New `test/nightlight-test.sh`, registered in CI. Nothing talks to a real hyprsunset or changes a real screen.

Two premise checks assert the thing the fix depends on: that hyprctl's error really does scrape into digits, and that none of them is `6000`, so the old comparison could not match. If that message ever stops carrying digits, those fail rather than the rest passing for the wrong reason.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the unanchored digit scrape returns | 4 |
| notify without checking the set succeeded | 3 |
| the missing-hyprsunset guard removed | 2 |

Related suites pass: `nightlight`, `hyprsunset-config`, `named-paths`, `launched-programs`, `notification-idiom`, `readme-keybindings`, `keybinding-viewer`, `suite-hygiene`. shellcheck clean.
