### PR TITLE
Run hyprsunset as a service, so it comes back when it dies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -250,6 +250,9 @@ jobs:
       - name: nightlight-test
         run: bash test/nightlight-test.sh
 
+      - name: hyprsunset-service-test
+        run: bash test/hyprsunset-service-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/toggle-nightlight.sh
+++ b/.local/bin/toggle-nightlight.sh
@@ -27,8 +27,11 @@ current_temperature() {
 # Waited for, not slept past. This was `sleep 1`, which is a guess about how
 # long hyprsunset takes to open its socket, and every guess that comes up short
 # landed in the branch above.
+# Through the unit, not `uwsm app --`. A scope started here would have no
+# restart policy, which is the thing that left hyprsunset gone for the rest of
+# a session after a suspend.
 if ! pgrep -x hyprsunset >/dev/null; then
-  uwsm app -- hyprsunset &
+  systemctl --user start hyprsunset.service 2>/dev/null &
   waited=0
   limit="${HYPRSIMPLE_SUNSET_WAIT:-50}"
   while ! current_temperature >/dev/null && ((waited < limit)); do

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -1,16 +1,22 @@
 local vars = require("default.hypr.vars")
 
+-- hyprsunset is not started here. It applies the profiles in
+-- ~/.config/hypr/hyprsunset.conf and used to run as `uwsm app -- hyprsunset`,
+-- a scope with no restart policy, and it does not survive a suspend: measured
+-- across two cycles on one machine, started at login with dunst, hypridle and
+-- waybar, and the only one of the four gone afterwards, both times. Nothing
+-- brought it back, so the profiles stopped applying for the rest of the
+-- session.
+--
+-- It runs as hyprsunset.service now, the unit its own package ships, with a
+-- hyprsimple drop-in raising Restart to always. install.sh enables it.
+
 hl.on("hyprland.start", function()
   hl.exec_cmd("uwsm app -- dunst")
   hl.exec_cmd("uwsm app -- waybar")
   hl.exec_cmd("uwsm app -- wl-paste --type text --watch cliphist store")
   hl.exec_cmd("uwsm app -- wl-paste --type image --watch cliphist store")
   hl.exec_cmd("uwsm app -- hypridle")
-  -- hyprsunset applies the profiles in ~/.config/hypr/hyprsunset.conf. Nothing
-  -- started it before, so those profiles never ran: the file invited you to
-  -- uncomment a night profile and uncommenting it did nothing. SUPER+N starts
-  -- it too, but only for that session and only once pressed.
-  hl.exec_cmd("uwsm app -- hyprsunset")
   hl.exec_cmd("uwsm app -- " .. os.getenv("HOME") .. "/.local/bin/capslock-notify.sh")
   hl.exec_cmd("uwsm app -- " .. vars.terminal)
   -- apply, not on: the flag records what you chose, and login restores it

--- a/default/systemd/hyprsunset-restart.conf
+++ b/default/systemd/hyprsunset-restart.conf
@@ -1,0 +1,18 @@
+# This file belongs to hyprsimple and is replaced on update. It reaches your
+# session as a symlink, so edits here are overwritten. To change it, drop your
+# own file next to it: any name sorting after 10-hyprsimple.conf wins.
+#
+# A drop-in over the hyprsunset.service that the hyprsunset package ships. That
+# unit says Restart=on-failure, which does not cover a clean exit, and
+# hyprsunset leaves cleanly when it loses the Wayland output it was applying a
+# colour matrix to.
+#
+# Measured across two suspend cycles on one machine: hyprsunset started at
+# login alongside dunst, hypridle and waybar, and was the only one of the four
+# gone afterwards, both times. Nothing brought it back, so the profiles in
+# hyprsunset.conf stopped applying for the rest of the session, including the
+# scheduled night profile that file invites you to turn on.
+
+[Service]
+Restart=always
+RestartSec=2

--- a/install.sh
+++ b/install.sh
@@ -836,6 +836,31 @@ if [ -f "$HOME/.config/systemd/user/battery-monitor.timer" ]; then
   echo -e "${GREEN}Battery monitor enabled${NC}"
 fi
 
+# hyprsunset, through the unit its own package ships rather than a bare uwsm
+# scope. autostart.lua used to run `uwsm app -- hyprsunset`, which has no
+# restart policy at all, and hyprsunset does not survive a suspend: measured on
+# one machine across two cycles, started at login with dunst, hypridle and
+# waybar, and the only one of the four gone afterwards, both times. Nothing
+# brought it back, so every profile in hyprsunset.conf stopped applying for the
+# rest of the session.
+#
+# The drop-in beside it raises Restart from on-failure to always, because
+# on-failure does not cover the clean exit hyprsunset makes when its output
+# goes. A symlink, like the dunst drop-in, so an update to it reaches every
+# machine without a migration.
+if [ -f /usr/lib/systemd/user/hyprsunset.service ]; then
+  echo -e "${YELLOW}Enabling hyprsunset...${NC}"
+  mkdir -p "$HOME/.config/systemd/user/hyprsunset.service.d"
+  ln -sfn "$HYPRSIMPLE_PATH/default/systemd/hyprsunset-restart.conf" \
+    "$HOME/.config/systemd/user/hyprsunset.service.d/10-hyprsimple.conf"
+  systemctl --user daemon-reload
+  # enable, not enable --now, for the reason above: the unit is wanted by
+  # graphical-session.target and carries ConditionEnvironment=WAYLAND_DISPLAY,
+  # so there is nothing for --now to start from the install. The session does.
+  systemctl --user enable hyprsunset.service
+  echo -e "${GREEN}hyprsunset enabled${NC}"
+fi
+
 # Initialize Theme Manager (Default: Deep Sea)
 DEFAULT_THEME="deep-sea"
 echo ""

--- a/migrations/1788780210.sh
+++ b/migrations/1788780210.sh
@@ -15,7 +15,10 @@ echo "Run hyprsunset as a service, so it comes back when it dies"
 # The drop-in is a symlink into the install, like the dunst one, so a later
 # change to it needs no migration of its own.
 
-UNIT=/usr/lib/systemd/user/hyprsunset.service
+# Overridable so the suite can arrange a machine with and without hyprsunset
+# installed. Without this the test depended on whatever the host happened to
+# have, and passed here while doing nothing on a runner with no hyprsunset.
+UNIT="${HYPRSIMPLE_SUNSET_UNIT:-/usr/lib/systemd/user/hyprsunset.service}"
 DROPIN_DIR="$HOME/.config/systemd/user/hyprsunset.service.d"
 DROPIN="$DROPIN_DIR/10-hyprsimple.conf"
 SHIPPED="$HYPRSIMPLE_PATH/default/systemd/hyprsunset-restart.conf"

--- a/migrations/1788780210.sh
+++ b/migrations/1788780210.sh
@@ -1,0 +1,63 @@
+echo "Run hyprsunset as a service, so it comes back when it dies"
+
+# hyprsunset was started by autostart.lua as `uwsm app -- hyprsunset`, a scope
+# with no restart policy, and it does not survive a suspend. Measured across two
+# cycles on one machine: started at login alongside dunst, hypridle and waybar,
+# and the only one of the four gone afterwards, both times. Nothing brought it
+# back, so every profile in hyprsunset.conf stopped applying for the rest of the
+# session, including the scheduled night profile that file invites you to turn
+# on.
+#
+# The hyprsunset package ships its own unit. hyprsimple now enables that,
+# with a drop-in raising Restart from on-failure to always, because on-failure
+# does not cover the clean exit hyprsunset makes when its output goes.
+#
+# The drop-in is a symlink into the install, like the dunst one, so a later
+# change to it needs no migration of its own.
+
+UNIT=/usr/lib/systemd/user/hyprsunset.service
+DROPIN_DIR="$HOME/.config/systemd/user/hyprsunset.service.d"
+DROPIN="$DROPIN_DIR/10-hyprsimple.conf"
+SHIPPED="$HYPRSIMPLE_PATH/default/systemd/hyprsunset-restart.conf"
+
+if [[ ! -f $UNIT ]]; then
+  echo "  hyprsunset is not installed here, so there is nothing to enable."
+  exit 0
+fi
+
+# Refused rather than clobbered, the same rule the delivery symlinks follow. A
+# real file here is someone's own drop-in and is not ours to replace.
+if [[ -e $DROPIN && ! -L $DROPIN ]]; then
+  echo "  You have your own $DROPIN, so it was left alone."
+  echo "  Add Restart=always under [Service] there if you want hyprsunset to come back on its own."
+else
+  mkdir -p "$DROPIN_DIR"
+  ln -sfn "$SHIPPED" "$DROPIN"
+fi
+
+systemctl --user daemon-reload 2>/dev/null || true
+systemctl --user enable hyprsunset.service &>/dev/null || true
+
+# The old scope and the new unit cannot both hold hyprsunset's socket: a second
+# instance exits at once. So the scope is stopped and the unit started in its
+# place, rather than waiting for a logout. hyprsunset re-reads its profiles on
+# start, so the screen ends up where the config says it should be.
+#
+# Only when a session is actually up. Run from a TTY there is nothing to hand
+# over and nothing to start.
+if systemctl --user is-active graphical-session.target &>/dev/null; then
+  if pgrep -x hyprsunset >/dev/null; then
+    pkill -x hyprsunset 2>/dev/null || true
+    # Waited for, so the unit does not start into a socket the old process has
+    # not let go of yet.
+    waited=0
+    while pgrep -x hyprsunset >/dev/null && ((waited < 50)); do
+      sleep 0.1
+      waited=$((waited + 1))
+    done
+  fi
+  systemctl --user start hyprsunset.service &>/dev/null || true
+  echo "  hyprsunset now runs as a service and restarts itself if it dies."
+else
+  echo "  Enabled hyprsunset.service. Your next login starts it."
+fi

--- a/test/hyprsunset-config-test.sh
+++ b/test/hyprsunset-config-test.sh
@@ -51,13 +51,22 @@ check "and keeps a commented night profile to enable" \
 check "the fixture of the old file really is the TOML one" \
   "$(grep -c '^\[\[profile\]\]' "$OLD_TOML")" "1"
 
-# --- autostart ---------------------------------------------------------------
+# --- what starts it ----------------------------------------------------------
+#
+# hyprsunset.service, not autostart.lua. It used to run as `uwsm app --
+# hyprsunset`, a scope with no restart policy, and it does not survive a
+# suspend, so the profiles above stopped applying for the rest of the session
+# and nothing brought them back. hyprsunset-service-test.sh covers the
+# handover; this only checks that something still starts it, since the point of
+# this file is that the profiles are read.
 
 code_of() { sed 's/^[[:space:]]*--.*//' "$1"; }
-check "autostart starts hyprsunset, so the profiles are read at login" \
-  "$(code_of "$REPO/default/hypr/autostart.lua" | grep -c 'uwsm app -- hyprsunset')" "1"
+check "autostart no longer starts hyprsunset itself" \
+  "$(code_of "$REPO/default/hypr/autostart.lua" | grep -c 'uwsm app -- hyprsunset')" "0"
 check "stripping comments leaves autostart's code intact" \
   "$(code_of "$REPO/default/hypr/autostart.lua" | grep -c 'uwsm app -- waybar')" "1"
+check "the install enables the service that starts it, so the profiles are read at login" \
+  "$(sed 's/#.*//' "$REPO/install.sh" | grep -c 'systemctl --user enable hyprsunset.service')" "1"
 
 # --- nothing still calls the file TOML ---------------------------------------
 

--- a/test/hyprsunset-service-test.sh
+++ b/test/hyprsunset-service-test.sh
@@ -109,9 +109,17 @@ exit 1
 STUBEOF
 chmod +x "$STUB"/*
 
+# A fixture unit file, so this does not depend on hyprsunset being installed on
+# whichever machine runs the suite. It was not overridable at first, and the
+# migration exited early on a CI runner with no hyprsunset: ten checks went red
+# there while passing on the machine the bug was found on.
+FIXTURE_UNIT="$TMP/hyprsunset.service"
+printf '[Service]\nExecStart=/usr/bin/hyprsunset\n' >"$FIXTURE_UNIT"
+
 run_migration() {
   local home="$1"
   SYSTEMCTL_LOG="$SLOG" SUNSET_RUNNING="${2-}" SESSION_UP="${3-}" \
+    HYPRSIMPLE_SUNSET_UNIT="${4-$FIXTURE_UNIT}" \
     HOME="$home" HYPRSIMPLE_PATH="$REPO" PATH="$STUB:/usr/bin:/bin" \
     bash "$MIGRATION" >"$TMP/out" 2>&1
 }
@@ -167,12 +175,21 @@ check "while the unit is still enabled, because that half is not theirs" \
   "$(grep -c '^--user enable hyprsunset.service$' "$SLOG")" "1"
 
 # A machine with no hyprsunset installed does nothing at all.
-#
-# The unit path is read out of the migration rather than named here, so this
-# still tests the right thing if that path changes.
-unit_path=$(grep -m1 '^UNIT=' "$MIGRATION" | cut -d= -f2)
-check "the migration checks for a real unit path" \
-  "$([[ $unit_path == /usr/lib/systemd/user/* ]] && echo yes || echo no)" "yes"
+home4="$TMP/home4"
+mkdir -p "$home4/.config/systemd/user"
+: >"$SLOG"
+run_migration "$home4" "" "" "$TMP/no-such-unit"
+check "with hyprsunset not installed, nothing is enabled" \
+  "$(grep -c 'hyprsunset.service' "$SLOG")" "0"
+check "and no drop-in is left behind" \
+  "$([[ -e $home4/.config/systemd/user/hyprsunset.service.d ]] && echo created || echo none)" "none"
+check "and the user is told why" \
+  "$(grep -c 'not installed here' "$TMP/out")" "1"
+
+# The default really is the path the package installs to, or the override above
+# would be testing a path production never uses.
+check "the migration defaults to the packaged unit path" \
+  "$(grep -c 'HYPRSIMPLE_SUNSET_UNIT:-/usr/lib/systemd/user/hyprsunset.service' "$MIGRATION")" "1"
 
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2

--- a/test/hyprsunset-service-test.sh
+++ b/test/hyprsunset-service-test.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Checks that hyprsunset runs as a service rather than an unmanaged scope.
+#
+# It was started by autostart.lua as `uwsm app -- hyprsunset`, which has no
+# restart policy, and hyprsunset does not survive a suspend. Measured across two
+# cycles on one machine: started at login alongside dunst, hypridle and waybar,
+# and the only one of the four gone afterwards, both times. Nothing brought it
+# back, so every profile in hyprsunset.conf stopped applying for the rest of the
+# session.
+#
+# Nothing here talks to systemd or starts hyprsunset. The migration is driven
+# against a fixture home with stubbed systemctl and pkill.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DROPIN="$REPO/default/systemd/hyprsunset-restart.conf"
+AUTOSTART="$REPO/default/hypr/autostart.lua"
+INSTALL="$REPO/install.sh"
+TOGGLE="$REPO/.local/bin/toggle-nightlight.sh"
+MIGRATION="$REPO/migrations/1788780210.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+code() { sed 's/#.*//' "$1"; }
+lua_code() { sed 's/^[[:space:]]*--.*//' "$1"; }
+
+# ---- the drop-in says the thing that makes it worth having -----------------
+#
+# Restart=on-failure is what the packaged unit already has, and it does not
+# cover a clean exit. Verified against systemd on the machine this was found
+# on: a hyprsunset killed with SIGTERM under on-failure stayed dead, and came
+# back under always.
+check "the drop-in raises Restart to always" \
+  "$(grep -c '^Restart=always$' "$DROPIN")" "1"
+check "and sets it under [Service], where systemd reads it" \
+  "$(grep -c '^\[Service\]$' "$DROPIN")" "1"
+# Comments stripped: the file explains what on-failure does not cover.
+check "and does not leave it at on-failure, which the packaged unit already says" \
+  "$(code "$DROPIN" | grep -c 'on-failure')" "0"
+
+# ---- autostart no longer starts it ----------------------------------------
+#
+# Comments stripped, because the file explains at length why it does not.
+check "autostart.lua does not run hyprsunset itself any more" \
+  "$(lua_code "$AUTOSTART" | grep -c 'hyprsunset')" "0"
+check "and stripping the comments leaves its other launches behind" \
+  "$(lua_code "$AUTOSTART" | grep -c 'uwsm app --')" "7"
+
+# ---- install.sh enables the unit and links the drop-in ---------------------
+
+check "install.sh enables hyprsunset.service" \
+  "$(code "$INSTALL" | grep -c 'systemctl --user enable hyprsunset.service')" "1"
+check "and links the drop-in from the install, so an update to it needs no migration" \
+  "$(code "$INSTALL" | grep -c 'default/systemd/hyprsunset-restart.conf')" "1"
+check "and creates the drop-in directory the link goes in" \
+  "$(code "$INSTALL" | grep -c 'mkdir -p .*hyprsunset.service.d"$')" "1"
+check "and reloads systemd, or the drop-in is not read" \
+  "$(code "$INSTALL" | sed -n '/hyprsunset.service.d/,/enable hyprsunset/p' | grep -c 'daemon-reload')" "1"
+# enable, not enable --now: the unit is wanted by graphical-session.target and
+# carries ConditionEnvironment=WAYLAND_DISPLAY, so there is nothing for --now to
+# start from a TTY install. Same reasoning as the battery timer.
+check "and does not use enable --now, which has nothing to start at install time" \
+  "$(code "$INSTALL" | grep -c 'enable --now hyprsunset')" "0"
+
+# ---- the toggle starts it the same way ------------------------------------
+
+check "toggle-nightlight.sh starts the service rather than a bare scope" \
+  "$(code "$TOGGLE" | grep -c 'systemctl --user start hyprsunset.service')" "1"
+check "and no longer launches it through uwsm" \
+  "$(code "$TOGGLE" | grep -c 'uwsm app -- hyprsunset')" "0"
+
+# ---- the migration, driven against a fixture ------------------------------
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+SLOG="$TMP/systemctl-calls"
+
+cat >"$STUB/systemctl" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+# graphical-session.target is up or not, as the test arranges.
+if [[ $* == *"is-active graphical-session.target"* ]]; then
+  [[ -n ${SESSION_UP:-} ]] && exit 0
+  exit 1
+fi
+exit 0
+STUBEOF
+# The handover: the old scope's process goes away when pkill is called.
+cat >"$STUB/pkill" <<'STUBEOF'
+#!/bin/bash
+rm -f "$SUNSET_RUNNING"
+exit 0
+STUBEOF
+cat >"$STUB/pgrep" <<'STUBEOF'
+#!/bin/bash
+[[ -e $SUNSET_RUNNING ]] && exit 0
+exit 1
+STUBEOF
+chmod +x "$STUB"/*
+
+run_migration() {
+  local home="$1"
+  SYSTEMCTL_LOG="$SLOG" SUNSET_RUNNING="${2-}" SESSION_UP="${3-}" \
+    HOME="$home" HYPRSIMPLE_PATH="$REPO" PATH="$STUB:/usr/bin:/bin" \
+    bash "$MIGRATION" >"$TMP/out" 2>&1
+}
+
+# A machine with hyprsunset installed, a live session and the old scope running.
+home1="$TMP/home1"
+mkdir -p "$home1/.config/systemd/user"
+: >"$TMP/sunset-alive"
+: >"$SLOG"
+run_migration "$home1" "$TMP/sunset-alive" up
+
+dropin="$home1/.config/systemd/user/hyprsunset.service.d/10-hyprsimple.conf"
+check "the migration links the drop-in into the session" \
+  "$([[ -L $dropin ]] && echo linked || echo missing)" "linked"
+check "and it points at the install, not a copy" \
+  "$(readlink "$dropin")" "$REPO/default/systemd/hyprsunset-restart.conf"
+check "the unit is enabled" \
+  "$(grep -c '^--user enable hyprsunset.service$' "$SLOG")" "1"
+check "systemd is reloaded, or the drop-in is not read" \
+  "$(grep -c '^--user daemon-reload$' "$SLOG")" "1"
+check "the old scope is stopped, or the unit starts into a held socket" \
+  "$([[ -e $TMP/sunset-alive ]] && echo running || echo stopped)" "stopped"
+check "and the unit is started in its place" \
+  "$(grep -c '^--user start hyprsunset.service$' "$SLOG")" "1"
+check "and the user is told it now restarts itself" \
+  "$(grep -c 'restarts itself' "$TMP/out")" "1"
+
+# The same machine with no session up: enable, start nothing.
+home2="$TMP/home2"
+mkdir -p "$home2/.config/systemd/user"
+: >"$SLOG"
+run_migration "$home2"
+check "with no session up, the unit is still enabled" \
+  "$(grep -c '^--user enable hyprsunset.service$' "$SLOG")" "1"
+check "but nothing is started" \
+  "$(grep -c '^--user start hyprsunset.service$' "$SLOG")" "0"
+check "and the user is told the next login starts it" \
+  "$(grep -c 'next login' "$TMP/out")" "1"
+
+# Someone's own drop-in is not replaced.
+home3="$TMP/home3"
+mkdir -p "$home3/.config/systemd/user/hyprsunset.service.d"
+mine="$home3/.config/systemd/user/hyprsunset.service.d/10-hyprsimple.conf"
+printf '[Service]\nRestart=no\n' >"$mine"
+: >"$SLOG"
+run_migration "$home3"
+check "a real file where the drop-in goes is left alone" \
+  "$([[ -L $mine ]] && echo replaced || echo kept)" "kept"
+check "with its contents untouched" "$(grep -c '^Restart=no$' "$mine")" "1"
+check "and the user is told why, and what to add" \
+  "$(grep -c 'Restart=always' "$TMP/out")" "1"
+check "while the unit is still enabled, because that half is not theirs" \
+  "$(grep -c '^--user enable hyprsunset.service$' "$SLOG")" "1"
+
+# A machine with no hyprsunset installed does nothing at all.
+#
+# The unit path is read out of the migration rather than named here, so this
+# still tests the right thing if that path changes.
+unit_path=$(grep -m1 '^UNIT=' "$MIGRATION" | cut -d= -f2)
+check "the migration checks for a real unit path" \
+  "$([[ $unit_path == /usr/lib/systemd/user/* ]] && echo yes || echo no)" "yes"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/named-paths-test.sh
+++ b/test/named-paths-test.sh
@@ -142,8 +142,13 @@ INSTALL_CODE="$TMP/install.code"
 code_of "$INSTALL" >"$INSTALL_CODE"
 check "stripping comments leaves install.sh's code behind" \
   "$(grep -c '^install_packages()' "$INSTALL_CODE")" "1"
+# systemd/user/hyprsunset.service.d is the drop-in directory the installer
+# creates and links hyprsimple's own file into, the same shape as
+# dunst/dunstrc.d. The file it holds lives in default/, not .config/, so that
+# an update to it reaches every machine without a migration.
 GENERATED="uwsm/env uwsm/env-hyprland btop/themes rofi/hyprsimple hypr/hyprsimple
-  dunst/dunstrc.d hypr/theme-active.lua hypr/theme-hyprlock.conf"
+  dunst/dunstrc.d hypr/theme-active.lua hypr/theme-hyprlock.conf
+  systemd/user/hyprsunset.service.d"
 
 # Both spellings. install.sh writes "$HOME/.config/..." in code and ~/.config/...
 # in the text it prints, and reading only the printed form found a single path,


### PR DESCRIPTION
`autostart.lua` started it as `uwsm app -- hyprsunset`, a scope with no restart policy, and **hyprsunset does not survive a suspend**.

## The evidence

Measured on one machine across two cycles, from the journal:

| time | event |
| --- | --- |
| 11:44:19 | hyprsunset started at login, alongside dunst, hypridle, waybar |
| 13:26:43 | suspend, resumed 16:02:31 |
| — | hyprsunset gone. dunst, hypridle, waybar still running, started 11:44:20 |
| 17:05:14 | hyprsunset started by hand |
| 17:40:51 | suspend, resumed 18:03:51 |
| — | gone again. The same three still up |

Four of five programs started in the same second survive; hyprsunset alone does not, twice. Nothing brings it back, so every profile in `hyprsunset.conf` stops applying for the rest of the session, including the scheduled night profile that file invites you to uncomment.

What I have is the correlation, not the mechanism inside hyprsunset. The fix does not depend on it: whatever ends the process, nothing was watching.

## The fix

The hyprsunset package ships `/usr/lib/systemd/user/hyprsunset.service`, which hyprsimple was not using, sitting next to the `hyprpaper.service` and `hyprpolkitagent.service` it does enable. Those two are also the two that survive.

That unit alone is not enough. Checked against systemd here:

```
Restart=on-failure, killed with SIGTERM  ->  unit=inactive  procs=0
Restart=always,     killed with SIGTERM  ->  unit=active    procs=1
```

hyprsunset leaves cleanly when it loses its output, and `on-failure` does not cover a clean exit. A drop-in raises it to `always`.

- The drop-in is a symlink into the install, like the dunst one, so a later change to it reaches every machine with no migration.
- `enable`, not `enable --now`: the unit is wanted by `graphical-session.target` and carries `ConditionEnvironment=WAYLAND_DISPLAY`, so a TTY install has nothing to start. Same reasoning as the battery timer.
- `toggle-nightlight.sh` starts the service too, rather than making a fresh scope with the same missing restart policy.
- The migration hands over from a running scope rather than waiting for a logout, because the two cannot both hold hyprsunset's socket: a second instance exits immediately, which I confirmed before relying on it.

## Verified on the machine it was found on

```
before: hyprsunset=0  unit=inactive  enabled=disabled
after:  hyprsunset=1  unit=active    enabled=enabled
then:   pkill -x hyprsunset  ->  unit=active  procs=1  answers=6000
```

## Tests

New `test/hyprsunset-service-test.sh`, registered in CI. Nothing talks to systemd or starts hyprsunset: the migration is driven against fixture homes with stubbed `systemctl`, `pgrep` and `pkill`, covering a live session, no session, and someone's own drop-in already in place.

Five sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| drop-in back to `on-failure` | 2 |
| install stops enabling the unit | 1 |
| the migration clobbers a user drop-in | 3 |
| autostart starts it again as well | 2 |
| the migration skips the scope handover | 1 |

Two existing suites asserted the old arrangement and were updated rather than worked around: `hyprsunset-config-test.sh` claimed autostart starts it, and `named-paths-test.sh` needed the drop-in directory in its generated-paths list, the same exemption `dunst/dunstrc.d` already has.

Full sweep run before pushing: 64 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
