### PR TITLE
Read the theme from hyprsimple's own state, not from gsettings

### DIFF
--- a/migrations/1788793000.sh
+++ b/migrations/1788793000.sh
@@ -18,11 +18,32 @@ echo "Write the GTK settings.ini that theme switches never created"
 # Only when the file is absent. A settings.ini that exists is the user's, and
 # the next theme switch edits just the one key in it.
 
+# The theme is derived from hyprsimple's own state, not from gsettings.
+#
+# gsettings does not fail without a session bus: it answers with the schema
+# default. Run from a TTY, which is what bootstrap.sh is for, `gsettings get
+# org.gnome.desktop.interface gtk-theme` returns 'Adwaita' on a machine whose
+# theme is Adwaita-dark. Measured by running bootstrap.sh under env -i against
+# a fresh HOME. So this wrote a light theme name for a dark desktop, and
+# because the file then exists it was never corrected.
+#
+# light.mode is the same thing theme-switcher.sh reads to make this decision,
+# it lives in the theme directory, and it needs no session at all.
 wrote=0
-theme=$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'")
+
+active_lua=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null)
+theme=""
+if [[ -n $active_lua ]]; then
+  # .../themes/<name>/generated/hyprland-colors.lua
+  theme_dir=$(dirname "$(dirname "$active_lua")")
+  if [[ -d $theme_dir ]]; then
+    if [[ -f $theme_dir/light.mode ]]; then theme="Adwaita"; else theme="Adwaita-dark"; fi
+  fi
+fi
 
 if [[ -z $theme ]]; then
-  echo "  Could not read the current GTK theme, so nothing was written."
+  echo "  Could not tell which theme is active, so nothing was written."
+  echo "  Your next theme switch writes these files."
   exit 0
 fi
 

--- a/migrations/1788797000.sh
+++ b/migrations/1788797000.sh
@@ -1,0 +1,55 @@
+echo "Correct a GTK theme name written from a session that could not be read"
+
+# Migration 1788793000 wrote ~/.config/gtk-{3,4}.0/settings.ini from
+#
+#   gsettings get org.gnome.desktop.interface gtk-theme
+#
+# and gsettings does not fail without a session bus: it answers with the schema
+# default. Run from a TTY, which is what bootstrap.sh is for, that returns
+# 'Adwaita' on a machine whose theme is Adwaita-dark. Measured by running
+# bootstrap.sh under env -i against a fresh HOME.
+#
+# So machines bootstrapped from a console got a light theme name written for a
+# dark desktop, and because the file then existed nothing corrected it.
+# 1788793000 reads light.mode now, but it has already run on those machines.
+#
+# Only the exact file that migration writes is touched: two lines, a [Settings]
+# header and the key, and nothing else. Anything a person has edited since has
+# more in it than that and is left alone.
+
+want=""
+active_lua=$(readlink "$HOME/.config/hypr/theme-active.lua" 2>/dev/null)
+if [[ -n $active_lua ]]; then
+  theme_dir=$(dirname "$(dirname "$active_lua")")
+  if [[ -d $theme_dir ]]; then
+    if [[ -f $theme_dir/light.mode ]]; then want="Adwaita"; else want="Adwaita-dark"; fi
+  fi
+fi
+
+if [[ -z $want ]]; then
+  echo "  Could not tell which theme is active, so nothing was changed."
+  exit 0
+fi
+
+corrected=0
+for gtk_dir in "$HOME/.config/gtk-3.0" "$HOME/.config/gtk-4.0"; do
+  settings="$gtk_dir/settings.ini"
+  [[ -f $settings ]] || continue
+
+  # Exactly the shape 1788793000 writes, and no more.
+  [[ $(wc -l <"$settings") -eq 2 ]] || continue
+  [[ $(sed -n '1p' "$settings") == "[Settings]" ]] || continue
+
+  current=$(sed -n '2p' "$settings")
+  [[ $current == gtk-theme-name=* ]] || continue
+  [[ $current == "gtk-theme-name=$want" ]] && continue
+
+  printf '[Settings]\ngtk-theme-name=%s\n' "$want" >"$settings"
+  corrected=$((corrected + 1))
+done
+
+if (( corrected > 0 )); then
+  echo "  Corrected $corrected settings.ini to $want, matching the theme you have."
+else
+  echo "  Nothing to correct."
+fi

--- a/test/gtk-settings-test.sh
+++ b/test/gtk-settings-test.sh
@@ -118,14 +118,18 @@ check "and no longer skips the file when it is absent" \
 # ---- the migration ---------------------------------------------------------
 
 STUB="$TMP/bin"; mkdir -p "$STUB"
