### PR TITLE
Stop two themes naming cursors that are not installed

### DIFF
--- a/.config/hypr/themes/catppuccin/cursor-theme
+++ b/.config/hypr/themes/catppuccin/cursor-theme
@@ -1,1 +1,1 @@
-catppuccin-mocha-lavender-cursors
+Adwaita

--- a/.config/hypr/themes/rosepine/cursor-theme
+++ b/.config/hypr/themes/rosepine/cursor-theme
@@ -1,1 +1,1 @@
-Adwaita-dark
+Adwaita

--- a/.config/hypr/themes/rosepine/icon-theme
+++ b/.config/hypr/themes/rosepine/icon-theme
@@ -1,1 +1,0 @@
-rose-pine-icons

--- a/.local/bin/theme-switcher.sh
+++ b/.local/bin/theme-switcher.sh
@@ -195,8 +195,39 @@ set_session_env() {
   mv "$tmp" "$file"
 }
 
+# A cursor theme is a directory with a cursors/ subdirectory in one of the
+# icon paths. Anything else is a name, not a theme.
+#
+# Checked because nothing else does. hyprctl setcursor answers "ok" for a theme
+# that is not installed, and gsettings stores whatever it is given, so two
+# shipped themes carried values that had never worked and nothing reported it:
+# catppuccin asked for catppuccin-mocha-lavender-cursors, which is in no
+# package list and no repository, and rosepine asked for Adwaita-dark, which is
+# a GTK theme name rather than a cursor theme. The only cursor themes on a
+# hyprsimple machine are Adwaita and Yaru.
+#
+# It matters past the switch: XCURSOR_THEME is written to uwsm/env and read at
+# every login, so a name that resolves to nothing outlives the theme that set
+# it, which is the opposite of what that export is for.
+cursor_theme_exists() {
+  local name="$1" dir
+  for dir in "$HOME/.local/share/icons" "$HOME/.icons" /usr/share/icons; do
+    [[ -d $dir/$name/cursors ]] && return 0
+  done
+  return 1
+}
+
 if [[ -f "$THEME_PATH/cursor-theme" ]]; then
   CURSOR="$(cat "$THEME_PATH/cursor-theme")"
+fi
+
+if [[ -n ${CURSOR:-} ]] && ! cursor_theme_exists "$CURSOR"; then
+  echo "theme-switcher: cursor theme '$CURSOR' is not installed, leaving the cursor alone" >&2
+  notify-send "Theme Manager" "Cursor theme '$CURSOR' is not installed, so the cursor was left as it is" >/dev/null 2>&1
+  CURSOR=""
+fi
+
+if [[ -n ${CURSOR:-} ]]; then
   gsettings set org.gnome.desktop.interface cursor-theme "$CURSOR"
   [[ -z "$THEME_SWITCHER_NO_RELOAD" ]] && hyprctl setcursor "$CURSOR" 24
 

--- a/test/btop-theme-test.sh
+++ b/test/btop-theme-test.sh
@@ -67,7 +67,10 @@ STUB="$TMP/bin"; mkdir -p "$STUB"
 # suite that had no stub, and opened a window complaining about a theme inside
 # the fixture.
 printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
-for tool in gsettings hyprctl systemctl pkill busctl hyprsimple-restart-waybar.sh; do
+# notify-send among them. theme-switcher.sh notifies on success and warns when
+# a theme names a cursor that is not installed, and an unstubbed one reaches the
+# desktop of whoever is running the tests.
+for tool in gsettings hyprctl systemctl pkill busctl hyprsimple-restart-waybar.sh notify-send; do
   printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
 done
 

--- a/test/cursor-theme-test.sh
+++ b/test/cursor-theme-test.sh
@@ -19,8 +19,13 @@
 # sixteen shipped themes have one at all. So XCURSOR_THEME was unset on a fresh
 # install, and switching to catppuccin or rosepine, which do declare a cursor,
 # did not set it either. Confirmed on the maintainer's machine: active theme
