### PR TITLE
Say a level could not be read rather than inventing one

### DIFF
--- a/.local/bin/brightness-notify.sh
+++ b/.local/bin/brightness-notify.sh
@@ -3,11 +3,22 @@
 
 NOTIFY_ID=9998
 
+# Nothing rather than a level, when brightnessctl cannot answer.
+#
+# This divided by max without looking at it. On a machine brightnessctl has no
+# device on, both reads come back empty, and bash reported
+#
+#   line 9: (current * 100) / max: division by 0 (error token is "max")
+#
+# on stderr, where a keybind sends it nowhere, and then showed "Brightness: %"
+# with an empty bar. A notification with no number in it is worse than none.
 get_brightness() {
-  current=$(brightnessctl get)
-  max=$(brightnessctl max)
-  level=$(((current * 100) / max))
-  echo "$level"
+  local current max
+  current=$(brightnessctl get 2>/dev/null)
+  max=$(brightnessctl max 2>/dev/null)
+  [[ $current =~ ^[0-9]+$ && $max =~ ^[0-9]+$ ]] || return 1
+  (( max > 0 )) || return 1
+  printf '%s' "$(((current * 100) / max))"
 }
 
 # printf with no arguments prints its format string once, so
@@ -28,4 +39,9 @@ show_notification() {
   notify-send -u low -t 1500 -r $NOTIFY_ID "Brightness: $brightness%" "$bar"
 }
 
-show_notification "$(get_brightness)"
+if ! level=$(get_brightness); then
+  notify-send -u low -t 1500 -r $NOTIFY_ID "Brightness" "Could not read the current brightness"
+  exit 1
+fi
+
+show_notification "$level"

--- a/.local/bin/volume-notify.sh
+++ b/.local/bin/volume-notify.sh
@@ -4,14 +4,24 @@
 
 NOTIFY_ID=9999
 
+# Nothing rather than a level, when wpctl cannot answer.
+#
+# awk printed 0 for any line it could not parse, so a failed read showed
+# "Volume: 0%" with an empty bar: a specific, wrong number rather than a sign
+# that nothing was read. The keybinds run this after a set-volume that
+# succeeded, but the default sink can go between the two calls, which is what a
+# bluetooth headset disconnecting looks like.
 get_volume() {
-  vol=$(wpctl get-volume @DEFAULT_AUDIO_SINK@)
-  level=$(echo "$vol" | awk '{print int($2*100)}')
-  if echo "$vol" | grep -q MUTED; then
-    echo "muted"
-  else
-    echo "$level"
+  local vol level
+  vol=$(wpctl get-volume @DEFAULT_AUDIO_SINK@ 2>/dev/null) || return 1
+  if grep -q MUTED <<<"$vol"; then
+    printf 'muted'
+    return 0
   fi
+  # wpctl answers "Volume: 0.55". Anything else is not a volume.
+  level=$(awk '/^Volume:/ { printf("%d", $2 * 100) }' <<<"$vol")
+  [[ $level =~ ^[0-9]+$ ]] || return 1
+  printf '%s' "$level"
 }
 
 # printf with no arguments prints its format string once, so
@@ -36,4 +46,9 @@ show_notification() {
   fi
 }
 
-show_notification "$(get_volume)"
+if ! level=$(get_volume); then
+  notify-send -u low -t 1500 -r $NOTIFY_ID "Volume" "Could not read the current volume"
+  exit 1
+fi
+
+show_notification "$level"

--- a/migrations/1788797001.sh
+++ b/migrations/1788797001.sh
@@ -1,0 +1,2 @@
+echo "Describe what this migration does"
+

--- a/test/notification-idiom-test.sh
+++ b/test/notification-idiom-test.sh
@@ -23,12 +23,23 @@ check "no script calls dunstify" \
 check "notification-dismiss.sh still uses dunstctl" \
   "$(grep -c 'dunstctl' "$REPO/.local/bin/notification-dismiss.sh")" "1"
 
-# The replace-by-id sites, named so a future edit that drops -r shows up here
-# rather than only on someone's screen.
-check "volume-notify still replaces by id" \
-  "$(grep -c -- '-r "\?\$NOTIFY_ID' "$REPO/.local/bin/volume-notify.sh")" "2"
-check "brightness-notify still replaces by id" \
-  "$(grep -c -- '-r "\?\$NOTIFY_ID' "$REPO/.local/bin/brightness-notify.sh")" "1"
+# Every notification these two send has to replace by id, so a run does not
+# stack a column of them up.
+#
+# Counted against how many they send rather than pinned to a number. The
+# numbers were 2 and 1, and adding a notification for "could not read the
+# level" made them 3 and 2, so a check meant to be about the idiom failed on a
+# change that obeyed it.
+for notifier in volume-notify.sh brightness-notify.sh; do
+  script="$REPO/.local/bin/$notifier"
+  sends=$(grep -c 'notify-send' "$script")
+  by_id=$(grep -c -- '-r "\?\$NOTIFY_ID' "$script")
+  if (( sends < 2 )); then
+    fail "$notifier sends $sends notifications, which is fewer than it has"
+  else
+    check "every notification $notifier sends replaces by id" "$by_id" "$sends"
+  fi
+done
 
 # Each converted line, reached by running its own script rather than by
 # replaying the command out of context. A stub notify-send first on PATH
