### PR TITLE
Announce the virtual mirror only when wl-mirror is still there

### DIFF
--- a/.local/bin/virtual-mirror-toggle.sh
+++ b/.local/bin/virtual-mirror-toggle.sh
@@ -11,12 +11,38 @@ if ! command -v wl-mirror >/dev/null; then
   exit 1
 fi
 
-PRIMARY=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
+PRIMARY=$(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | .name')
 
 if pgrep -x wl-mirror >/dev/null; then
   pkill -x wl-mirror
   notify-send "Virtual Mirror" "Stopped"
 else
+  # A name, before anything is told to mirror it.
+  #
+  # This went unchecked, so a compositor that answered without a focused
+  # monitor gave an empty name, wl-mirror was run with "" and refused it, and
+  # the notification read "Mirroring  - Select this window in screen sharing
+  # apps" with a blank where the monitor should be.
+  if [[ -z $PRIMARY ]]; then
+    notify-send -u critical "Virtual Mirror" "Could not tell which monitor is focused"
+    exit 1
+  fi
+
   wl-mirror "$PRIMARY" &
+  mirror_pid=$!
+
+  # wl-mirror is backgrounded, so a refused output or a missing protocol ends it
+  # at once and silently. Without this the notification told the user to go and
+  # select a window that was never opened, which is worse than saying nothing:
+  # the whole point of this key is that the window exists to be shared.
+  #
+  # screen-record.sh does the same for the same reason, and the wait is
+  # overridable there too so a suite need not sit through it.
+  sleep "${HYPRSIMPLE_MIRROR_START_WAIT:-0.4}"
+  if ! kill -0 "$mirror_pid" 2>/dev/null; then
+    notify-send -u critical "Virtual Mirror" "wl-mirror could not mirror $PRIMARY"
+    exit 1
+  fi
+
   notify-send "Virtual Mirror" "Mirroring $PRIMARY - Select this window in screen sharing apps"
 fi

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -72,7 +72,7 @@ STUBEOF
 done
 chmod +x "$STUB"/*
 
-run() { CALL_LOG="$LOG" PATH="$STUB:/usr/bin:/bin" bash "$@"; }
+run() { CALL_LOG="$LOG" MIRROR_PIDS="${MIRROR_PIDS:-/dev/null}" PATH="$STUB:/usr/bin:/bin" bash "$@"; }
 
 # --- monitor-mirror-toggle.sh -----------------------------------------------
 
@@ -320,6 +320,82 @@ check "and does not announce a mirror that never started" \
   "$(grep -c 'Mirroring' "$LOG")" "0"
 check "and says what is missing" \
   "$(grep -c 'wl-mirror is not installed' "$LOG")" "1"
+
+# The mirror is announced only when wl-mirror is still there to be selected.
+#
+# wl-mirror is backgrounded, so a refused output or a missing protocol ends it
+# at once and silently. The notification told the user to go and select a window
+# that was never opened, which is worse than saying nothing: the whole point of
+# this key is that the window exists to be shared. screen-record.sh was fixed
+# for the same shape and this was not.
+#
+# The stub wl-mirror exits immediately, which is exactly the failing case, so a
+# separate one that stays up is needed for the working case.
+#
+# pgrep_RC=1 throughout, or the stub reports wl-mirror already running and the
+# script takes its stop branch without reaching any of this.
+# It records its own pid, so the cleanup below can name it.
+#
+# The first version cleaned up with `pkill -f wl-mirror-alive`, and pkill -f
+# matches any process whose whole command line contains that string. It killed
+# the shell that was running this suite, because that shell's command line
+# contained the pattern. Killing one recorded pid cannot reach anything else.
+cat >"$STUB/wl-mirror-alive" <<'STUBEOF'
+#!/bin/bash
+printf 'wl-mirror %s\n' "$*" >>"$CALL_LOG"
+printf '%s\n' "$$" >>"$MIRROR_PIDS"
+exec sleep 5
+STUBEOF
+chmod +x "$STUB/wl-mirror-alive"
+
+MIRROR_PIDS="$TMP/mirror-pids"; : >"$MIRROR_PIDS"
+kill_mirrors() {
+  local pid
+  while read -r pid; do
+    [[ -n $pid ]] && kill "$pid" 2>/dev/null
+  done <"$MIRROR_PIDS"
+  : >"$MIRROR_PIDS"
+}
+
+: >"$LOG"
+MONITORS_JSON="$FIX/monitors-extended.json" pgrep_RC=1 HYPRSIMPLE_MIRROR_START_WAIT=0.1 \
+  run "$BIN/virtual-mirror-toggle.sh" >/dev/null 2>&1
+rc=$?
+check "a wl-mirror that dies at once is not announced as mirroring" \
+  "$(grep -c 'Mirroring' "$LOG")" "0"
+check "and the failure is reported" \
+  "$(grep -c 'could not mirror' "$LOG")" "1"
+check "and the script exits non-zero" "$rc" "1"
+
+# The working case, with a wl-mirror that stays up.
+cp "$STUB/wl-mirror-alive" "$STUB/wl-mirror"
+: >"$LOG"
+MONITORS_JSON="$FIX/monitors-extended.json" pgrep_RC=1 HYPRSIMPLE_MIRROR_START_WAIT=0.2 \
+  run "$BIN/virtual-mirror-toggle.sh" >/dev/null 2>&1
+rc=$?
+check "a wl-mirror that stays up is announced" \
+  "$(grep -c 'Mirroring' "$LOG")" "1"
+check "and names the monitor it was given" \
+  "$(grep -c 'Mirroring eDP-1' "$LOG")" "1"
+check "and exits 0" "$rc" "0"
+# Left running by the check above, and this suite must not leak it.
+kill_mirrors
+
+# A compositor that answers with no focused monitor gave an empty name, and
+# "Mirroring  - Select this window" was shown with a blank in it.
+cat >"$TMP/monitors-none-focused.json" <<'JSONEOF'
+[{"name":"eDP-1","focused":false}]
+JSONEOF
+: >"$LOG"
+MONITORS_JSON="$TMP/monitors-none-focused.json" pgrep_RC=1 HYPRSIMPLE_MIRROR_START_WAIT=0.1 \
+  run "$BIN/virtual-mirror-toggle.sh" >/dev/null 2>&1
+rc=$?
+check "no focused monitor is reported rather than mirrored" \
+  "$(grep -c 'Could not tell which monitor is focused' "$LOG")" "1"
+check "and nothing is announced as mirroring" \
+  "$(grep -c 'Mirroring' "$LOG")" "0"
+check "and wl-mirror is never run" "$(grep -c '^wl-mirror ' "$LOG")" "0"
+check "and the script exits non-zero" "$rc" "1"
 
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2


### PR DESCRIPTION
`virtual-mirror-toggle.sh` backgrounded wl-mirror and notified without looking at either the monitor name or the process:

```bash
PRIMARY=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
...
wl-mirror "$PRIMARY" &
notify-send "Virtual Mirror" "Mirroring $PRIMARY - Select this window in screen sharing apps"
```

A compositor that answers with no focused monitor gives an empty name. Measured:

```
NOTIFICATION: Virtual Mirror Mirroring  - Select this window in screen sharing apps
wl-mirror: no such output ''
rc=0
```

A blank where the monitor should be, exit 0, and wl-mirror already dead.

wl-mirror is backgrounded, so a refused output or a missing protocol ends it at once and silently. Telling someone to go and select a window that was never opened is worse than saying nothing, because the whole point of this key is that the window exists to be shared.

## The precedent was in the repository

`screen-record.sh` already carries it:

> The recorder is backgrounded, so a bad argument or a missing shared library ends it immediately and silently: no file, no indicator, no message. Give it a moment and say so if it is already gone.

Same shape, fixed there, absent here. That is the fourth time in this run that a file defended against something in one place and not another, after the migration runner, the installer prompt, and the audio switch.

## The fix

The name is checked before anything is told to mirror it, and the process is checked before the mirror is announced. The wait is overridable, as the recorder's is, so the suite need not sit through it.

## Tests

Ten checks in `toggle-scripts-test.sh`, covering all three outcomes: wl-mirror dies at once, wl-mirror stays up, and no focused monitor. The working case needs its own stub that stays alive, because the shared stub exits immediately and that is precisely the failing case.

Two sabotages, both red:

| sabotage | checks failed |
| --- | --- |
| the liveness check is removed | 3 |
| the empty-name check is removed | 4 |

## One thing I broke and fixed in the same change

My first cleanup line was `pkill -f 'wl-mirror-alive'`, and `pkill -f` matches any process whose whole command line contains the pattern. **It killed the shell running the suite**, because that shell's command line contained the string. It kills one recorded pid now, which cannot reach anything else. That is the same broad-match mistake this project keeps finding in its own code, committed in a test.

Verified no leak: `sleep` process count is unchanged across a full run, and no wl-mirror is left behind.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