-# rosepine, which declares Adwaita-dark, and XCURSOR_THEME unset in the running
-# session.
+# rosepine, and XCURSOR_THEME unset in the running session.
+#
+# Both of those declared values were themselves wrong, found later: catppuccin
+# named catppuccin-mocha-lavender-cursors and rosepine named Adwaita-dark,
+# neither of which is an installed cursor theme. They name Adwaita now, and
+# theme-switcher.sh refuses one with no cursors/ directory rather than passing
+# it to hyprctl, which answers "ok" either way.
 #
 # uwsm carries XCURSOR_THEME in UWSM_FINALIZE_VARNAMES, so the variable is the
 # mechanism this setup already expects.
@@ -78,7 +83,10 @@ STUB="$TMP/bin"; mkdir -p "$STUB"
 # suite that had no stub, and opened a window complaining about a theme inside
 # the fixture.
 printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
-for tool in gsettings hyprctl systemctl pkill hyprsimple-restart-waybar.sh; do
+# notify-send among them. theme-switcher.sh warns when a theme names a cursor
+# that is not installed, and this suite drives exactly that case, so without a
+# stub the warning went to the maintainer's own desktop. It did, once.
+for tool in gsettings hyprctl systemctl pkill hyprsimple-restart-waybar.sh notify-send; do
   printf '#!/bin/bash\nexit 0\n' >"$STUB/$tool"; chmod +x "$STUB/$tool"
 done
 
