### PR TITLE
Name every shipped script in the README, and keep it that way

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ These are sourced by other files rather than run directly.
 | `bashrc.sh` / `zsh.sh` / `fish.fish` | Per-shell init (zoxide, fzf, starship, aliases) sourced from your shell's rc file |
 | `terminal.sh` | Detect your login shell and wire the matching init script into its rc file |
 | `hypr-helpers.sh` | Shared hyprpaper helper functions used by the wallpaper scripts |
+| `hyprsimple-require.sh` | Loads the helpers a script needs, and stops it rather than letting it run with them missing |
+| `hyprsimple-theme-deliver.sh` | Puts a theme's generated files where each program reads them, shared by the theme switcher and the updater |
+| `hyprsimple-hw-battery.sh` | Exits 0 when this machine has a battery, which is how hyprsimple decides it is a laptop |
+| `hyprsimple-hw-nvidia.sh` | Exits 0 when this machine has an NVIDIA GPU |
 
 ## FAQ
 

--- a/test/readme-keybindings-test.sh
+++ b/test/readme-keybindings-test.sh
@@ -187,6 +187,48 @@ check "and that mode captures the whole output, not a region" \
 check "so the README says monitor rather than region" \
   "$(sed -n "${start},${end}p" "$README" | grep -c 'SUPER + CTRL + Print` | Screenshot current monitor to clipboard')" "1"
 
+# --- every shipped script appears in the README -------------------------------
+#
+# The README has a Scripts section listing what each one does, and nothing kept
+# it in step with .local/bin. Four had gone missing: hyprsimple-hw-battery.sh
+# and hyprsimple-hw-nvidia.sh, and hyprsimple-require.sh and
+# hyprsimple-theme-deliver.sh, both added while fixing something else. A reader
+# looking for what a file in their ~/.local/bin does found nothing.
+#
+# Both sides are read out of the repository. A list written down here would go
+# stale the same way the README did.
+
+mapfile -t shipped < <(find "$REPO/.local/bin" -maxdepth 1 -type f -printf '%f\n' | LC_ALL=C sort)
+mapfile -t named < <(grep -oE '`[a-zA-Z0-9_.-]+\.(sh|fish)`' "$README" | tr -d '`' | LC_ALL=C sort -u)
+
+if (( ${#shipped[@]} < 20 )); then
+  fail "found ${#shipped[@]} scripts in .local/bin, which is too few to be right"
+elif (( ${#named[@]} < 20 )); then
+  fail "found ${#named[@]} script names in the README, which is too few to be right"
+else
+  pass "comparing ${#shipped[@]} shipped scripts against ${#named[@]} named in the README"
+fi
+
+undocumented=()
+for script in "${shipped[@]}"; do
+  printf '%s\n' "${named[@]}" | grep -qxF "$script" || undocumented+=("$script")
+done
+undocumented_str=""
+(( ${#undocumented[@]} > 0 )) && undocumented_str="$(printf '%s ' "${undocumented[@]}")"
+check "every script in .local/bin is named somewhere in the README" "$undocumented_str" ""
+
+# And the other way: a row for a script that was deleted sends the reader to a
+# file that is not there. install.sh is named in the install instructions and
+# lives at the repository root rather than in .local/bin, so it is not one.
+missing=()
+for name in "${named[@]}"; do
+  [[ $name == install.sh || $name == bootstrap.sh ]] && continue
+  [[ -f $REPO/.local/bin/$name ]] || missing+=("$name")
+done
+missing_str=""
+(( ${#missing[@]} > 0 )) && missing_str="$(printf '%s ' "${missing[@]}")"
+check "and every script the README names is one that ships" "$missing_str" ""
+
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
Four scripts in `.local/bin` appear nowhere in the README:

| script | since |
| --- | --- |
| `hyprsimple-hw-battery.sh` | long-standing |
| `hyprsimple-hw-nvidia.sh` | long-standing |
| `hyprsimple-require.sh` | added in #124 |
| `hyprsimple-theme-deliver.sh` | added in #119 |

Two of those are mine, added while fixing something else. Someone looking up what a file in their own `~/.local/bin` does found nothing.

The README has a Scripts section that lists every other one, and nothing kept the two in step. That is how these went missing and how the next one would.

## The fix

All four documented, the two helpers under **Shell init & internal helpers** where the other sourced helper already lives, and the two predicates beside them.

`readme-keybindings-test.sh` now compares both directions, reading each side out of the repository rather than from a list in the test:

- every shipped script has to be named in the README
- every script the README names has to ship

`install.sh` and `bootstrap.sh` are exempt from the second half: they are named in the install instructions and live at the repository root rather than in `.local/bin`.

## Tests

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| a script is dropped from the README again | 1 |
| the README names a script that does not ship | 2 |
| a new script is added and not documented | 1 |

The third is the case that matters: it is exactly what happened twice in the last few days, and the check now catches it before the PR lands.

Both counts are asserted before the comparison, so a grep that stops matching fails loudly instead of comparing two empty lists and passing.

Full sweep before pushing: 67 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
