### PR TITLE
Do not record the idle dim as the brightness to go back to

### DIFF
--- a/.local/bin/battery-monitor.sh
+++ b/.local/bin/battery-monitor.sh
@@ -72,11 +72,30 @@ if [[ "$BATTERY_STATE" == "discharging" ]]; then
       # otherwise stop the real brightness ever being written and so lose the
       # restore silently.
       recorded=$(cat "$BRIGHTNESS_FILE" 2>/dev/null)
-      if [[ ! $recorded =~ ^[0-9]+$ ]]; then
-        current_brightness() { brightnessctl -m 2>/dev/null | cut -d, -f4 | tr -d '%'; }
-        printf '%s\n' "$(current_brightness)" >"$BRIGHTNESS_FILE"
+      now=$(brightnessctl -m 2>/dev/null | cut -d, -f4 | tr -d '%')
+
+      # A screen already at the dim level has no before value to read.
+      #
+      # hypridle dims to the same 5 after ten minutes idle, through
+      # brightnessctl -s and -r, and it gets there first: its timeout is ten
+      # minutes and the battery falls past a threshold whenever it does. A
+      # crossing during that idle used to record 5 as the brightness to go back
+      # to, and the guard on the restore rejects 5, so the screen stayed at 5
+      # when the charger went in. Traced end to end:
+      #
+      #   80, idle dims to 5, crossing records 5, user returns and hypridle
+      #   restores 80, next crossing dims to 5 again, charging restores nothing.
+      #
+      # Neither recording nor dimming here. The screen is where it needs to be
+      # already, and the value that would be recorded is another program's, not
+      # the user's. The next crossing after hypridle restores reads the real
+      # one.
+      if [[ $now != "$LOW_BATTERY_BRIGHTNESS" ]]; then
+        if [[ ! $recorded =~ ^[0-9]+$ ]]; then
+          printf '%s\n' "$now" >"$BRIGHTNESS_FILE"
+        fi
+        brightnessctl set "${LOW_BATTERY_BRIGHTNESS}"%
       fi
-      brightnessctl set "${LOW_BATTERY_BRIGHTNESS}"%
       notify-send -u critical "Battery Low" "Battery at ${BATTERY_LEVEL}%, brightness reduced to ${LOW_BATTERY_BRIGHTNESS}%"
       echo "$crossed" >"$FLAG_FILE"
     fi

--- a/test/notification-idiom-test.sh
+++ b/test/notification-idiom-test.sh
@@ -175,20 +175,112 @@ fi
 # unreachable, and then every check below returns an empty string and fails
 # with a confusing message instead of skipping.
 if dunstctl count displayed >/dev/null 2>&1; then
+  # Every check below asks about notifications this suite sent, and about
+  # nothing else on the machine.
+  #
+  # This section used to read `dunstctl count displayed`, which counts the whole
+  # stack, so any notification from anything else that landed inside a window
+  # was counted as this suite's. Reproduced deliberately rather than waited for:
+  # with one unrelated notify-send 0.4s into the 1.5s window below, "a critical
+  # notification honours its own -t" read 2 where it wanted 0. That is the flake
+  # that showed up once in a full sweep and would not reproduce on its own.
+  #
+  # Two repairs were tried against a machine sending unrelated notifications
+  # throughout the run, and both broke in their turn:
+  #
+  #   count displayed, differenced around a close by id
+  #     a notification dunst had queued rather than shown read as absent. With
+  #     30 standing, dunst had 19 displayed and 11 waiting.
+  #   displayed plus waiting, differenced the same way
+  #     the total moved between the two reads when something else arrived, so
+  #     the difference came out as -1 rather than 0 or 1.
+  #
+  # Both measured the whole machine and subtracted. dunst offers no way to list
+  # what it is holding, over dunstctl or over its D-Bus interface, so the two
+  # questions here are asked in the two ways it does answer.
+
+  # dunst moves a notification into its history the moment it expires or is
+  # closed, and a live one is not there, so one read of one id says whether
+  # dunst still holds it.
+  held_by_id() {
+    local seen
+    seen=$(dunstctl history |
+      jq --argjson i "$1" '[.data[][] | select(.id.data == $i)] | length')
+    [[ $seen == 0 ]] && printf '1' || printf '0'
+  }
+
+  # How many notifications of one probe dunst is holding. History is the only
+  # listable view, so the probes are closed into it and counted there by an
+  # appname unique to this run and this check, which is what keeps everything
+  # else on the machine out of the number.
+  probe_app() { printf 'hyprsimple-probe-%s-%s' "$$" "$1"; }
+  held_for_app() {
+    dunstctl close-all
+    dunstctl history |
+      jq --arg a "$1" '[.data[][] | select(.appname.data == $a)] | length'
+  }
+
+  # History is a ring, so a long enough burst of other notifications pushes an
+  # entry out of it and these reads would miss a probe that really was there.
+  #
+  # Detected rather than guessed at. A marker is closed into history before each
+  # probe, so it sits older than anything the probe puts there, and eviction
+  # takes the oldest first. A marker still present when the probe is read means
+  # nothing of that age has been dropped and the reading stands. Checked against
+  # dunst rather than against a number, so it does not go stale if
+  # history_length is ever set.
+  mark_history() {
+    local id
+    id=$(notify-send -p -u low -t 1000 --transient "probe" "history marker")
+    dunstctl close "$id" >/dev/null 2>&1
+    printf '%s' "$id"
+  }
+  marker_survives() {
+    [[ $(dunstctl history |
+      jq --argjson i "$1" '[.data[][] | select(.id.data == $i)] | length') != 0 ]]
+  }
+  # Said rather than reported as a product failure, in the same shape as the
+  # timing guard further down.
+  held_check() {
+    local marker="$1"; shift
+    if marker_survives "$marker"; then
+      check "$1" "$2" "$3"
+    else
+      printf 'not ok - inconclusive: dunst evicted a marker from history, so a probe read may have missed one\n' >&2
+      failures=$((failures + 1))
+    fi
+  }
+
+  # The probes have to be able to fail, or every check below reads the same
+  # number for a working dunst and a broken one.
   dunstctl close-all
