### PR TITLE
Say whether idle locking is actually on

### DIFF
--- a/.local/bin/toggle-idle.sh
+++ b/.local/bin/toggle-idle.sh
@@ -1,9 +1,37 @@
 #!/bin/bash
 
+# Turn idle locking on or off, and say which of the two actually happened.
+#
+# This backgrounded hypridle, discarded its output and notified regardless:
+#
+#   uwsm app -- hypridle >/dev/null 2>&1 &
+#   notify-send "Idle" "Now locking when idle"
+#
+# A hypridle that refuses to start left the user told the screen would lock on
+# idle when nothing was going to lock it. That is worse than the other
+# announce-regardless bugs in this project: the rest waste a keypress, this one
+# tells you a screen lock is armed when it is not.
+#
+# Waited for and checked, the same way screen-record.sh checks its recorder and
+# virtual-mirror-toggle.sh its mirror. Overridable so the suite need not sit
+# through the wait.
+IDLE_START_WAIT="${HYPRSIMPLE_IDLE_START_WAIT:-0.4}"
+
 if pgrep -x hypridle >/dev/null; then
-  pkill -x hypridle
-  notify-send "Idle" "Stopped locking when idle"
+  if pkill -x hypridle; then
+    notify-send "Idle" "Stopped locking when idle"
+  else
+    notify-send -u critical "Idle" "Could not stop hypridle, so the screen still locks when idle"
+    exit 1
+  fi
 else
   uwsm app -- hypridle >/dev/null 2>&1 &
+
+  sleep "$IDLE_START_WAIT"
+  if ! pgrep -x hypridle >/dev/null; then
+    notify-send -u critical "Idle" "hypridle would not start, so the screen will not lock when idle"
+    exit 1
+  fi
+
   notify-send "Idle" "Now locking when idle"
 fi

--- a/test/toggle-scripts-test.sh
+++ b/test/toggle-scripts-test.sh
@@ -397,6 +397,86 @@ check "and nothing is announced as mirroring" \
 check "and wl-mirror is never run" "$(grep -c '^wl-mirror ' "$LOG")" "0"
 check "and the script exits non-zero" "$rc" "1"
 