@@ -92,7 +100,14 @@ setup_home() {
   cp "$BIN/theme-switcher.sh" "$BIN/hypr-helpers.sh" "$BIN/theme-apply-templates.sh" \
     "$BIN/hyprsimple-require.sh" "$BIN/hyprsimple-theme-deliver.sh" \
     "$HOME_DIR/.local/bin/"
-  printf 'Adwaita-dark\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+  printf 'FixtureCursor\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+  # A real cursor theme inside the fixture home. theme-switcher.sh refuses a
+  # cursor theme with no cursors/ directory now, because two shipped themes
+  # named ones nothing installs and nothing reported it: hyprctl setcursor
+  # answers "ok" either way. A fixture naming a theme that does not exist would
+  # exercise that refusal instead of the export these checks are about.
+  mkdir -p "$HOME_DIR/.local/share/icons/FixtureCursor/cursors"
+  mkdir -p "$HOME_DIR/.local/share/icons/OtherCursor/cursors"
   cat >"$HOME_DIR/.config/uwsm/env" <<'ENVEOF'
 export XCURSOR_SIZE=24
 export GDK_BACKEND="wayland,x11,*"
@@ -110,24 +125,24 @@ check "the fixture starts with no XCURSOR_THEME" \
 
 switch_to withcursor
 check "switching to a theme that declares a cursor writes XCURSOR_THEME" \
-  "$(env_file | grep -c '^export XCURSOR_THEME=Adwaita-dark$')" "1"
+  "$(env_file | grep -c '^export XCURSOR_THEME=FixtureCursor$')" "1"
 check "and the rest of the file is kept" \
   "$(env_file | grep -c 'XCURSOR_SIZE\|GDK_BACKEND')" "2"
 
 # The file is read once at login, so a second export would win silently and the
 # file would grow a line per switch.
-printf 'Bibata-Original-Classic\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+printf 'OtherCursor\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
 switch_to withcursor
 check "switching again replaces the line rather than appending one" \
   "$(env_file | grep -c '^export XCURSOR_THEME=')" "1"
 check "and it holds the new value" \
-  "$(env_file | grep -c '^export XCURSOR_THEME=Bibata-Original-Classic$')" "1"
+  "$(env_file | grep -c '^export XCURSOR_THEME=OtherCursor$')" "1"
 
 # A theme with no cursor-theme file leaves the setting alone, which is what
 # gsettings and setcursor already did. Changing that is a separate decision.
 switch_to plain
 check "a theme that declares no cursor leaves the value alone" \
-  "$(env_file | grep -c '^export XCURSOR_THEME=Bibata-Original-Classic$')" "1"
+  "$(env_file | grep -c '^export XCURSOR_THEME=OtherCursor$')" "1"
 
 # The two runtime paths still happen, so this is not a swap of one mechanism
 # for another.
@@ -146,6 +161,85 @@ check "a home with no uwsm/env still switches theme without error" \
   "$([[ -e $HOME_DIR/.config/uwsm/env ]] && echo created || echo absent)" "absent"
 check "and leaves no temporary file behind" \
   "$(find "$HOME_DIR/.config/uwsm" -name 'env.tmp.*' | wc -l | tr -d ' ')" "0"
+
+# ---- a cursor theme that is not installed is refused --------------------------
+#
+# hyprctl setcursor answers "ok" for a theme that does not exist and gsettings
+# stores whatever it is given, so nothing ever reported that two shipped themes
+# named cursors nothing installs: catppuccin asked for
+# catppuccin-mocha-lavender-cursors, in no package list and no repository, and
+# rosepine asked for Adwaita-dark, which is a GTK theme name. Measured on a live
+# machine, the only directories with a cursors/ subdirectory were Adwaita and
+# Yaru.
+#
+# It outlives the switch: XCURSOR_THEME goes into uwsm/env and is read at every
+# login, so a name resolving to nothing persists past the theme that set it.
+#
+# Its own setup_home, because the section above deletes uwsm/env and these need
+# a previous value to show is left standing.
+setup_home
+switch_to withcursor
+check "the fixture starts with a cursor theme that does exist" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=FixtureCursor$')" "1"
+
+printf 'NoSuchCursorTheme\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+switch_to withcursor
+check "a cursor theme with no cursors directory is not exported" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=NoSuchCursorTheme$')" "0"
+check "and the previous value is left standing rather than cleared" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=FixtureCursor$')" "1"
+
+# A directory without cursors/ inside it is a name, not a cursor theme. That is
+# exactly the shape of rosepine's Adwaita-dark, which exists as a GTK theme name
+# and never as a cursor theme.
+mkdir -p "$HOME_DIR/.local/share/icons/NotACursorTheme"
+printf 'NotACursorTheme\n' >"$HOME_DIR/.config/hypr/themes/withcursor/cursor-theme"
+switch_to withcursor
+check "an icon directory with no cursors subdirectory is refused too" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=NotACursorTheme$')" "0"
+
+# And the refusal is not blanket: adding the subdirectory makes it acceptable.
+mkdir -p "$HOME_DIR/.local/share/icons/NotACursorTheme/cursors"
+switch_to withcursor
+check "and accepted once it has one, so the check is about cursors/ and not the name" \
+  "$(env_file | grep -c '^export XCURSOR_THEME=NotACursorTheme$')" "1"
+
+# ---- every shipped theme names a cursor theme that could exist ---------------
+#
+# Read out of the repository rather than listed here. On a machine with the
+# icon packages installed this checks they are really there; on one without, it
+# checks the value at least looks like a cursor theme rather than a GTK theme.
+
+shipped_cursors=()
+while IFS= read -r file; do
+  shipped_cursors+=("$(basename "$(dirname "$file")"):$(cat "$file")")
+done < <(find "$REPO/.config/hypr/themes" -maxdepth 2 -name cursor-theme | sort)
+
+if (( ${#shipped_cursors[@]} == 0 )); then
+  fail "no theme ships a cursor-theme file, so this check reads nothing"
+else
+  pass "found ${#shipped_cursors[@]} theme(s) declaring a cursor"
+fi
+
+missing=()
+for entry in "${shipped_cursors[@]}"; do
+  name="${entry#*:}"
+  found=no
+  for dir in "$HOME/.local/share/icons" "$HOME/.icons" /usr/share/icons; do
+    [[ -d $dir/$name/cursors ]] && found=yes
+  done
+  [[ $found == no ]] && missing+=("$entry")
+done
+
+if (( ${#missing[@]} > 0 )) && [[ ! -d /usr/share/icons/Adwaita/cursors ]]; then
+  # No cursor themes installed at all, which is a CI runner. Saying so rather
+  # than reporting every theme as broken.
+  pass "no cursor themes are installed here, so the shipped names are not checked"
+else
+  missing_str=""
+  (( ${#missing[@]} > 0 )) && missing_str="$(printf '%s ' "${missing[@]}")"
+  check "every shipped theme names a cursor theme that is installed" "$missing_str" ""
+fi
 
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -333,6 +333,45 @@ unstubbed_str=""
 check "every suite that can reach rofi puts one of its own in front of it" \
   "$unstubbed_str" ""
 
+# The same for notify-send, and for the same reason.
+#
+# A notification from a test lands on the desktop of whoever is running it.
+# theme-switcher.sh gained a warning for a cursor theme that is not installed,
+# cursor-theme-test.sh drives exactly that case, and the warning reached the
+# maintainer's screen because that suite stubbed gsettings and hyprctl and not
+# notify-send.
+#
+# The scripts that notify are read out of the repository, so one that starts
+# notifying later is covered without this check being touched.
+mapfile -t notifying < <(
+  for script in "$REPO/.local/bin"/*.sh; do
+    sed 's/^[[:space:]]*#.*//' "$script" | grep -q 'notify-send' &&
+      basename "$script"
+  done
+)
+
+if (( ${#notifying[@]} < 5 )); then
+  fail "found ${#notifying[@]} scripts that notify, which is too few to be right"
+else
+  pass "found ${#notifying[@]} scripts that send notifications"
+fi
+
+noisy=()
+for suite in "${suites[@]}"; do
+  code=$(sed 's/^[[:space:]]*#.*//' "$suite")
+  grep -q 'PATH="\$STUB:' <<<"$code" || continue
+  runs_notifier=0
+  for script in "${notifying[@]}"; do
+    grep -qE "bash [^|;&]*$script" <<<"$code" && runs_notifier=1
+  done
+  (( runs_notifier )) || continue
+  grep -q 'notify-send' <<<"$code" || noisy+=("$(basename "$suite")")
+done
+
+noisy_str=""
+(( ${#noisy[@]} > 0 )) && noisy_str="$(printf '%s ' "${noisy[@]}")"
+check "every suite that runs a notifying script stubs notify-send" "$noisy_str" ""
+
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
Two of the sixteen shipped themes declare a cursor theme. Both named one that does not exist.

| theme | declared | reality |
| --- | --- | --- |
| `catppuccin` | `catppuccin-mocha-lavender-cursors` | in no package list and no repository |
| `rosepine` | `Adwaita-dark` | a GTK theme name, not a cursor theme |

On a live machine the only directories with a `cursors/` subdirectory are `Adwaita` and `Yaru`. `Adwaita-dark` is not among the icon directories at all, and `/usr/share/icons/Adwaita/cursors/../index.theme` says `Name=Adwaita`.

## Why nothing reported it

Measured directly:

```
$ hyprctl setcursor catppuccin-mocha-lavender-cursors 24
ok
$ echo $?
0
```

`hyprctl setcursor` accepts a theme that does not exist and answers `ok`. `gsettings` stores whatever it is given. So both mechanisms reported success about a value that could never work.

It also outlives the switch. `XCURSOR_THEME` is written to `uwsm/env` and read at every login, so a name resolving to nothing persists past the theme that set it, which is the opposite of what that export was added for.

## The fix

- Both themes name `Adwaita`.
- `theme-switcher.sh` checks for a `cursors/` subdirectory before applying, and says so instead of setting a value that cannot work.
- `rosepine/icon-theme` is dropped. It named `rose-pine-icons`, and the same theme ships `icons.theme` which the code prefers, so that file has never been read.

## Tests

Ten checks added to `test/cursor-theme-test.sh`. The refusal is exercised in both shapes that occurred: a name with no directory at all, and a directory with no `cursors/` inside it, which is exactly `Adwaita-dark`. A third check adds the subdirectory and confirms the value is then accepted, so the refusal is about `cursors/` and not about the name.

A separate check reads every shipped `cursor-theme` file out of the repository and requires the theme to be installed, skipping loudly on a machine with no cursor themes at all, which is what a CI runner is.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the validation is removed | 3 |
| it accepts any directory rather than one with `cursors/` | 1 |
| a theme goes back to naming a missing cursor | 1 |

The last one reproduces the original bug and the metadata check catches it.

---

## A leak this caused, and the guard for it

The warning `theme-switcher.sh` now prints reached **the maintainer's own desktop** during a test run. `cursor-theme-test.sh` drives exactly that case and stubbed `gsettings`, `hyprctl`, `systemctl` and `pkill`, but not `notify-send`, with `/usr/bin` on the PATH behind them.

Both affected suites gain the stub, and `suite-hygiene-test.sh` now refuses any suite that runs a notifying script without one. The 19 notifying scripts are read out of the repository rather than listed, so one that starts notifying later is covered. Sabotage confirms it fires.

This is the second leak of this shape, after the rofi window in #124, and it is the same fix: name the class, read the members out of the repository, refuse the suite that can reach the real thing.

Full sweep before pushing: 67 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