-  notify-send -u low -t 3000 -r 4242 "probe" "first"
-  notify-send -u low -t 3000 -r 4242 "probe" "second"
-  check "two notify-send with one id display as one notification" \
-    "$(dunstctl count displayed)" "1"
+  canary=$(notify-send -p -u low -t 5000 --transient "probe" "canary")
+  check "a notification just sent reads as held" "$(held_by_id "$canary")" "1"
+  dunstctl close "$canary" >/dev/null 2>&1
+  check "and reads as gone once closed" "$(held_by_id "$canary")" "0"
+
+  # --- one id replaces, two ids accumulate -----------------------------------
+
+  app_r=$(probe_app replace)
+  dunstctl close-all
+  mark_r=$(mark_history)
+  notify-send -a "$app_r" -u low -t 3000 -r 4242 --transient "probe" "first"
+  notify-send -a "$app_r" -u low -t 3000 -r 4242 --transient "probe" "second"
+  held_check "$mark_r" "two notify-send with one id leave dunst holding one notification" \
+    "$(held_for_app "$app_r")" "1"
 
   # Discrimination: the check above is worthless unless the same pair without
-  # -r would actually display two.
+  # -r would actually leave two.
+  app_n=$(probe_app distinct)
   dunstctl close-all
-  notify-send -u low -t 3000 "probe" "first"
-  notify-send -u low -t 3000 "probe" "second"
-  check "the same pair without an id displays as two" \
-    "$(dunstctl count displayed)" "2"
+  mark_n=$(mark_history)
+  notify-send -a "$app_n" -u low -t 3000 --transient "probe" "first"
+  notify-send -a "$app_n" -u low -t 3000 --transient "probe" "second"
+  held_check "$mark_n" "the same pair without an id leaves it holding two" \
+    "$(held_for_app "$app_n")" "2"
 
+  # --- what dunst does with critical urgency ---------------------------------
+  #
   # screen-record.sh sends critical notifications with -t 3000, and dunst
   # documents critical urgency as never expiring by default. It does expire
   # here, because default/dunst/10-hyprsimple.conf sets a global timeout and
@@ -204,40 +296,34 @@ if dunstctl count displayed >/dev/null 2>&1; then
   # Measured in the failing state rather than reasoned about: with the machine
   # idle, an ordinary -t 1000 notification was still displayed after 2 seconds
   # and a transient one was gone, at both critical and low urgency.
-  # These two race a wall clock against dunst's global timeout, so they report
-  # how long they actually took. "critical without -t outlives that window"
-  # failed once during a full sweep and could not be reproduced afterwards in
-  # twelve isolated runs or four more full sweeps. Neither theory survived
-  # testing: no suite restarts the live dunst, and the check held under load.
   #
-  # Rather than guess at a fix for something that would not reproduce, the
-  # window is now measured. If the elapsed time reaches the timeout the check
-  # could not have concluded anything, and it says so instead of reporting the
-  # product as broken. The sleep is also 1s rather than 2.5s, which leaves four
-  # seconds of headroom in a five second window instead of two and a half.
+  # The second races a wall clock against dunst's global timeout, so it reports
+  # how long it actually took. If the elapsed time reaches the timeout the check
+  # could not have concluded anything, and it says so.
   global_timeout_ms=5000
-
   elapsed_ms() { printf '%s' "$(( $(date +%s%3N) - $1 ))"; }
 
   dunstctl close-all