-# A heredoc, not a printf. Building this stub with nested printf quoting ate
-# the %s and wrote a script that printed an empty line, so the migration read
-# no theme and four checks failed for a reason that had nothing to do with it.
-cat >"$STUB/gsettings" <<'STUBEOF'
-#!/bin/bash
-echo "'Adwaita-dark'"
-STUBEOF
-chmod +x "$STUB/gsettings"
+# No gsettings stub any more, and that is the point.
+#
+# The migration used to read the theme from gsettings, which does not fail
+# without a session bus: it answers with the schema default. Run from a TTY,
+# which is what bootstrap.sh is for, it returned Adwaita on a machine whose
+# theme is Adwaita-dark, so a light name was written for a dark desktop and the
+# file then existed so nothing corrected it. Measured by running bootstrap.sh
+# under env -i against a fresh HOME.
+#
+# It reads light.mode now, which is what theme-switcher.sh reads to make the
+# same decision, lives in the theme directory and needs no session. So these
+# fixtures arrange a theme rather than a gsettings answer.
 
 # A rofi of its own, ahead of the real one. This suite only greps
 # theme-switcher.sh rather than running it, so nothing here reaches a picker
@@ -135,11 +139,23 @@ chmod +x "$STUB/gsettings"
 printf '#!/bin/bash\nexit 1\n' >"$STUB/rofi"
 chmod +x "$STUB/rofi"
 
+# An active theme in a fixture home, the way a real one is arranged: a symlink
+# at ~/.config/hypr/theme-active.lua pointing into <theme>/generated/.
+make_active_theme() {
+  local home="$1" name="$2" light="${3-}"
+  local theme="$home/.config/hypr/themes/$name"
+  mkdir -p "$theme/generated" "$home/.config/hypr"
+  [[ -n $light ]] && : >"$theme/light.mode"
+  : >"$theme/generated/hyprland-colors.lua"
+  ln -sfn "$theme/generated/hyprland-colors.lua" "$home/.config/hypr/theme-active.lua"
+}
+
 run_migration() {
   HOME="$1" PATH="$STUB:/usr/bin:/bin" bash "$MIGRATION" >"$TMP/out" 2>&1
 }
 
 h1="$TMP/h1"; mkdir -p "$h1"
+make_active_theme "$h1" darkone
 run_migration "$h1"
 check "the migration writes gtk-3.0/settings.ini when it is absent" \
   "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$h1/.config/gtk-3.0/settings.ini" 2>/dev/null)" "1"
@@ -151,24 +167,99 @@ run_migration "$h1"
 check "running it again writes nothing" "$(grep -c 'already exist' "$TMP/out")" "1"
 
 h2="$TMP/h2"; mkdir -p "$h2/.config/gtk-3.0" "$h2/.config/gtk-4.0"
+make_active_theme "$h2" darkone
 printf '[Settings]\ngtk-font-name=Mine\n' >"$h2/.config/gtk-3.0/settings.ini"
 printf '[Settings]\ngtk-font-name=Mine\n' >"$h2/.config/gtk-4.0/settings.ini"
 run_migration "$h2"
 check "an existing settings.ini is not rewritten by the migration" \
   "$(cat "$h2/.config/gtk-3.0/settings.ini")" "$(printf '[Settings]\ngtk-font-name=Mine')"
 
-# gsettings unreachable: write nothing rather than a made up theme name.
-cat >"$STUB/gsettings" <<'STUBEOF'
-#!/bin/bash
-exit 1
-STUBEOF
-chmod +x "$STUB/gsettings"
+# A light theme gets the light name, which is the half a schema default would
+# have got right by accident.
+h4="$TMP/h4"; mkdir -p "$h4"
+make_active_theme "$h4" lightone light
+run_migration "$h4"
+check "a theme declaring light.mode gets the light GTK theme name" \
+  "$(grep -c '^gtk-theme-name=Adwaita$' "$h4/.config/gtk-3.0/settings.ini" 2>/dev/null)" "1"
+check "and not the dark one" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$h4/.config/gtk-3.0/settings.ini" 2>/dev/null)" "0"
+
+# No active theme: write nothing rather than guess.
 h3="$TMP/h3"; mkdir -p "$h3"
 run_migration "$h3"
-check "with no readable GTK theme, nothing is written" \
+check "with no active theme, nothing is written" \
   "$([[ -e $h3/.config/gtk-3.0/settings.ini ]] && echo written || echo none)" "none"
 check "and the migration says why" \
