### PR TITLE
Guard the installer's last prompt, and make the rule a check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -969,7 +969,16 @@ echo "2. Customize ~/.config/hypr/monitors.lua for your setup"
 echo "3. Update later with: hyprsimple-update"
 echo ""
 
-read -rp "Logout to take effect? (y/n) " logout
+# Only ask when someone is there to answer, the same guard the prompt earlier
+# in this file carries. Under curl-pipe stdin is the script itself, and the line
+# this read would take as its answer is the `if` on the next line: the one that
+# tests the answer. Bash then carries on parsing from inside a block whose
+# opening it never saw.
+logout=""
+if [[ -t 0 ]]; then
+  read -rp "Logout to take effect? (y/n) " logout
+fi
+
 if [ "$logout" == "y" ]; then
   echo "Logging out..."
   # hyprsimple's own logout, the same one SUPER + X and the power menu run. It

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -372,6 +372,61 @@ noisy_str=""
 (( ${#noisy[@]} > 0 )) && noisy_str="$(printf '%s ' "${noisy[@]}")"
 check "every suite that runs a notifying script stubs notify-send" "$noisy_str" ""
 
+
+# ---- nothing that runs unattended asks a question it cannot hear -------------
+#
+# install.sh, bootstrap.sh, the migration runner and every migration can all run
+# with no terminal attached. bootstrap's documented install is
+# `curl -fsSL .../bootstrap.sh | bash`, where stdin is the script itself, so a
+# read there does not wait for a person: it takes the next line of the script as
+# the answer and that line never runs.
+#
+# It has happened twice. The migration runner consumed a line of bootstrap.sh,
+# and install.sh's closing prompt would have consumed the `if` that tests its own
+# answer. Both files already guarded one prompt each and not the other.
+#
+# The rule rather than the two instances: a read that prompts must sit behind a
+# check for a terminal. Scripts a person runs by hand, like setup-dns.sh and the
+# vendored hotspot.sh, are not in this set and are not checked.
+
+UNATTENDED=("$REPO/install.sh" "$REPO/bootstrap.sh"
+  "$REPO/.local/bin/hyprsimple-migrate.sh" "$REPO/.local/bin/hyprsimple-update.sh")
+while IFS= read -r m; do UNATTENDED+=("$m"); done < <(find "$REPO/migrations" -name '*.sh' | sort)
+
+if (( ${#UNATTENDED[@]} < 6 )); then
+  fail "found ${#UNATTENDED[@]} unattended scripts to audit, which is too few to be right"
+else
+  pass "auditing ${#UNATTENDED[@]} scripts that can run with no terminal"
+fi
+
+# Counted so the check cannot pass by finding no prompts at all.
+prompts=0
+unguarded=()
+for script in "${UNATTENDED[@]}"; do
+  [[ -f $script ]] || continue
+  # Whole-line comments only. Stripping from the first # anywhere would cut a
+  # prompt string containing one.
+  mapfile -t prompt_lines < <(sed 's/^[[:space:]]*#.*//' "$script" | grep -n 'read -[a-z]*p' | cut -d: -f1)
+  for n in "${prompt_lines[@]}"; do
+    prompts=$((prompts + 1))
+    # The guard has to be above the prompt and close to it. Ten lines is more
+    # than any of these needs and far less than the distance to an unrelated one.
+    start=$(( n > 10 ? n - 10 : 1 ))
+    sed 's/^[[:space:]]*#.*//' "$script" | sed -n "${start},${n}p" |
+      grep -q -- '-t 0' || unguarded+=("$(basename "$script"):$n")
+  done
+done
+
+if (( prompts < 3 )); then
+  fail "found $prompts prompts across those scripts, which is fewer than there are"
+else
+  pass "found $prompts prompts, each of which must be guarded"
+fi
+
+unguarded_str=""
+(( ${#unguarded[@]} > 0 )) && unguarded_str="$(printf '%s ' "${unguarded[@]}")"
+check "every prompt in an unattended script is behind a terminal check" \
+  "$unguarded_str" ""
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
`install.sh` guards the prompt near its start against curl-pipe, and says why:

```bash
# Only ask when someone is there to answer. Under curl-pipe, stdin is the
# script itself, so reading from it would consume the installer.
if [[ -t 0 ]]; then
  read -rp "Continue and install HEAD? (y/N) " reply
```

It left the one at its end unguarded:

```bash
read -rp "Logout to take effect? (y/n) " logout
if [ "$logout" == "y" ]; then
```

The line that read takes as its answer is the `if` on the very next line: the one that tests the answer.

## What that actually does

The tail of `install.sh` piped into bash, with `hypr-logout.sh` replaced by an echo:

```
Logging out...
LOGOUT-WOULD-RUN
bash: line 21: syntax error near unexpected token `else'
```

The `if` is consumed, so `echo "Logging out..."` and the logout run **unconditionally**, without the question ever being answered. Then bash reaches an `else` whose `if` it never saw and dies.

So it is not a lost line. It logs the user out and then breaks.

With the guard, the same tail piped into bash prints `Exiting...` and stops, which is the no-answer behaviour.

Note on reach: the documented install is `git clone` then `./install.sh`, where stdin is a terminal and none of this happens. But this file already defends against curl-pipe in its other prompt, so curl-pipe is inside its own stated threat model, and half a defence is the part worth fixing.

## The rule, not the two instances

This is the second of these in a week, after the migration runner consuming a line of `bootstrap.sh` in #129. In both files one prompt was guarded and another was not, so the hazard was understood and applied unevenly. That is a rule waiting to be written down.

`suite-hygiene-test.sh` now audits `install.sh`, `bootstrap.sh`, `hyprsimple-update.sh`, the migration runner and every migration, and refuses a prompt that is not behind a check for a terminal within the ten lines above it.

The prompts are **counted first**, so the check cannot pass by finding none at all. It currently finds 4 across 40 scripts.

Scripts a person runs by hand are deliberately not in that set: `setup-dns.sh` asks which DNS provider to use and the vendored `hotspot.sh` asks for an SSID, and both are only ever run on purpose.

## Tests

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the installer's last prompt loses its guard again | 1 |
| the migration runner's guard is removed | 1 |
| a new migration adds an unguarded prompt | 1 |

The third is the one that earns the check: it covers migrations that do not exist yet, which run unattended exactly once on every machine and cannot be re-run.

Full sweep before pushing: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
