### PR TITLE
Report the audio switch only when pactl made it

### DIFF
--- a/.local/bin/audio-switch.sh
+++ b/.local/bin/audio-switch.sh
@@ -41,5 +41,17 @@ if [[ $next_sink_name == "$current_sink_name" ]]; then
   exit 0
 fi
 
-pactl set-default-sink "$next_sink_name"
-notify-send "Audio Output" "Switched to: $next_sink_description"
+# Reporting the switch only if pactl made it.
+#
+# This was an unchecked call followed by an unconditional notification, which
+# is the same shape the single-sink case above was fixed for. pactl exits 1
+# with "Failure: No such entity" when the sink is not there any more, and the
+# list this choice came from is a moment old: a bluetooth headset that
+# disconnects in between leaves the sound coming out of the speakers while the
+# notification says it moved.
+if pactl set-default-sink "$next_sink_name"; then
+  notify-send "Audio Output" "Switched to: $next_sink_description"
+else
+  notify-send -u critical "Audio Output" "Could not switch to $next_sink_description"
+  exit 1
+fi

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -243,12 +243,22 @@ check "a path outside the theme falls back to the cached wallpaper" \
 one_sink='[{"name":"alsa_output.analog-stereo","description":"Built-in Audio","ports":[]}]'
 two_sinks='[{"name":"alsa_output.analog-stereo","description":"Built-in Audio","ports":[]},{"name":"bluez_output.AA","description":"Headphones","ports":[]}]'
 
+# set-default-sink can be made to fail, because it can fail in life: the list
+# the choice came from is a moment old, and pactl exits 1 with "Failure: No
+# such entity" for a sink that has gone since. A bluetooth headset
+# disconnecting in between looks exactly like that.
 cat >"$STUB/pactl" <<'STUBEOF'
 #!/bin/bash
 printf 'pactl %s\n' "$*" >>"$CALL_LOG"
 case "$1" in
   get-default-sink) printf '%s\n' "$DEFAULT_SINK" ;;
   -f) printf '%s\n' "$SINKS_JSON" ;;
+  set-default-sink)
+    if [[ -n ${SET_SINK_FAILS:-} ]]; then
+      echo "Failure: No such entity" >&2
+      exit 1
+    fi
+    ;;
 esac
 STUBEOF
 chmod +x "$STUB/pactl"
@@ -267,6 +277,25 @@ SINKS_JSON="$two_sinks" DEFAULT_SINK="alsa_output.analog-stereo" \
 check "two sinks still cycle to the other one" \
   "$(grep -c 'set-default-sink bluez_output.AA' "$LOG")" "1"
 check "and report the switch" "$(grep -c 'Switched to: Headphones' "$LOG")" "1"
+
+# The sink goes between the list and the set. pactl fails, and the switch used
+# to be announced anyway: sound still coming out of the speakers while the
+# notification said it had moved. Same shape as the single-sink case above,
+# which this file already covers.
+: >"$LOG"
+SET_SINK_FAILS=1 SINKS_JSON="$two_sinks" DEFAULT_SINK="alsa_output.analog-stereo" \
+  run "$BIN/audio-switch.sh" >/dev/null 2>&1
+check "a switch pactl refused is not reported as done" \
+  "$(grep -c 'Switched to' "$LOG")" "0"
+check "and is reported as failed instead" \
+  "$(grep -c 'Could not switch to Headphones' "$LOG")" "1"
+check "critically, so it is not lost among the ordinary notifications" \
+  "$(grep -c -- '-u critical' "$LOG")" "1"
+
+# It was still attempted, or the checks above would pass for a script that
+# stopped trying to switch at all.
+check "and the switch really was attempted" \
+  "$(grep -c 'set-default-sink bluez_output.AA' "$LOG")" "1"
 
 # --- virtual-mirror-toggle.sh -----------------------------------------------
 


### PR DESCRIPTION
`audio-switch.sh` called `set-default-sink` without looking at the result:

```bash
pactl set-default-sink "$next_sink_name"
notify-send "Audio Output" "Switched to: $next_sink_description"
```

pactl exits 1 with `Failure: No such entity` for a sink that is not there any more, and the list this choice came from is a moment old. A bluetooth headset that disconnects in between leaves the sound coming out of the speakers while the notification says it moved.

Measured with a pactl that lists two sinks and refuses the set:

```
Failure: No such entity
NOTIFICATION: Audio Output Switched to: Headset
rc=0
```

## The precedent was already in the file

A few lines above, the single-sink case carries this comment:

> With a single sink the cycle lands back on the one already selected. That set no default and still reported "Switched to", so the only machine where this key does nothing was also the only one where it always claimed success.

Same shape, fixed once, and the call below it was left unchecked. That is the third time this week a file has defended against something in one place and not the other, after the migration runner and the installer prompt.

## The fix

The switch is reported when pactl made it. A refusal is reported critically and the script exits non-zero.

## How it was found

By extending the `env -i` probe from #132 to readers that answer without failing. This keeps turning out to be one class:

| command | what it does instead of failing |
| --- | --- |
| `gsettings get` | returns the schema default (#131) |
| `hyprctl setcursor` | says `ok` for a theme that is not installed (#127) |
| `wpctl get-volume` | exits 0 for a node that is gone (#132) |
| `pactl set-default-sink` | **does** fail, and nothing read the status |

The last one is the inverse and worth naming: the status was there to be read, and was not.

## Tests

Four checks in `toggle-scripts-test.sh`. The stub's `set-default-sink` can be made to fail, because it can fail in life, rather than the failure being simulated some other way.

One of the four asserts the switch was still **attempted**, so the other three cannot pass for a script that quietly stopped trying to switch at all.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| back to notifying unconditionally | 3 |
| it stops attempting the switch at all | 3 |
| the failure is announced quietly rather than critically | 1 |

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