-  "$(grep -c 'Could not read the current GTK theme' "$TMP/out")" "1"
+  "$(grep -c 'Could not tell which theme is active' "$TMP/out")" "1"
+
+# The heart of it: no session bus, and the answer is still right.
+#
+# env -i so there is no DBUS_SESSION_BUS_ADDRESS and no XDG_RUNTIME_DIR, which
+# is what a TTY bootstrap looks like. A real gsettings is on PATH here on
+# purpose: if the migration asked it, it would answer Adwaita and this check
+# would fail.
+h5="$TMP/h5"; mkdir -p "$h5"
+make_active_theme "$h5" darkone
+env -i HOME="$h5" PATH="/usr/bin:/bin" bash "$MIGRATION" >"$TMP/out5" 2>&1
+check "with no session bus at all, a dark theme still gets the dark name" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$h5/.config/gtk-3.0/settings.ini" 2>/dev/null)" "1"
+check "and the migration no longer consults gsettings" \
+  "$(sed 's/^[[:space:]]*#.*//' "$MIGRATION" | grep -c gsettings)" "0"
+
+# ---- the correction for machines that already ran the old one ---------------
+#
+# 1788793000 has already run where it read the schema default, so fixing it is
+# not enough. 1788797000 corrects those, and only the exact two-line file the
+# old one wrote.
+
+CORRECTION="$REPO/migrations/1788797000.sh"
+
+wrong_file() {
+  local home="$1"
+  mkdir -p "$home/.config/gtk-3.0" "$home/.config/gtk-4.0"
+  printf '[Settings]\ngtk-theme-name=Adwaita\n' >"$home/.config/gtk-3.0/settings.ini"
+  printf '[Settings]\ngtk-theme-name=Adwaita\n' >"$home/.config/gtk-4.0/settings.ini"
+}
+
+c1="$TMP/c1"; mkdir -p "$c1"
+make_active_theme "$c1" darkone
+wrong_file "$c1"
+HOME="$c1" bash "$CORRECTION" >"$TMP/cout" 2>&1
+check "a light name written for a dark theme is corrected" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$c1/.config/gtk-3.0/settings.ini")" "1"
+check "in both files" \
+  "$(grep -c '^gtk-theme-name=Adwaita-dark$' "$c1/.config/gtk-4.0/settings.ini")" "1"
+check "and it says how many" "$(grep -c 'Corrected 2 settings.ini' "$TMP/cout")" "1"
+
+HOME="$c1" bash "$CORRECTION" >"$TMP/cout2" 2>&1
+check "running it again finds nothing" "$(grep -c 'Nothing to correct' "$TMP/cout2")" "1"
+
+# A file with anything else in it is somebody's, and is not touched.
+c2="$TMP/c2"; mkdir -p "$c2"
+make_active_theme "$c2" darkone
+mkdir -p "$c2/.config/gtk-3.0" "$c2/.config/gtk-4.0"
+printf '[Settings]\ngtk-theme-name=Adwaita\ngtk-font-name=Mine 11\n' >"$c2/.config/gtk-3.0/settings.ini"
+before=$(cat "$c2/.config/gtk-3.0/settings.ini")
+HOME="$c2" bash "$CORRECTION" >/dev/null 2>&1
+check "a settings.ini with anything else in it is left alone" \
+  "$([[ $(cat "$c2/.config/gtk-3.0/settings.ini") == "$before" ]] && echo unchanged || echo edited)" "unchanged"
+
+# And a correct file is not rewritten, so nothing churns on every update.
+c3="$TMP/c3"; mkdir -p "$c3"
+make_active_theme "$c3" lightone light
+mkdir -p "$c3/.config/gtk-3.0" "$c3/.config/gtk-4.0"
+printf '[Settings]\ngtk-theme-name=Adwaita\n' >"$c3/.config/gtk-3.0/settings.ini"
+HOME="$c3" bash "$CORRECTION" >"$TMP/cout3" 2>&1
+check "a file already naming the right theme is not touched" \
+  "$(grep -c 'Nothing to correct' "$TMP/cout3")" "1"
+
+# No active theme: change nothing rather than guess.
+c4="$TMP/c4"; mkdir -p "$c4"
+wrong_file "$c4"
+HOME="$c4" bash "$CORRECTION" >"$TMP/cout4" 2>&1
+check "with no active theme, nothing is changed" \
+  "$(grep -c '^gtk-theme-name=Adwaita$' "$c4/.config/gtk-3.0/settings.ini")" "1"
+check "and it says why" "$(grep -c 'Could not tell which theme is active' "$TMP/cout4")" "1"
 
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2