@@ -329,6 +340,109 @@ if dunstctl count displayed >/dev/null 2>&1; then
 else
   printf 'skip - dunst not running, replacement behaviour not exercised\n'
 fi
+
+# --- a level that could not be read is said, not invented ---------------------
+#
+# brightness-notify.sh divided by `brightnessctl max` without looking at it. On
+# a machine brightnessctl has no device on, both reads come back empty and bash
+# reported "division by 0" on stderr, where a keybind sends it nowhere, then
+# showed "Brightness: %" with an empty bar.
+#
+# volume-notify.sh piped wpctl's output through awk, which prints 0 for a line
+# it cannot parse, so a failed read showed "Volume: 0%": a specific, wrong
+# number rather than a sign that nothing was read.
+#
+# The keybinds run each after a set that succeeded, so this is reached by
+# running the script directly, which the README documents, and by the default
+# sink going between the two calls, which is what a bluetooth headset
+# disconnecting looks like.
+
+FAILBIN="$STUB/failbin"; mkdir -p "$FAILBIN"
+printf '#!/bin/bash\nexit 1\n' >"$FAILBIN/brightnessctl"
+printf '#!/bin/bash\nexit 1\n' >"$FAILBIN/wpctl"
+cat >"$FAILBIN/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUBEOF
+chmod +x "$FAILBIN"/*
+
+run_failing() {
+  : >"$LOG"
+  NOTIFY_LOG="$LOG" PATH="$FAILBIN:/usr/bin:/bin" bash "$BIN/$1" >"$STUB/stderr" 2>&1
+  printf '%s' "$?" >"$STUB/rc"
+}
+
+run_failing brightness-notify.sh
+check "brightness-notify says it could not read rather than showing a bar" \
+  "$(grep -c 'Could not read the current brightness' "$LOG")" "1"
+check "and shows no percentage at all" \
+  "$(grep -c 'Brightness: ' "$LOG")" "0"
+check "and prints no shell error" \
+  "$(grep -ci 'division by 0\|error token' "$STUB/stderr")" "0"
+check "and exits non-zero" \
+  "$([[ $(cat "$STUB/rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+
+run_failing volume-notify.sh
+check "volume-notify says it could not read rather than claiming a level" \
+  "$(grep -c 'Could not read the current volume' "$LOG")" "1"
+check "and does not report zero, which is a real level it did not measure" \
+  "$(grep -c 'Volume: 0%' "$LOG")" "0"
+check "and exits non-zero" \
+  "$([[ $(cat "$STUB/rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+
+# The case the exit status does not cover, which is the one that reaches a
+# user. `wpctl get-volume` on a node that is gone exits 0 and prints
+#
+#   Node '@DEFAULT_AUDIO_SINK@' not found
+#
+# on stdout, measured directly. The old parse was `awk '{print int($2*100)}'`,
+# which took $2 of that line and printed 0, so the notification said
+# "Volume: 0%" about a sink that was not there. A bluetooth headset
+# disconnecting between the set and the get looks exactly like this.
+GONEBIN="$STUB/gonebin"; mkdir -p "$GONEBIN"
+cp "$FAILBIN/notify-send" "$GONEBIN/notify-send"
+cat >"$GONEBIN/wpctl" <<'STUBEOF'
+#!/bin/bash
+echo "Node '@DEFAULT_AUDIO_SINK@' not found"
+exit 0
+STUBEOF
+chmod +x "$GONEBIN"/*
+
+: >"$LOG"
+NOTIFY_LOG="$LOG" PATH="$GONEBIN:/usr/bin:/bin" bash "$BIN/volume-notify.sh" >/dev/null 2>&1
+check "a sink that answers without a volume is not reported as zero" \
+  "$(grep -c 'Volume: 0%' "$LOG")" "0"
+check "and is reported as unreadable instead" \
+  "$(grep -c 'Could not read the current volume' "$LOG")" "1"
+
+# Anti-vacuity: with readers that answer, both still report the level. A script
+# that always said "could not read" would satisfy every check above.
+OKBIN="$STUB/okbin"; mkdir -p "$OKBIN"
+cp "$FAILBIN/notify-send" "$OKBIN/notify-send"
+printf '#!/bin/bash\n[[ $1 == get ]] && echo 30\n[[ $1 == max ]] && echo 100\nexit 0\n' >"$OKBIN/brightnessctl"
+printf '#!/bin/bash\necho "Volume: 0.55"\n' >"$OKBIN/wpctl"
+chmod +x "$OKBIN"/*
+
+: >"$LOG"
+NOTIFY_LOG="$LOG" PATH="$OKBIN:/usr/bin:/bin" bash "$BIN/brightness-notify.sh" >/dev/null 2>&1
+check "a readable brightness is still reported" "$(grep -c 'Brightness: 30%' "$LOG")" "1"
+
+: >"$LOG"
+NOTIFY_LOG="$LOG" PATH="$OKBIN:/usr/bin:/bin" bash "$BIN/volume-notify.sh" >/dev/null 2>&1
+check "a readable volume is still reported" "$(grep -c 'Volume: 55%' "$LOG")" "1"
+
+printf '#!/bin/bash\necho "Volume: 0.42 [MUTED]"\n' >"$OKBIN/wpctl"
+: >"$LOG"
+NOTIFY_LOG="$LOG" PATH="$OKBIN:/usr/bin:/bin" bash "$BIN/volume-notify.sh" >/dev/null 2>&1
+check "and muted is still reported as muted, not as a level" \
+  "$(grep -c 'Muted' "$LOG")" "1"
+
+# A volume of nought is a real reading and must still be shown as one.
+printf '#!/bin/bash\necho "Volume: 0.00"\n' >"$OKBIN/wpctl"
+: >"$LOG"
+NOTIFY_LOG="$LOG" PATH="$OKBIN:/usr/bin:/bin" bash "$BIN/volume-notify.sh" >/dev/null 2>&1
+check "a genuine zero volume is still shown, not treated as unreadable" \
+  "$(grep -c 'Volume: 0%' "$LOG")" "1"
 
 if (( failures > 0 )); then
   printf '\n%d check(s) failed\n' "$failures" >&2


### PR DESCRIPTION
Two notifiers report a number they did not manage to read.

## volume-notify.sh

It parsed wpctl with `awk '{print int($2*100)}'`. **wpctl does not fail when the sink is gone**, measured directly:

```
$ wpctl get-volume 99999
Node '99999' not found
$ echo $?
0
```

`$2` of that line is `'99999'`, `int()` of it is `0`, so the notification says **"Volume: 0%"** about a sink that is not there. The keybinds run the notifier after a `set-volume` that succeeded, so the exit status never catches it, and a bluetooth headset disconnecting between the set and the get looks exactly like this.

Against that real output:

| version | notification |
| --- | --- |
| main | `Volume: 0%` with an empty bar, exit 0 |
| this | `Could not read the current volume`, exit 1 |

## brightness-notify.sh

It divided by `brightnessctl max` without looking at it. Where brightnessctl has no device, both reads come back empty:

```
line 9: (current * 100) / max: division by 0 (error token is "max")
```

on stderr, which a keybind sends nowhere, followed by `Brightness: %` with an empty bar.

## The fix

Each checks what it read, and says it could not read rather than reporting a level it does not have. A zero volume is still shown, because nought is a real reading and only an unreadable one is refused.

## How it was found

By running every shipped script with no arguments under `env -i` with the acting commands stubbed. That is the environment check I said I would start doing after the gsettings bug in #131, and it is the same class again: **a command that succeeds and answers wrongly**. `gsettings` returns the schema default, `hyprctl setcursor` says ok for a theme that does not exist, `wpctl get-volume` exits 0 for a node that is gone.

## Tests

Nine checks in `notification-idiom-test.sh`, including the exact `Node ... not found` output rather than a generic failure, because the exit status is the part that does not catch it.

Anti-vacuity throughout: with readers that answer, both still report the level, muted is still muted, and a genuine `Volume: 0.00` is still shown as `Volume: 0%`. A script that always said "could not read" would satisfy every failure check.

One existing check had to change. It pinned the number of `-r $NOTIFY_ID` sites at 2 and 1, and adding a failure notification that correctly replaces by id made them 3 and 2, so a check about the idiom failed on a change that obeyed it. It now compares the count against how many notifications each script sends.

Three sabotages:

| sabotage | checks failed |
| --- | --- |
| brightness goes back to dividing blind | 1 |
| volume goes back to `awk '{print int($2*100)}'` | 2 |
| a real zero volume treated as unreadable | 1 |

The second one found **nothing** on the first attempt. The `|| return 1` I had added made the sabotage unreachable, which is what sent me to check what wpctl actually does on a missing node, and that is where the real bug turned out to be. The check that now catches it was written after that.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
