### PR TITLE
Write the GTK settings.ini that theme switches only pretended to update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -259,6 +259,9 @@ jobs:
       - name: rofi-wallpaper-rule-test
         run: bash test/rofi-wallpaper-rule-test.sh
 
+      - name: gtk-settings-test
+        run: bash test/gtk-settings-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -112,11 +112,67 @@ fi
 gsettings set org.gnome.desktop.interface gtk-theme "$GTK_THEME_NAME"
 
 # Update gtk-3.0 and gtk-4.0 settings.ini (some apps read these instead of gsettings)
+#
+# This used to be a mkdir followed by `[[ -f settings.ini ]] && sed`, and
+# nothing in hyprsimple has ever created settings.ini. So the mkdir made the
+# directory, the test then failed, and the block wrote nothing on every theme
+# switch. Measured on a live machine: ~/.config/gtk-3.0 and ~/.config/gtk-4.0
+# both present and both empty, on an install that had switched themes many
+# times. The apps the comment above is about were reading nothing.
+#
+# Three cases, because the file belongs to the user when it exists:
+#   absent          write a minimal one
+#   has the key     replace that line, keeping the rest
+#   lacks the key   add it under [Settings], keeping the rest
+set_gtk_theme_name() {
+  local file="$1" name="$2"
+
+  if [[ ! -f $file ]]; then
+    printf '[Settings]\ngtk-theme-name=%s\n' "$name" >"$file"
+    return 0
+  fi
+
+  # Section aware, because settings.ini is an ini file and the key only counts
+  # under [Settings]. A first attempt matched ^gtk-theme-name= anywhere, which
+  # rewrote one sitting under a later section and left [Settings] without the
+  # key. That is the same unanchored-match mistake this file just had in its
+  # rofi rewrite.
+  local tmp="$file.hyprsimple.$$"
+  awk -v name="$name" '
+    /^[[:space:]]*\[/ {
+      # Leaving [Settings] without having seen the key: add it here.
+      if (in_settings && !done) { print "gtk-theme-name=" name; done = 1 }
+      in_settings = ($0 ~ /^[[:space:]]*\[Settings\][[:space:]]*$/)
+      if (in_settings) seen_settings = 1
+      print
+      next
+    }
+    in_settings && /^[[:space:]]*gtk-theme-name[[:space:]]*=/ {
+      if (!done) { print "gtk-theme-name=" name; done = 1 }
+      next
+    }
+    { print }
+    END {
+      if (!done) {
+        if (in_settings) print "gtk-theme-name=" name
+        else if (!seen_settings) { print ""; print "[Settings]"; print "gtk-theme-name=" name }
+      }
+    }
+  ' "$file" >"$tmp" || { rm -f "$tmp"; return 0; }
+
+  # A [Settings] section that ended before EOF and got no key would leave the
+  # file without one. awk above adds it on the section boundary, so this only
+  # guards the case where awk wrote nothing at all.
+  if [[ -s $tmp ]]; then
+    mv -f "$tmp" "$file"
+  else
+    rm -f "$tmp"
+  fi
+}
+
 for gtk_dir in "$HOME/.config/gtk-3.0" "$HOME/.config/gtk-4.0"; do
   mkdir -p "$gtk_dir"
-  if [[ -f "$gtk_dir/settings.ini" ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$GTK_THEME_NAME/" "$gtk_dir/settings.ini"
-  fi
+  set_gtk_theme_name "$gtk_dir/settings.ini" "$GTK_THEME_NAME"
 done
 
 # Icon theme (icons.theme = omarchy style, icon-theme = hyprsimple style)

--- a/migrations/1788793000.sh
+++ b/migrations/1788793000.sh
@@ -1,0 +1,41 @@
+echo "Write the GTK settings.ini that theme switches never created"
+
+# theme-switcher.sh has always ended with
+#
+#   mkdir -p "$gtk_dir"
+#   [[ -f "$gtk_dir/settings.ini" ]] && sed -i "s/^gtk-theme-name=.*/.../"
+#
+# under a comment saying some apps read these instead of gsettings. Nothing in
+# hyprsimple has ever created settings.ini, so the mkdir made the directory,
+# the test then failed, and the block wrote nothing on every theme switch.
+# Measured on a live install that had switched themes many times:
+# ~/.config/gtk-3.0 and ~/.config/gtk-4.0 both present and both empty.
+#
+# theme-switcher.sh writes the file now, but only when a theme is next
+# switched, which may be never. This writes it once from the theme already in
+# force, so the apps that read it stop disagreeing with the rest of the desktop.
+#
+# Only when the file is absent. A settings.ini that exists is the user's, and
+# the next theme switch edits just the one key in it.
+
+wrote=0
+theme=$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'")
+
+if [[ -z $theme ]]; then
+  echo "  Could not read the current GTK theme, so nothing was written."
+  exit 0
+fi
+
+for gtk_dir in "$HOME/.config/gtk-3.0" "$HOME/.config/gtk-4.0"; do
+  settings="$gtk_dir/settings.ini"
+  [[ -e $settings ]] && continue
+  mkdir -p "$gtk_dir"
+  printf '[Settings]\ngtk-theme-name=%s\n' "$theme" >"$settings"
+  wrote=$((wrote + 1))
+done
+
+if (( wrote > 0 )); then
+  echo "  Wrote $wrote settings.ini naming $theme. Your next theme switch keeps them in step."
+else
+  echo "  Both settings.ini files already exist, so they were left alone."
+fi

--- a/test/gtk-settings-test.sh
+++ b/test/gtk-settings-test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Checks that a theme switch writes gtk-theme-name into settings.ini, and that
+# the migration writes the file for installs that never had one.
+#
+# theme-switcher.sh has always ended with
+#
+#   mkdir -p "$gtk_dir"
+#   [[ -f "$gtk_dir/settings.ini" ]] && sed -i "s/^gtk-theme-name=.*/.../"
+#
+# under a comment saying some apps read these instead of gsettings. Nothing in
+# hyprsimple has ever created settings.ini, so the mkdir made the directory,
+# the test then failed, and the block wrote nothing on every theme switch.
+# Measured on a live install that had switched themes many times:
+# ~/.config/gtk-3.0 and ~/.config/gtk-4.0 both present and both empty.
+#
+# Nothing here touches the real ~/.config and no rofi is reachable.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+SWITCHER="$BIN/theme-switcher.sh"
+MIGRATION="$REPO/migrations/1788793000.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+# ---- the writer, taken out of the shipped script ---------------------------
+#
+# Extracted rather than copied, so these exercise what ships. If the function
+# is renamed or removed the extraction comes up empty and says so.
+FUNC="$TMP/set_gtk_theme_name.sh"
+awk '/^set_gtk_theme_name\(\) \{/,/^\}$/' "$SWITCHER" >"$FUNC"
+if ! grep -q '^set_gtk_theme_name() {' "$FUNC" || ! grep -q '^}$' "$FUNC"; then
+  fail "could not read set_gtk_theme_name out of theme-switcher.sh"
+  printf '\n1 check(s) failed\n' >&2
+  exit 1
+fi
+pass "read set_gtk_theme_name out of theme-switcher.sh"
+# shellcheck source=/dev/null
+source "$FUNC"
+
+W="$TMP/work"; mkdir -p "$W"
+
+# absent
+set_gtk_theme_name "$W/absent.ini" Adwaita-dark
+check "an absent settings.ini is created" \
+  "$([[ -f $W/absent.ini ]] && echo written || echo missing)" "written"
+check "with a [Settings] header" "$(grep -c '^\[Settings\]$' "$W/absent.ini")" "1"
+check "and the theme name under it" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$W/absent.ini")" "1"
+
+# key already there
+printf '[Settings]\ngtk-font-name=Sans 11\ngtk-theme-name=Old\ngtk-cursor-theme-name=Bibata\n' \
+  >"$W/haskey.ini"
+set_gtk_theme_name "$W/haskey.ini" Adwaita
+check "an existing key is replaced" "$(grep -c '^gtk-theme-name=Adwaita$' "$W/haskey.ini")" "1"
+check "and not duplicated" "$(grep -c '^gtk-theme-name=' "$W/haskey.ini")" "1"
+check "and the user's other settings are kept" \
+  "$(grep -c -e '^gtk-font-name=Sans 11$' -e '^gtk-cursor-theme-name=Bibata$' "$W/haskey.ini")" "2"
+
+# [Settings] present, key absent
+printf '[Settings]\ngtk-font-name=Sans 11\n' >"$W/nokey.ini"
+set_gtk_theme_name "$W/nokey.ini" Adwaita-dark
+check "a file with [Settings] and no key gains one" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$W/nokey.ini")" "1"
+check "and keeps what was there" "$(grep -c '^gtk-font-name=Sans 11$' "$W/nokey.ini")" "1"
+
+# no [Settings] at all
+printf '# my notes\n' >"$W/nosection.ini"
+set_gtk_theme_name "$W/nosection.ini" Adwaita-dark
+check "a file with no [Settings] gains the section" \
+  "$(grep -c '^\[Settings\]$' "$W/nosection.ini")" "1"
+check "and the key" "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$W/nosection.ini")" "1"
+check "and the user's line survives" "$(grep -c '^# my notes$' "$W/nosection.ini")" "1"
+
+# A key under a different section is not the one GTK reads, and is not ours.
+#
+# The first version of this function matched ^gtk-theme-name= anywhere, so it
+# rewrote the one under [Other] and left [Settings] without a key. That is the
+# same unanchored-match mistake theme-switcher.sh had in its rofi rewrite.
+printf '[Settings]\ngtk-font-name=Sans\n\n[Other]\ngtk-theme-name=Wrong\n' >"$W/sections.ini"
+set_gtk_theme_name "$W/sections.ini" Adwaita-dark
+check "a key under another section is left alone" \
+  "$(grep -c '^gtk-theme-name=Wrong$' "$W/sections.ini")" "1"
+check "and [Settings] gets its own" \
+  "$(awk '/^\[Settings\]/{s=1;next} /^\[/{s=0} s && /^gtk-theme-name=Adwaita-dark$/{n++} END{print n+0}' "$W/sections.ini")" "1"
+
+# Running twice must not stack lines up.
+set_gtk_theme_name "$W/nokey.ini" Adwaita
+set_gtk_theme_name "$W/nokey.ini" Adwaita-dark
+check "switching themes repeatedly leaves exactly one key" \
+  "$(grep -c '^gtk-theme-name=' "$W/nokey.ini")" "1"
+check "holding the last value asked for" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$W/nokey.ini")" "1"
+
+# ---- the caller really uses it ---------------------------------------------
+#
+# Comments stripped, because the block explains the old shape in one.
+code() { sed 's/#.*//' "$1"; }
+check "theme-switcher.sh calls it for both GTK directories" \
+  "$(code "$SWITCHER" | grep -c 'set_gtk_theme_name "\$gtk_dir/settings.ini"')" "1"
+check "inside a loop over gtk-3.0 and gtk-4.0" \
+  "$(code "$SWITCHER" | grep -c 'for gtk_dir in .*gtk-3.0.*gtk-4.0')" "1"
+check "and no longer skips the file when it is absent" \
+  "$(code "$SWITCHER" | grep -c 'if \[\[ -f "\$gtk_dir/settings.ini" \]\]')" "0"
+
+# ---- the migration ---------------------------------------------------------
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+# A heredoc, not a printf. Building this stub with nested printf quoting ate
+# the %s and wrote a script that printed an empty line, so the migration read
+# no theme and four checks failed for a reason that had nothing to do with it.
+cat >"$STUB/gsettings" <<'STUBEOF'
+#!/bin/bash
+echo "'Adwaita-dark'"
+STUBEOF
+chmod +x "$STUB/gsettings"
+
+# A rofi of its own, ahead of the real one. This suite only greps
+# theme-switcher.sh rather than running it, so nothing here reaches a picker
+# today, but the stub directory below is what would be in front if that ever
+# changed. suite-hygiene-test.sh requires it of any suite that names a
+# picker-capable script, and being conservative there costs one line.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
+chmod +x "$STUB/rofi"
+
+run_migration() {
+  HOME="$1" PATH="$STUB:/usr/bin:/bin" bash "$MIGRATION" >"$TMP/out" 2>&1
+}
+
+h1="$TMP/h1"; mkdir -p "$h1"
+run_migration "$h1"
+check "the migration writes gtk-3.0/settings.ini when it is absent" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$h1/.config/gtk-3.0/settings.ini" 2>/dev/null)" "1"
+check "and gtk-4.0" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$h1/.config/gtk-4.0/settings.ini" 2>/dev/null)" "1"
+check "and says how many it wrote" "$(grep -c 'Wrote 2 settings.ini' "$TMP/out")" "1"
+
+run_migration "$h1"
+check "running it again writes nothing" "$(grep -c 'already exist' "$TMP/out")" "1"
+
+h2="$TMP/h2"; mkdir -p "$h2/.config/gtk-3.0" "$h2/.config/gtk-4.0"
+printf '[Settings]\ngtk-font-name=Mine\n' >"$h2/.config/gtk-3.0/settings.ini"
+printf '[Settings]\ngtk-font-name=Mine\n' >"$h2/.config/gtk-4.0/settings.ini"
+run_migration "$h2"
+check "an existing settings.ini is not rewritten by the migration" \
+  "$(cat "$h2/.config/gtk-3.0/settings.ini")" "$(printf '[Settings]\ngtk-font-name=Mine')"
+
+# gsettings unreachable: write nothing rather than a made up theme name.
+cat >"$STUB/gsettings" <<'STUBEOF'
+#!/bin/bash
+exit 1
+STUBEOF
+chmod +x "$STUB/gsettings"
+h3="$TMP/h3"; mkdir -p "$h3"
+run_migration "$h3"
+check "with no readable GTK theme, nothing is written" \
+  "$([[ -e $h3/.config/gtk-3.0/settings.ini ]] && echo written || echo none)" "none"
+check "and the migration says why" \
+  "$(grep -c 'Could not read the current GTK theme' "$TMP/out")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
`theme-switcher.sh` ended with:

```bash
# Update gtk-3.0 and gtk-4.0 settings.ini (some apps read these instead of gsettings)
for gtk_dir in "$HOME/.config/gtk-3.0" "$HOME/.config/gtk-4.0"; do
  mkdir -p "$gtk_dir"
  if [[ -f "$gtk_dir/settings.ini" ]]; then
    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$GTK_THEME_NAME/" "$gtk_dir/settings.ini"
  fi
done
```

**Nothing in hyprsimple has ever created `settings.ini`.** So the `mkdir` made the directory, the `-f` test then failed, and the block wrote nothing on every theme switch. The `mkdir` existed only so the check could fail.

## Measured

On a live install that had switched themes many times:

```
~/.config/gtk-3.0   present, empty
~/.config/gtk-4.0   present, empty
```

and nothing in the repository ships or writes that file:

```
$ grep -rn 'settings.ini' .local/bin install.sh migrations .config default
theme-switcher.sh:114   # Update gtk-3.0 and gtk-4.0 settings.ini (some apps read these...)
theme-switcher.sh:117   if [[ -f "$gtk_dir/settings.ini" ]]; then
theme-switcher.sh:118     sed -i ...
$ find . -name settings.ini
(nothing)
```

The apps that comment is about were reading nothing, on every install.

## The fix

Three cases, because the file belongs to the user when it exists:

| state | action |
| --- | --- |
| absent | write a minimal one |
| has `gtk-theme-name=` | replace that line, keep the rest |
| lacks it | add it under `[Settings]`, creating the section if the file has none |

**Section aware**, because `settings.ini` is an ini file and the key only counts under `[Settings]`. My first attempt matched `^gtk-theme-name=` anywhere, rewrote one sitting under a later section and left `[Settings]` without a key. That is the same unanchored-match mistake this file had in its rofi rewrite one commit ago, so it is checked here.

A migration writes the file once from the theme already in force, so an install that never switches theme again is not left waiting. Only when the file is absent, and nothing is written when the current theme cannot be read rather than a name being invented.

## Tests

New `test/gtk-settings-test.sh`, registered in CI, 24 checks.

The writer is **extracted out of `theme-switcher.sh`** and sourced, rather than copied into the suite, so the cases exercise what ships. If it is renamed the extraction comes up empty and the suite says so instead of testing a stale copy.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| back to the old skip-when-absent shape | 2 |
| the writer stops being section aware | 1 |
| the migration overwrites a file the user already has | 2 |

One fixture fault of my own is worth recording: the `gsettings` stub was built with nested `printf` quoting that ate its `%s`, so it printed an empty line and four migration checks failed for a reason that had nothing to do with the migration. It is a heredoc now, with a comment saying why.

`suite-hygiene-test.sh` also flagged the new suite for naming `theme-switcher.sh` without a rofi stub in front of its PATH. It only greps that script rather than running it, but the guard is right to be conservative and the stub costs one line.

Full sweep before pushing: 67 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
