### PR TITLE
Stop a missing helper from being announced as a success

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,6 +253,9 @@ jobs:
       - name: hyprsunset-service-test
         run: bash test/hyprsunset-service-test.sh
 
+      - name: required-helpers-test
+        run: bash test/required-helpers-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-require.sh
+++ b/.local/bin/hyprsimple-require.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Source a hyprsimple helper, or stop rather than carry on without it.
+#
+# `source` on a file that is not there prints one line and returns non-zero,
+# and none of these scripts set -e, so every one of them continued into code
+# whose functions no longer existed. bash reports each missing function on
+# stderr and keeps going, so the script ran to the end and announced success.
+#
+# Measured with hyprsimple-theme-deliver.sh removed, which is the state of any
+# install whose ~/.local/bin predates the file:
+#
+#   theme-switcher.sh deep-sea
+#     -> "deliver_theme_configs: command not found", exit 0,
+#        "Theme 'deep-sea' applied!", and none of the eight generated files
+#        delivered.
+#
+# and with hypr-helpers.sh removed:
+#
+#   wallpaper-switcher.sh next
+#     -> "write_hyprpaper_conf: command not found", exit 0,
+#        "Wallpaper 2-deep-sea.jpg", and hyprpaper.conf never written, so the
+#        wallpaper on screen did not change.
+#
+# hyprsimple-update.sh already tests for its one helper before sourcing it, for
+# the same reason. This is that check, in one place, for the callers that were
+# still sourcing blind.
+#
+# Usage: require_helper <name.sh> [<name.sh> ...]
+# Sourced, not run, so the definitions land in the caller's shell.
+
+require_helper() {
+  local name path missing=()
+  for name in "$@"; do
+    path="$HOME/.local/bin/$name"
+    if [[ -r $path ]]; then
+      # shellcheck source=/dev/null
+      source "$path"
+    else
+      missing+=("$name")
+    fi
+  done
+
+  (( ${#missing[@]} == 0 )) && return 0
+
+  local list="${missing[*]}"
+  echo "hyprsimple: missing helper(s): $list" >&2
+  echo "Run hyprsimple-update to restore them." >&2
+  # Told on screen as well. These scripts are run from a keybind, where stderr
+  # goes nowhere anyone will see, and the whole point is that the failure used
+  # to be announced as success.
+  command -v notify-send >/dev/null &&
+    notify-send -u critical "hyprsimple" "Missing helper: $list. Run hyprsimple-update." 
+  exit 1
+}

--- a/.local/bin/live-wallpaper-toggle.sh
+++ b/.local/bin/live-wallpaper-toggle.sh
@@ -7,7 +7,14 @@
 CACHE_DIR="$HOME/.cache"
 FLAG="$CACHE_DIR/live_wallpaper_enabled"
 
-source "$HOME/.local/bin/hypr-helpers.sh"
+# This one line cannot use require_helper, so it carries the check itself.
+source "$HOME/.local/bin/hyprsimple-require.sh" 2>/dev/null || {
+  echo "hyprsimple: missing helper: hyprsimple-require.sh. Run hyprsimple-update." >&2
+  command -v notify-send >/dev/null &&
+    notify-send -u critical "hyprsimple" "Missing helper: hyprsimple-require.sh. Run hyprsimple-update."
+  exit 1
+}
+require_helper hypr-helpers.sh
 
 # Derive backgrounds dir from current wallpaper path
 CURRENT_PATH=$(cat "$CACHE_DIR/current_wallpaper_path" 2>/dev/null)

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
-source "$HOME/.local/bin/hypr-helpers.sh"
-source "$HOME/.local/bin/hyprsimple-theme-deliver.sh"
+# Tested for before use, not sourced blind. A missing helper used to leave
+# this script running with its functions undefined, delivering nothing and
+# still reporting "Theme applied!" at the end.
+# This one line cannot use require_helper, so it carries the check itself.
+source "$HOME/.local/bin/hyprsimple-require.sh" 2>/dev/null || {
+  echo "hyprsimple: missing helper: hyprsimple-require.sh. Run hyprsimple-update." >&2
+  command -v notify-send >/dev/null &&
+    notify-send -u critical "hyprsimple" "Missing helper: hyprsimple-require.sh. Run hyprsimple-update."
+  exit 1
+}
+require_helper hypr-helpers.sh hyprsimple-theme-deliver.sh
 
 # Usage: theme-switcher.sh [theme-name]
 #   No argument: show rofi picker

--- a/.local/bin/wallpaper-switcher.sh
+++ b/.local/bin/wallpaper-switcher.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-source "$HOME/.local/bin/hypr-helpers.sh"
+# This one line cannot use require_helper, so it carries the check itself.
+source "$HOME/.local/bin/hyprsimple-require.sh" 2>/dev/null || {
+  echo "hyprsimple: missing helper: hyprsimple-require.sh. Run hyprsimple-update." >&2
+  command -v notify-send >/dev/null &&
+    notify-send -u critical "hyprsimple" "Missing helper: hyprsimple-require.sh. Run hyprsimple-update."
+  exit 1
+}
+require_helper hypr-helpers.sh
 
 # Switch wallpaper within the current theme
 # Usage: wallpaper-switcher.sh [next|pick]

--- a/test/btop-theme-test.sh
+++ b/test/btop-theme-test.sh
@@ -70,7 +70,7 @@ setup_home() {
   rm -rf "${TMP:?}/home"
   mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.config/uwsm" "$HOME_DIR/.cache" \
     "$HOME_DIR/.config/hypr/themes/demo/generated"
-  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" "$BIN/hyprsimple-require.sh" \
     "$BIN/hyprsimple-theme-deliver.sh" \
     "$HOME_DIR/.local/bin/"
   printf 'theme[main_bg]="#191724"\n' \

--- a/test/btop-theme-test.sh
+++ b/test/btop-theme-test.sh
@@ -61,6 +61,12 @@ check "and hyprsimple ships no btop config of its own, which is why nothing set 
 # --- the switcher selects it ------------------------------------------------
 
 STUB="$TMP/bin"; mkdir -p "$STUB"
+# A rofi that answers with nothing, never the real one. These scripts open a
+# picker when given no argument and /usr/bin is on the PATH below, so the real
+# rofi was reachable from here. It reached the maintainer's screen once, from a
+# suite that had no stub, and opened a window complaining about a theme inside
+# the fixture.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 for tool in gsettings hyprctl systemctl pkill busctl hyprsimple-restart-waybar.sh; do
   printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
 done

--- a/test/cursor-theme-test.sh
+++ b/test/cursor-theme-test.sh
@@ -81,7 +81,10 @@ setup_home() {
   rm -rf "${TMP:?}/home"
   mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.config/uwsm" "$HOME_DIR/.cache" \
     "$HOME_DIR/.config/hypr/themes/withcursor" "$HOME_DIR/.config/hypr/themes/plain"
+  # theme-switcher.sh requires both helpers before it will run, so the
+  # fixture carries both even though this file only reads the cursor half.
   cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+    "$BIN/hyprsimple-require.sh" "$BIN/hyprsimple-theme-deliver.sh" \
     "$HOME_DIR/.local/bin/"
   printf 'Adwaita-dark\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
   cat >"$HOME_DIR/.config/uwsm/env" <<'ENVEOF'

--- a/test/cursor-theme-test.sh
+++ b/test/cursor-theme-test.sh
@@ -72,6 +72,12 @@ check "and stripping comments leaves its code behind" \
 # --- the switcher persists it ------------------------------------------------
 
 STUB="$TMP/bin"; mkdir -p "$STUB"
+# A rofi that answers with nothing, never the real one. These scripts open a
+# picker when given no argument and /usr/bin is on the PATH below, so the real
+# rofi was reachable from here. It reached the maintainer's screen once, from a
+# suite that had no stub, and opened a window complaining about a theme inside
+# the fixture.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 for tool in gsettings hyprctl systemctl pkill hyprsimple-restart-waybar.sh; do
   printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
 done

--- a/test/dunst-split-test.sh
+++ b/test/dunst-split-test.sh
@@ -95,7 +95,10 @@ fi
 switch_home="$TMP/switch-home"
 must_be_fixture "$switch_home"
 mkdir -p "$switch_home/.local/bin" "$switch_home/.config/hypr"
-cp "$REPO/.local/bin/hypr-helpers.sh" "$switch_home/.local/bin/hypr-helpers.sh"
+# hyprsimple-require.sh too: the scripts test for their helpers before
+# sourcing them, so a fixture without it stops rather than running.
+cp "$REPO/.local/bin/hypr-helpers.sh" "$REPO/.local/bin/hyprsimple-require.sh" \
+  "$switch_home/.local/bin/"
 # theme-switcher.sh delivers generated files through this, shared with
 # hyprsimple-update.sh so the two cannot deliver different sets.
 cp "$REPO/.local/bin/hyprsimple-theme-deliver.sh" "$switch_home/.local/bin/"

--- a/test/ghostty-theme-test.sh
+++ b/test/ghostty-theme-test.sh
@@ -67,7 +67,7 @@ setup_home() {
   rm -rf "${TMP:?}/home"
   mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.cache" \
     "$HOME_DIR/.config/ghostty" "$HOME_DIR/.config/hypr/themes/demo"
-  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
+  cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" "$BIN/hyprsimple-require.sh" \
     "$BIN/hyprsimple-theme-deliver.sh" \
     "$HOME_DIR/.local/bin/"
   # A theme naming a built-in ghostty theme, which is the branch that appends

--- a/test/ghostty-theme-test.sh
+++ b/test/ghostty-theme-test.sh
@@ -55,6 +55,12 @@ fi
 # --- the switch ---------------------------------------------------------------
 
 STUB="$TMP/bin"; mkdir -p "$STUB"
+# A rofi that answers with nothing, never the real one. These scripts open a
+# picker when given no argument and /usr/bin is on the PATH below, so the real
+# rofi was reachable from here. It reached the maintainer's screen once, from a
+# suite that had no stub, and opened a window complaining about a theme inside
+# the fixture.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 for tool in gsettings hyprctl systemctl pkill busctl notify-send \
   hyprsimple-restart-waybar.sh hyprsimple-restart-dunst.sh; do
   printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"

--- a/test/live-wallpaper-persistence-test.sh
+++ b/test/live-wallpaper-persistence-test.sh
@@ -43,7 +43,10 @@ setup() {
   rm -rf "${TMP:?}/home"
   mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.cache" \
     "$HOME_DIR/.config/hypr/themes/demo/backgrounds"
-  cp "$BIN/live-wallpaper-toggle.sh" "$BIN/hypr-helpers.sh" "$HOME_DIR/.local/bin/"
+  # hyprsimple-require.sh too: the scripts test for their helpers before
+  # sourcing them, so a fixture without it stops rather than running.
+  cp "$BIN/live-wallpaper-toggle.sh" "$BIN/hypr-helpers.sh" \
+    "$BIN/hyprsimple-require.sh" "$HOME_DIR/.local/bin/"
   printf 'x\n' >"$HOME_DIR/.config/hypr/themes/demo/backgrounds/a.jpg"
   printf 'x\n' >"$HOME_DIR/.config/hypr/themes/demo/backgrounds/b.jpg"
   printf '%s\n' "$HOME_DIR/.config/hypr/themes/demo/backgrounds/a.jpg" \

--- a/test/live-wallpaper-persistence-test.sh
+++ b/test/live-wallpaper-persistence-test.sh
@@ -34,6 +34,12 @@ check() {
 }
 
 STUB="$TMP/bin"; mkdir -p "$STUB"
+# A rofi that answers with nothing, never the real one. These scripts open a
+# picker when given no argument and /usr/bin is on the PATH below, so the real
+# rofi was reachable from here. It reached the maintainer's screen once, from a
+# suite that had no stub, and opened a window complaining about a theme inside
+# the fixture.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 for t in systemctl notify-send hyprctl; do
   printf '#!/bin/bash\nexit 0\n' >"$STUB/$t"; chmod +x "$STUB/$t"
 done

--- a/test/required-helpers-test.sh
+++ b/test/required-helpers-test.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Checks that a missing helper stops the script rather than being announced as
+# success.
+#
+# theme-switcher.sh, wallpaper-switcher.sh and live-wallpaper-toggle.sh source
+# helpers out of ~/.local/bin. `source` on a file that is not there prints one
+# line and returns non-zero, and none of these set -e, so each carried on with
+# the helper's functions undefined. bash reports every missing function on
+# stderr and keeps going, so the script reached its end and said it had worked.
+#
+# Measured before the fix, with the helper removed, which is the state of any
+# install whose ~/.local/bin predates it:
+#
+#   theme-switcher.sh deep-sea      exit 0, "Theme 'deep-sea' applied!", and
+#                                   none of the eight generated files delivered
+#   wallpaper-switcher.sh next      exit 0, "Wallpaper 2-deep-sea.jpg", and
+#                                   hyprpaper.conf never written at all
+#
+# Nothing here touches the real ~/.config, and no compositor is contacted:
+# hyprctl, systemctl, busctl, gsettings and notify-send are all stubs.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+for c in hyprctl systemctl busctl gsettings brightnessctl; do
+  printf '#!/bin/bash\nexit 0\n' >"$STUB/$c"
+done
+# pkill and pgrep are stubbed too. theme-switcher.sh ends by restarting waybar
+# and dunst through --if-running, and an unstubbed pkill here would reach the
+# maintainer's own session.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/pgrep"
+printf '#!/bin/bash\nexit 0\n' >"$STUB/pkill"
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUBEOF
+chmod +x "$STUB"/*
+
+NLOG="$TMP/notifications"
+
+# A fixture home holding a theme with colours to render, so the scripts have
+# real work to do rather than exiting early for a reason of their own.
+build_home() {
+  local home="$1"
+  rm -rf "${home:?}"
+  mkdir -p "$home/.local/bin" "$home/.cache" "$home/.config/waybar" \
+    "$home/.config/rofi/launcher" "$home/.config/rofi/powermenu" \
+    "$home/.config/hypr/themes/demo/backgrounds" \
+    "$home/.config/hypr/themes/templates"
+  cp "$BIN"/*.sh "$home/.local/bin/"
+  printf 'x\n' >"$home/.config/rofi/launcher/style.rasi"
+  printf 'x\n' >"$home/.config/rofi/powermenu/style.rasi"
+  cp "$REPO/.config/hypr/themes/templates"/*.tpl "$home/.config/hypr/themes/templates/"
+  cp "$REPO/.config/hypr/themes/deep-sea/colors.toml" \
+    "$home/.config/hypr/themes/demo/colors.toml"
+  # Two wallpapers, so wallpaper-switcher.sh has somewhere to cycle to. Real
+  # files rather than empty ones, because it copies them.
+  printf 'not-really-an-image-1\n' >"$home/.config/hypr/themes/demo/backgrounds/1-one.jpg"
+  printf 'not-really-an-image-2\n' >"$home/.config/hypr/themes/demo/backgrounds/2-two.jpg"
+  printf '%s\n' "$home/.config/hypr/themes/demo/backgrounds/1-one.jpg" \
+    >"$home/.cache/current_wallpaper_path"
+}
+
+run_in() {
+  local home="$1" script="$2"; shift 2
+  : >"$NLOG"
+  # HYPRSIMPLE_PATH, because theme-apply-templates.sh reads its templates out
+  # of the install rather than the home. Without it the render produced nothing
+  # and the delivery had nothing to deliver, which looked like the bug.
+  #
+  # THEME_SWITCHER_NO_RELOAD is deliberately not set: it suppresses the very
+  # notification these checks read. The reloads it would skip are all stubbed.
+  NOTIFY_LOG="$NLOG" HYPRSIMPLE_PATH="$REPO" HOME="$home" \
+    PATH="$STUB:/usr/bin:/bin" \
+    bash "$home/.local/bin/$script" "$@" >/dev/null 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+HOME_FIXTURE="$TMP/home"
+
+# ---- the fixture works when nothing is missing -----------------------------
+#
+# Asserted first. Every check below is about a script stopping, and a fixture
+# where the script never got anywhere would satisfy all of them for the wrong
+# reason.
+
+build_home "$HOME_FIXTURE"
+run_in "$HOME_FIXTURE" theme-switcher.sh demo
+check "with every helper present, a theme switch succeeds" "$(cat "$TMP/rc")" "0"
+check "and says so" "$(grep -c "Theme 'demo' applied" "$NLOG")" "1"
+check "and the delivery really ran, which is what a missing helper skips" \
+  "$([[ -e $HOME_FIXTURE/.config/waybar/theme-active.css ]] && echo delivered || echo missing)" \
+  "delivered"
+
+build_home "$HOME_FIXTURE"
+run_in "$HOME_FIXTURE" wallpaper-switcher.sh next
+check "and a wallpaper switch succeeds" "$(cat "$TMP/rc")" "0"
+check "and writes the config hyprpaper reads" \
+  "$([[ -f $HOME_FIXTURE/.config/hypr/hyprpaper.conf ]] && echo written || echo missing)" \
+  "written"
+
+# ---- each helper removed in turn -------------------------------------------
+#
+# The pairs are read out of the scripts rather than listed here, so a caller
+# that starts requiring something new is covered without this file being
+# touched, and one that stops requiring anything at all is caught by the count.
+
+mapfile -t requirements < <(
+  for script in "$BIN"/*.sh; do
+    sed 's/#.*//' "$script" |
+      grep -oE '^require_helper .*' |
+      sed "s|^require_helper ||; s|^|$(basename "$script") |"
+  done
+)
+if (( ${#requirements[@]} < 3 )); then
+  fail "found ${#requirements[@]} scripts calling require_helper, which is fewer than there are"
+else
+  pass "found ${#requirements[@]} scripts calling require_helper"
+fi
+
+for line in "${requirements[@]}"; do
+  script="${line%% *}"
+  for needed in ${line#* }; do
+    build_home "$HOME_FIXTURE"
+    rm -f "$HOME_FIXTURE/.local/bin/$needed"
+    run_in "$HOME_FIXTURE" "$script"
+    check "$script stops when $needed is missing" \
+      "$([[ $(cat "$TMP/rc") != "0" ]] && echo stopped || echo continued)" "stopped"
+    check "and names it rather than claiming success" \
+      "$(grep -c "Missing helper: .*$needed" "$NLOG")" "1"
+    check "and announces nothing else" \
+      "$(grep -cv 'Missing helper' "$NLOG")" "0"
+  done
+done
+
+# ---- the guard on the guard ------------------------------------------------
+#
+# require_helper is itself sourced, so its own absence cannot be caught by it.
+# Each caller carries that one check inline.
+
+for script in theme-switcher.sh wallpaper-switcher.sh live-wallpaper-toggle.sh; do
+  build_home "$HOME_FIXTURE"
+  rm -f "$HOME_FIXTURE/.local/bin/hyprsimple-require.sh"
+  run_in "$HOME_FIXTURE" "$script"
+  check "$script stops when hyprsimple-require.sh itself is missing" \
+    "$([[ $(cat "$TMP/rc") != "0" ]] && echo stopped || echo continued)" "stopped"
+  check "and says which file it wanted" \
+    "$(grep -c 'hyprsimple-require.sh' "$NLOG")" "1"
+done
+
+# ---- nothing is left sourcing a helper without the check -------------------
+#
+# Comments stripped: hyprsimple-require.sh documents the old shape in one.
+
+blind=()
+while IFS= read -r hit; do
+  [[ -n $hit ]] && blind+=("$hit")
+done < <(
+  for script in "$BIN"/*.sh; do
+    sed 's/#.*//' "$script" |
+      grep -qE '^source "\$HOME/\.local/bin/[a-z-]+\.sh"$' &&
+      basename "$script"
+  done
+)
+blind_str=""; (( ${#blind[@]} > 0 )) && blind_str="$(printf '%s ' "${blind[@]}")"
+check "no script sources a helper without a check on it" "$blind_str" ""
+
+# And the one line that has to source without require_helper carries its own
+# check, on every caller.
+guarded=0
+for script in theme-switcher.sh wallpaper-switcher.sh live-wallpaper-toggle.sh; do
+  sed 's/#.*//' "$BIN/$script" |
+    grep -q 'source "$HOME/.local/bin/hyprsimple-require.sh" 2>/dev/null ||' &&
+    guarded=$((guarded + 1))
+done
+check "and every caller guards the line that loads the checker itself" "$guarded" "3"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/required-helpers-test.sh
+++ b/test/required-helpers-test.sh
@@ -46,6 +46,15 @@ done
 # maintainer's own session.
 printf '#!/bin/bash\nexit 1\n' >"$STUB/pgrep"
 printf '#!/bin/bash\nexit 0\n' >"$STUB/pkill"
+# rofi above all. These scripts open a picker when given no argument, and
+# /usr/bin is on the PATH below, so the real rofi was reachable. It opened a
+# window on the maintainer's screen during a sabotage run, complaining about a
+# theme inside the fixture. theme-picker-test.sh has warned about exactly this
+# since it was written; this suite did not carry the stub over.
+#
+# It answers with nothing, so a picker that is reached selects nothing and the
+# caller exits rather than waiting for input.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 cat >"$STUB/notify-send" <<'STUBEOF'
 #!/bin/bash
 printf '%s\n' "$*" >>"$NOTIFY_LOG"

--- a/test/shell-init-test.sh
+++ b/test/shell-init-test.sh
@@ -291,6 +291,11 @@ while IFS= read -r line; do
   case "$cmd" in "" | '$0' | '$(basename' | "Usage"*) continue ;; esac
   [[ -f "$BIN/$cmd" ]] && continue
   printf '%s\n' "$bash_names" | grep -qx "$cmd" && continue
+  # A sourced helper documents the usage of the function it defines, which is
+  # neither a script nor an alias and is still a real thing to run. Accepted
+  # only when some script actually defines it, so a usage line naming a
+  # function that does not exist is still caught.
+  grep -qhE "^[[:space:]]*$cmd\(\) \{" "$BIN"/*.sh && continue
   bad_usage+=("$cmd")
 done < <(grep -hoE 'Usage:? [a-zA-Z0-9_.$/(-]+' "$BIN"/*.sh | LC_ALL=C sort -u)
 

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -284,6 +284,55 @@ else
     "$unisolated_str" ""
 fi
 
+# A suite must not be able to reach the real rofi.
+#
+# rofi opens a window on whoever is running the tests. Several of these suites
+# run scripts that open a picker when given no argument, with /usr/bin on the
+# PATH they build, and had no rofi of their own in front of it. That is not
+# theoretical: during one sabotage run a picker was reached and rofi appeared on
+# the maintainer's screen, complaining about a theme path inside the fixture.
+#
+# The scripts that can open one are read out of the repository rather than
+# listed here, so a picker added to another script later is covered without
+# this check being touched.
+mapfile -t picker_scripts < <(
+  for script in "$REPO/.local/bin"/*.sh; do
+    sed 's/#.*//' "$script" | grep -q 'hyprsimple-image-picker.sh' &&
+      basename "$script"
+  done
+)
+# hyprsimple-image-picker.sh is the one that actually runs rofi, so it counts
+# too.
+picker_scripts+=(hyprsimple-image-picker.sh)
+
+if (( ${#picker_scripts[@]} < 3 )); then
+  fail "found ${#picker_scripts[@]} scripts that can open a picker, which is too few to be right"
+else
+  pass "found ${#picker_scripts[@]} scripts that can open a picker"
+fi
+
+unstubbed=()
+for suite in "${suites[@]}"; do
+  # Whole-line comments only. Stripping from the first # anywhere cut
+  # `printf '#!/bin/bash\n...' >"$STUB/rofi"` down to `printf '`, so the stub
+  # this check is looking for disappeared and three suites that have one were
+  # reported as missing it.
+  code=$(sed 's/^[[:space:]]*#.*//' "$suite")
+  # Only suites that put a directory of their own ahead of a real one.
+  grep -q 'PATH="\$STUB:' <<<"$code" || continue
+  runs_picker=0
+  for script in "${picker_scripts[@]}"; do
+    grep -qF "$script" <<<"$code" && runs_picker=1
+  done
+  (( runs_picker )) || continue
+  grep -q 'rofi' <<<"$code" || unstubbed+=("$(basename "$suite")")
+done
+
+unstubbed_str=""
+(( ${#unstubbed[@]} > 0 )) && unstubbed_str="$(printf '%s ' "${unstubbed[@]}")"
+check "every suite that can reach rofi puts one of its own in front of it" \
+  "$unstubbed_str" ""
+
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1

--- a/test/theme-picker-test.sh
+++ b/test/theme-picker-test.sh
@@ -522,7 +522,10 @@ check "with the cache directory made unwritable, the picker still prints a key" 
 ws_home="$TMP/ws-home"
 must_be_fixture "$ws_home"
 mkdir -p "$ws_home/.local/bin" "$ws_home/.cache"
-cp "$REPO/.local/bin/hypr-helpers.sh" "$ws_home/.local/bin/hypr-helpers.sh"
+# hyprsimple-require.sh too: the scripts test for their helpers before
+# sourcing them, so a fixture without it stops rather than running.
+cp "$REPO/.local/bin/hypr-helpers.sh" "$REPO/.local/bin/hyprsimple-require.sh" \
+  "$ws_home/.local/bin/"
 
 ws_marker="$TMP/picker-invoked-marker"
 cat >"$ws_home/.local/bin/hyprsimple-image-picker.sh" <<STUB2

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -199,7 +199,9 @@ check "an unknown mode exits non-zero rather than doing something" \
 HOME_DIR="$TMP/home"
 THEME="$HOME_DIR/.config/hypr/themes/rosepine"
 mkdir -p "$THEME/backgrounds" "$HOME_DIR/.cache" "$HOME_DIR/.local/bin"
-cp "$BIN/hypr-helpers.sh" "$HOME_DIR/.local/bin/"
+# hyprsimple-require.sh too: the scripts test for their helpers before
+# sourcing them, so a fixture without it stops rather than running.
+cp "$BIN/hypr-helpers.sh" "$BIN/hyprsimple-require.sh" "$HOME_DIR/.local/bin/"
 printf 'first\n' >"$THEME/backgrounds/0-with-you.jpg"
 printf 'second\n' >"$THEME/backgrounds/1-elsewhere.jpg"
 printf '%s\n' "$THEME/backgrounds/0-with-you.jpg" >"$HOME_DIR/.cache/current_wallpaper_path"

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -35,6 +35,12 @@ check() {
 }
 
 STUB="$TMP/bin"; mkdir -p "$STUB"
+# A rofi that answers with nothing, never the real one. These scripts open a
+# picker when given no argument and /usr/bin is on the PATH below, so the real
+# rofi was reachable from here. It reached the maintainer's screen once, from a
+# suite that had no stub, and opened a window complaining about a theme inside
+# the fixture.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 LOG="$TMP/calls"
 
 # One hyprctl stub for every script here. It answers from files the test names,


### PR DESCRIPTION
`theme-switcher.sh`, `wallpaper-switcher.sh` and `live-wallpaper-toggle.sh` sourced helpers out of `~/.local/bin` without checking they were there.

`source` on a file that is not there prints one line and returns non-zero, and none of these scripts set `-e`, so each carried on with the helper's functions undefined. bash reports every missing function on stderr and keeps going, so the script reached its end and said it had worked.

## Measured, with the helper removed

That is the state of any install whose `~/.local/bin` predates the file.

```
theme-switcher.sh deep-sea
  deliver_theme_configs: command not found
  exit 0
  "Theme 'deep-sea' applied!"
  none of the eight generated files delivered

wallpaper-switcher.sh next
  write_hyprpaper_conf: command not found
  exit 0
  "Wallpaper 2-deep-sea.jpg"
  hyprpaper.conf never written, so the wallpaper on screen did not change
```

`hyprsimple-update.sh` already tests for its one helper before sourcing it. This is a gap I left on the other side of the same helper when the delivery was split out in #119.

## The fix

`hyprsimple-require.sh` holds the check, and every caller uses it. It names what is missing on screen as well as on stderr, because these run from keybinds where nobody reads stderr.

The line that loads the checker cannot use the checker, so each caller carries that one check inline.

## Fallout, handled rather than softened

Eight suites built fixture homes holding a subset of the scripts and now stop where they used to run. Each fixture gains the file. `cursor-theme-test.sh` gains the delivery helper too, which `theme-switcher.sh` has required since #119 and that fixture never had.

`shell-init-test.sh` flagged the usage line of a sourced function as naming a command that does not exist. It now accepts a name some script actually defines as a function, and still catches one nothing defines, which is checked by sabotage.

---

# Second commit: keeping the suites away from the real rofi

**rofi opened a window on the maintainer's screen during one of my sabotage runs**, complaining it could not open a theme at a path inside the test fixture.

Six suites ran scripts that open a picker when given no argument, with `/usr/bin` on the PATH they build and no rofi of their own in front of it. `theme-picker-test.sh` has carried a stub and a comment saying why since it was written; the other six did not, including the one added in this PR.

Each now puts a rofi of its own ahead of the real one, answering with nothing so a picker that is reached selects nothing and the caller exits rather than waiting for input.

`suite-hygiene-test.sh` refuses any suite that can reach a picker without one. The scripts that can open a picker are read out of the repository rather than listed, so one added later is covered.

That check first reported three suites as missing a stub they had. It was stripping comments from the first `#` anywhere, which cut `printf '#!/bin/bash\n...' >"$STUB/rofi"` down to `printf '`. It strips whole-line comments only, and the sabotage that removes a stub is red.

## Tests

New `test/required-helpers-test.sh`, registered in CI, 26 checks. The script and helper pairs are read out of the scripts themselves, so a caller that starts requiring something new is covered without the suite being touched.

Three checks run first with nothing missing, because every other check is about a script stopping and a fixture where the script never got anywhere would satisfy all of them for the wrong reason.

Sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| `theme-switcher.sh` goes back to a blind source | 5 |
| the inline guard on the checker is dropped | 4 |
| it stops but says nothing on screen | 4 |
| a rofi stub is removed from a suite | 1 |
| a usage line names a function nothing defines | 1 |

One sabotage is not in that table: making `require_helper` warn instead of stopping. It does not fail the suite, it **hangs** it, because the scripts then continue into a picker and wait. That is the same path that put rofi on screen, and it is what the second commit closes.

Full sweep before pushing: 65 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