--- a/test/suite-hygiene-test.sh
+++ b/test/suite-hygiene-test.sh
@@ -427,6 +427,53 @@ unguarded_str=""
 (( ${#unguarded[@]} > 0 )) && unguarded_str="$(printf '%s ' "${unguarded[@]}")"
 check "every prompt in an unattended script is behind a terminal check" \
   "$unguarded_str" ""
+
+# ---- a migration must not take a value from the session -----------------------
+#
+# Migrations run once, unattended, and cannot be re-run. bootstrap.sh runs them,
+# and bootstrap is for machines that predate the update system, so a console
+# with no session bus is an ordinary place for one to run.
+#
+# gsettings does not fail there. It answers with the schema default. A migration
+# that wrote ~/.config/gtk-3.0/settings.ini from
+#
+#   gsettings get org.gnome.desktop.interface gtk-theme
+#
+# recorded Adwaita on a machine whose theme is Adwaita-dark, and because the
+# file then existed nothing corrected it. Measured by running bootstrap.sh under
+# env -i against a fresh HOME. The migration guarded an empty answer, and the
+# answer was never empty, only wrong.
+#
+# hyprctl is the same shape: it answers ok for a cursor theme that is not
+# installed. A migration deciding what to write must read hyprsimple's own
+# files, which are there whether or not a session is.
+#
+# Acting on the exit status is fine and is not what this looks for. Only
+# capturing output as a value.
+
+session_readers=()
+for migration in "$REPO/migrations"/*.sh; do
+  sed 's/^[[:space:]]*#.*//' "$migration" |
+    grep -qE '\$\((gsettings get|hyprctl|dunstctl|busctl)' &&
+    session_readers+=("$(basename "$migration")")
+done
+
+readers_str=""
+(( ${#session_readers[@]} > 0 )) && readers_str="$(printf '%s ' "${session_readers[@]}")"
+check "no migration reads a value out of the running session" "$readers_str" ""
+
+# Not vacuous: migrations do call these, they just act on the status rather than
+# capturing the answer. If that stops being true the check above means nothing.
+callers=0
+for migration in "$REPO/migrations"/*.sh; do
+  sed 's/^[[:space:]]*#.*//' "$migration" |
+    grep -qE '\b(gsettings|hyprctl|systemctl --user)\b' && callers=$((callers + 1))
+done
+if (( callers < 3 )); then
+  fail "only $callers migrations touch the session at all, so the check above proves little"
+else
+  pass "$callers migrations touch the session, and none of them reads a value from it"
+fi
 if [[ $failures -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
This fixes a bug I introduced in #126, three merges ago, and adds the check that would have caught it.

## The bug

Migration `1788793000` wrote `~/.config/gtk-{3,4}.0/settings.ini` from:

```bash
theme=$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'")
if [[ -z $theme ]]; then ... exit 0; fi
```

**gsettings does not fail without a session bus. It answers with the schema default.**

```
$ gsettings get org.gnome.desktop.interface gtk-theme
'Adwaita-dark'

$ env -i HOME=/tmp PATH=/usr/bin:/bin gsettings get org.gnome.desktop.interface gtk-theme
'Adwaita'
```

The guard is on an empty answer, and the answer is never empty, only wrong.

## How it was found

By running `bootstrap.sh` end to end under `env -i` against a fresh HOME, which is what a console bootstrap looks like. It reported:

```
Wrote 2 settings.ini naming Adwaita. Your next theme switch keeps them in step.
```

on a desktop set to `Adwaita-dark`. Because the file then exists, the migration never runs again and nothing corrects it. `bootstrap.sh` exists for machines that predate the update system, so a TTY is an ordinary place for this to run.

It is correct on a machine that ran `hyprsimple-update` from inside a session, which is why it looked fine until bootstrap was actually exercised.

## The fix

The theme is derived from `light.mode` in the active theme directory, which is what `theme-switcher.sh` reads to make the same decision, and which needs no session. With no active theme it writes nothing and says so.

`1788797000` corrects machines that already ran the old one, touching only the exact two-line file it wrote and leaving anything edited since.

Verified end to end: a TTY bootstrap with a dark theme active now writes `Adwaita-dark` where `gsettings` in that same environment would have said `Adwaita`.

## The guard

`suite-hygiene-test.sh` now refuses any migration that captures output from `gsettings`, `hyprctl`, `dunstctl` or `busctl`. Acting on the exit status is fine and is not what it looks for.

`hyprctl` has the same shape and it has already bitten once: it answers `ok` for a cursor theme that is not installed (#127).

**Verified against the real thing rather than a lookalike**: putting the line shipped in #126 back, verbatim, turns the check red. A second check counts the migrations that touch the session at all, currently 6, so the first cannot pass by there being nothing to find.

## Tests

`gtk-settings-test.sh` no longer stubs gsettings, because the migration no longer asks it. Fixtures arrange a theme instead. One check runs the migration under `env -i` with a real gsettings on PATH on purpose: if it consulted it, that check fails.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the migration goes back to gsettings | 6 |
| `light.mode` is ignored, everything gets the dark name | 2 |
| the correction migration rewrites a file with more in it | 1 |

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