+# --- toggle-idle.sh ----------------------------------------------------------
+#
+# It backgrounded hypridle, discarded its output and notified regardless, so a
+# hypridle that refused to start left the user told the screen would lock on
+# idle when nothing was going to lock it. Worse than the other
+# announce-regardless bugs here: the rest waste a keypress, this one says a
+# screen lock is armed when it is not.
+#
+# Its own stub directory, because pgrep has to answer differently before and
+# after the start, which the shared stub cannot do.
+IDLE="$TMP/idle"; mkdir -p "$IDLE"
+IDLE_STARTED="$IDLE/started"
+
+cat >"$IDLE/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf 'notify-send %s\n' "$*" >>"$CALL_LOG"
+STUBEOF
+cat >"$IDLE/pgrep" <<'STUBEOF'
+#!/bin/bash
+[[ -e $IDLE_STARTED ]] && exit 0
+exit 1
+STUBEOF
+cat >"$IDLE/uwsm" <<'STUBEOF'
+#!/bin/bash
+printf 'uwsm %s\n' "$*" >>"$CALL_LOG"
+[[ -n ${UWSM_FAILS:-} ]] && exit 1
+: >"$IDLE_STARTED"
+exit 0
+STUBEOF
+cat >"$IDLE/pkill" <<'STUBEOF'
+#!/bin/bash
+printf 'pkill %s\n' "$*" >>"$CALL_LOG"
+[[ -n ${PKILL_FAILS:-} ]] && exit 1
+rm -f "$IDLE_STARTED"
+exit 0
+STUBEOF
+chmod +x "$IDLE"/*
+
+run_idle() {
+  CALL_LOG="$LOG" IDLE_STARTED="$IDLE_STARTED" HYPRSIMPLE_IDLE_START_WAIT=0.1 \
+    PATH="$IDLE:/usr/bin:/bin" bash "$BIN/toggle-idle.sh" >/dev/null 2>&1
+  printf '%s' "$?" >"$TMP/idle-rc"
+}
+
+# hypridle refuses to start.
+rm -f "$IDLE_STARTED"; : >"$LOG"
+UWSM_FAILS=1 run_idle
+check "a hypridle that will not start is not reported as locking" \
+  "$(grep -c 'Now locking when idle' "$LOG")" "0"
+check "and the user is told the screen will not lock" \
+  "$(grep -c 'will not lock when idle' "$LOG")" "1"
+check "critically, because a lock that is not armed is worth interrupting for" \
+  "$(grep -c -- '-u critical' "$LOG")" "1"
+check "and the script exits non-zero" \
+  "$([[ $(cat "$TMP/idle-rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+check "and it really did try to start it" "$(grep -c '^uwsm ' "$LOG")" "1"
+
+# hypridle starts and stays up.
+rm -f "$IDLE_STARTED"; : >"$LOG"
+run_idle
+check "a hypridle that starts is reported as locking" \
+  "$(grep -c 'Now locking when idle' "$LOG")" "1"
+check "and the script exits 0" "$(cat "$TMP/idle-rc")" "0"
+
+# Running again turns it off, because pgrep now finds it.
+: >"$LOG"
+run_idle
+check "a second press stops it" "$(grep -c 'Stopped locking when idle' "$LOG")" "1"
+check "and exits 0" "$(cat "$TMP/idle-rc")" "0"
+
+# The stop can fail too, and then idle locking is still on.
+: >"$IDLE_STARTED"; : >"$LOG"
+PKILL_FAILS=1 run_idle
+check "a stop that failed is not reported as stopped" \
+  "$(grep -c 'Stopped locking when idle' "$LOG")" "0"
+check "and says the screen still locks" \
+  "$(grep -c 'still locks when idle' "$LOG")" "1"
+check "and exits non-zero" \
+  "$([[ $(cat "$TMP/idle-rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
`toggle-idle.sh` backgrounded hypridle, discarded its output and notified regardless:

```bash
uwsm app -- hypridle >/dev/null 2>&1 &
notify-send "Idle" "Now locking when idle"
```

Measured with a uwsm that fails:

```
NOTIFICATION: Idle Now locking when idle
rc=0
```

**This one is worse than the other announce-regardless bugs in this project.** The rest waste a keypress. This says a screen lock is armed when it is not, and the person walks away from the machine believing it.

## The fix

The start is waited for and checked, the way `screen-record.sh` checks its recorder and `virtual-mirror-toggle.sh` its mirror. The stop is checked too, and a stop that failed says the screen **still** locks rather than claiming it does not.

## How it was found

By sweeping every backgrounded process in the shipped scripts for one with no check after it, rather than reading files one at a time. Of the five:

| script | verdict |
| --- | --- |
| `screen-record.sh` (×2) | already checked |
| `virtual-mirror-toggle.sh` | checked, in #134 |
| `hyprsimple-restart-dunst.sh`, `hyprsimple-restart-waybar.sh` | unchecked, but announce nothing, so nothing is promised |
| **`toggle-idle.sh`** | **unchecked and makes a promise** |

Naming the pattern and sweeping for it found the one instance that mattered and cleared the two that did not, which is faster and more honest than another file-by-file read.

## Tests

**The script had no test at all before this.** Twelve checks now cover all four outcomes: start fails, start succeeds, stop succeeds, stop fails. Its own stub directory, because `pgrep` has to answer differently before and after the start and the shared stub cannot.

Two sabotages, both red:

| sabotage | checks failed |
| --- | --- |
| back to notifying regardless | 4 |
| the stop is not checked | 3 |

My first attempt at the first sabotage cut the file badly enough to give a syntax error, which tests less than intended, so I redid it as a clean behaviour revert and confirmed `bash -n` passes before reading the result.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