-  notify-send -u critical -t 1000 --transient "probe" "critical honours -t"
+  mark_s=$(mark_history)
+  short=$(notify-send -p -u critical -t 1000 --transient "probe" "critical honours -t")
   sleep 1.5
-  check "a critical notification honours its own -t" \
-    "$(dunstctl count displayed)" "0"
+  held_check "$mark_s" "a critical notification honours its own -t" \
+    "$(held_by_id "$short")" "0"
 
   dunstctl close-all
+  mark_l=$(mark_history)
   started=$(date +%s%3N)
-  notify-send -u critical --transient "probe" "critical without -t outlives it"
+  long=$(notify-send -p -u critical --transient "probe" "critical without -t outlives it")
   sleep 1
-  displayed=$(dunstctl count displayed)
+  still_held=$(held_by_id "$long")
   took=$(elapsed_ms "$started")
   if (( took >= global_timeout_ms )); then
-    printf 'not ok - inconclusive: reading the count took %sms, past the %sms timeout\n' \
+    printf 'not ok - inconclusive: reading the state took %sms, past the %sms timeout\n' \
       "$took" "$global_timeout_ms" >&2
     failures=$((failures + 1))
   else
-    check "a critical notification without -t outlives that window ($((took))ms of ${global_timeout_ms}ms)" \
-      "$displayed" "1"
+    held_check "$mark_l" "a critical notification without -t outlives that window (${took}ms of ${global_timeout_ms}ms)" \
+      "$still_held" "1"
   fi
   dunstctl close-all
 else

--- a/test/screenshot-and-battery-test.sh
+++ b/test/screenshot-and-battery-test.sh
@@ -308,6 +308,38 @@ run_at 9
 check "and so is a record that is not a number" \
   "$(cat "$BF" 2>/dev/null)" "80"
 
+# hypridle dims to the same level, and gets there first: its brightness
+# listener fires after ten minutes idle, and a battery falls past a threshold
+# whenever it does. A crossing during that idle used to read the screen at 5
+# and record 5 as the brightness to go back to, and the restore rejects 5, so
+# the charger went in and the screen stayed dark. This is the whole sequence.
+
+rm -f "$FLAG" "$BF"; : >"$NLOG"; : >"$BLOG"; printf '80' >"$LEVEL"
+printf '5' >"$LEVEL"                       # hypridle has dimmed it
+run_at 19
+check "a crossing while the screen is already dim records nothing" \
+  "$([[ -f $BF ]] && cat "$BF" || echo none)" "none"
+check "and issues no brightness command, because it is already there" \
+  "$(grep -c 'set 5%' "$BLOG")" "0"
+check "while still announcing the low battery" \
+  "$(grep -c 'Battery Low' "$NLOG")" "1"
+
+printf '80' >"$LEVEL"                      # hypridle restores on activity
+run_at 14
+check "the next crossing after that restore records the real brightness" \
+  "$(cat "$BF" 2>/dev/null)" "80"
+check "and dims" "$(level)" "5"
+
+run_at 40 charging
+check "so the charger puts the screen back rather than leaving it dark" \
+  "$(level)" "80"
+
+# The same shape when the user chose 5 themselves rather than hypridle.
+rm -f "$FLAG" "$BF"; : >"$NLOG"; : >"$BLOG"; printf '5' >"$LEVEL"
+run_at 9
+check "a screen the user set to the dim level is not recorded either" \
+  "$([[ -f $BF ]] && cat "$BF" || echo none)" "none"
+
 # The script must not use the save slot hypridle uses for its idle dim, or the
 # two overwrite each other.
 # Comments stripped before counting. The script explains in a comment why it
@@ -322,6 +354,18 @@ check "and stripping comments leaves its real calls behind" \
   "$(script_code "$BIN/battery-monitor.sh" | grep -c 'brightnessctl set')" "2"
 check "while hypridle still uses that slot for idle" \
   "$(grep -c 'brightnessctl -s' "$REPO/default/hypr/hypridle/20-brightness.conf")" "1"
+
+# The premise of the checks above: hypridle really does dim to the same number
+# the battery monitor uses. If it ever dims to something else, those checks stop
+# describing a collision and this one says so.
+idle_level=$(grep -oE 'brightnessctl -s set [0-9]+' \
+  "$REPO/default/hypr/hypridle/20-brightness.conf" | grep -oE '[0-9]+$')
+monitor_level=$(sed 's/#.*//' "$BIN/battery-monitor.sh" |
+  grep -oE '^LOW_BATTERY_BRIGHTNESS=[0-9]+' | cut -d= -f2)
+check "and dims to the same level the battery monitor does, which is why they collide" \
+  "$idle_level" "$monitor_level"
+check "and that level was really read out of both files" \
+  "$([[ -n $idle_level && -n $monitor_level ]] && echo yes || echo no)" "yes"
 
 # Restore the plain stubs for anything after this point.
 cat >"$STUB/brightnessctl" <<'STUBEOF'


### PR DESCRIPTION
`battery-monitor.sh` reads the screen before dimming, so charging can put it back. That was #116.

hypridle dims to the **same 5**, through `brightnessctl -s` and `-r`:

```
# default/hypr/hypridle/20-brightness.conf
timeout = 600                        # 10min
on-timeout = brightnessctl -s set 5
on-resume  = brightnessctl -r
```

And it gets there first: its timeout is ten minutes, and a battery on a laptop left idle falls past a threshold whenever it does. A crossing during that idle read the screen at 5 and recorded **5** as the value to restore. The restore rejects 5, deliberately, so the record was useless.

## Traced end to end

With stubs, before the fix:

```
1. on battery, screen 80                 -> screen=80  record=none
2. idle: hypridle saves 80, dims         -> screen=5   record=none
3. crossing 20% while idle               -> screen=5   record=5      <- poisoned
4. user returns, hypridle restores       -> screen=80  record=5
5. falls past 15%                        -> screen=5   record=5
6. charger in                            -> screen=5   record=none   <- stuck dark
```

Step 6 is the bug #116 was written to fix, reached by another route. The record it depends on was taken while another program held the screen.

After the fix, same sequence:

```
3. crossing 20% while idle               -> screen=5   record=none
5. falls past 15% (after hypridle restored 80) -> screen=5  record=80
6. charger in                            -> screen=80  record=none
```

## The fix

A screen already at the dim level is neither recorded nor dimmed. There is no before value to read there, the value that would be recorded belongs to another program rather than the user, and the screen is already where the battery monitor wants it. The next crossing after hypridle restores reads the real one.

The low battery notification still fires, because that is about the battery rather than the screen.

The same held when the user set 5 themselves, with the same outcome for the same reason, and the same fix covers it.

## Tests

Seven checks in `test/screenshot-and-battery-test.sh`, walking the whole six-step sequence rather than asserting the guard in isolation, plus the user-set case.

Two premise checks read the dim level out of **both** files and assert they are equal, since the collision is the entire reason this fix exists. If hypridle is ever pointed at a different level, those fail rather than the sequence checks quietly stopping to describe anything real.

Two sabotages, both red:

| sabotage | checks failed |
| --- | --- |
| record and dim regardless of the current level | 5 |
| hypridle dims to 7 instead of 5 | 1, on the premise check |

Full sweep before pushing: 64 suites. CI's own shellcheck invocation reproduced locally, clean.

---

# Second commit: the flake in `notification-idiom-test.sh`

Its live-dunst section counted with `dunstctl count displayed`, which counts every notification on the machine, so anything arriving inside a window was counted as this suite's. That is the flake that turned up once in a full sweep and would not reproduce on its own.

## Reproduced rather than waited for

With one unrelated `notify-send` 0.4s into the 1.5s window, "a critical notification honours its own -t" read **2** where it wanted 0.

Against one unrelated notification per second for the length of the run:

| version | result |
| --- | --- |
| before | failed 5 runs out of 5 |
| after | passed 5 runs out of 5 |

## Why it took three attempts

dunst offers no way to list what it is holding, over `dunstctl` or over its D-Bus interface. Two repairs were tried under the same noise and both broke:

| attempt | how it broke |
| --- | --- |
| `count displayed`, differenced around a close by id | a notification dunst had *queued* rather than shown read as absent. With 30 standing, dunst had 19 displayed and 11 waiting |
| displayed plus waiting, differenced the same way | the total moved between the two reads when something else arrived, so the difference came out as `-1` rather than 0 or 1 |

Both measured the whole machine and subtracted. The version here asks only about notifications this suite sent:

- **Is one still held**: read from its absence from history, by id. dunst moves a notification to history the moment it expires or is closed, so one read of one id answers it, and nothing else on the machine can change that answer.
- **How many did a probe leave**: counted in history by an appname unique to this run and this check.

A replaced notification is not pushed to history, which was checked before relying on it.

## The eviction guard

History is a ring, so a long enough burst pushes an entry out and a probe read would miss one that really was there. A marker is closed into history before each probe, older than anything the probe puts there, and eviction takes the oldest first. If the marker is gone at read time, the check says it could not conclude instead of reporting dunst as broken. Checked against dunst rather than against a number, so it does not go stale if `history_length` is ever set.

## Tests

Four sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the second send stops reusing the id | 1 |
| the control pair reuses one id, losing discrimination | 1 |
| the `-t` probe is no longer transient | 1 |
| the id probe always answers "held" | 2 |

