### PR TITLE
Do not announce a live wallpaper change hyprpaper did not take

### DIFF
--- a/.local/bin/live-wallpaper-toggle.sh
+++ b/.local/bin/live-wallpaper-toggle.sh
@@ -28,6 +28,20 @@ fi
 
 ACTION="$1"
 
+# Restart hyprpaper and say whether it took.
+#
+# Both branches below used to run the restart unchecked and notify regardless,
+# so a hyprpaper that would not come back left the user told live wallpaper was
+# on while nothing was cycling. Measured with a systemctl that fails:
+# "Enabled (30s cycle)", exit 0.
+#
+# The setting itself is already written by then, and that part did work, so the
+# message says the state was recorded and names the half that did not happen
+# rather than pretending nothing was done.
+reload_hyprpaper() {
+  systemctl --user restart hyprpaper.service 2>/dev/null
+}
+
 turn_off() {
   # Try to get current wallpaper from hyprpaper IPC
   ACTIVE=$(hyprctl hyprpaper listactive 2>/dev/null | head -1)
@@ -51,15 +65,23 @@ turn_off() {
 
   write_hyprpaper_conf "$HOME/.cache/current_wallpaper"
   rm -f "$FLAG"
-  systemctl --user restart hyprpaper.service
-  notify-send "Live Wallpaper" "Disabled" -i "$CACHE_DIR/current_wallpaper"
+  if reload_hyprpaper; then
+    notify-send "Live Wallpaper" "Disabled" -i "$CACHE_DIR/current_wallpaper"
+  else
+    notify-send -u critical "Live Wallpaper" "Disabled, but hyprpaper did not restart, so the screen still shows the old one until you log in again"
+    exit 1
+  fi
 }
 
 turn_on() {
   write_hyprpaper_conf "$BG_DIR" 30
   touch "$FLAG"
-  systemctl --user restart hyprpaper.service
-  notify-send "Live Wallpaper" "Enabled (30s cycle)" -i "$CACHE_DIR/current_wallpaper"
+  if reload_hyprpaper; then
+    notify-send "Live Wallpaper" "Enabled (30s cycle)" -i "$CACHE_DIR/current_wallpaper"
+  else
+    notify-send -u critical "Live Wallpaper" "Enabled, but hyprpaper did not restart, so nothing cycles until you log in again"
+    exit 1
+  fi
 }
 
 case "$ACTION" in

--- a/test/live-wallpaper-persistence-test.sh
+++ b/test/live-wallpaper-persistence-test.sh
@@ -145,6 +145,80 @@ check "and no longer forces it on" \
 check "stripping comments leaves the file's code intact" \
   "$(code_of "$REPO/default/hypr/autostart.lua" | grep -c 'uwsm app -- waybar')" "1"
 
+# --- a reload that failed is not announced as a change on screen -------------
+#
+# Both branches ran `systemctl --user restart hyprpaper.service` unchecked and
+# notified regardless, so a hyprpaper that would not come back left the user
+# told live wallpaper was on while nothing was cycling. Measured with a
+# systemctl that fails: "Enabled (30s cycle)", exit 0.
+#
+# The setting is written before the restart and that part does work, so the
+# message names the half that did not happen rather than pretending nothing was
+# done, and the flag is still expected to be set.
+
+NLOG="$TMP/notifications"
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUBEOF
+chmod +x "$STUB/notify-send"
+
+run_notifying() {
+  NOTIFY_LOG="$NLOG" HOME="$HOME_DIR" PATH="$STUB:/usr/bin:/bin" \
+    bash "$HOME_DIR/.local/bin/live-wallpaper-toggle.sh" "$1" >/dev/null 2>&1
+  printf '%s' "$?" >"$TMP/lw-rc"
+}
+
+fail_restart() {
+  cat >"$STUB/systemctl" <<'STUBEOF'
+#!/bin/bash
+echo "Failed to restart hyprpaper.service" >&2
+exit 1
+STUBEOF
+  chmod +x "$STUB/systemctl"
+}
+pass_restart() { printf '#!/bin/bash\nexit 0\n' >"$STUB/systemctl"; chmod +x "$STUB/systemctl"; }
+
+# Turning it on, with a hyprpaper that will not restart.
+setup; rm -f "$HOME_DIR/.cache/live_wallpaper_enabled"
+fail_restart; : >"$NLOG"
+run_notifying on
+check "a failed restart is not announced as cycling" \
+  "$(grep -c 'Enabled (30s cycle)' "$NLOG")" "0"
+check "and the user is told nothing cycles yet" \
+  "$(grep -c 'nothing cycles' "$NLOG")" "1"
+check "and it exits non-zero" \
+  "$([[ $(cat "$TMP/lw-rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+check "while the setting is still recorded, because that part did work" "$(flag)" "on"
+
+# Turning it off, same failure.
+setup
+fail_restart; : >"$NLOG"
+run_notifying off
+check "a failed restart on the way off is not announced as disabled" \
+  "$(grep -c '^Live Wallpaper Disabled -i' "$NLOG")" "0"
+check "and says the old one is still on screen" \
+  "$(grep -c 'still shows the old one' "$NLOG")" "1"
+check "while the setting is still recorded" "$(flag)" "off"
+
+# Anti-vacuity: with a restart that works, both are announced plainly. A script
+# that always reported failure would satisfy every check above.
+setup; rm -f "$HOME_DIR/.cache/live_wallpaper_enabled"
+pass_restart; : >"$NLOG"
+run_notifying on
+check "a restart that works is announced as cycling" \
+  "$(grep -c 'Enabled (30s cycle)' "$NLOG")" "1"
+check "and exits 0" "$(cat "$TMP/lw-rc")" "0"
+
+: >"$NLOG"
+run_notifying off
+check "and turning it off is announced plainly" \
+  "$(grep -c 'Live Wallpaper Disabled' "$NLOG")" "1"
+check "and exits 0" "$(cat "$TMP/lw-rc")" "0"
+
+# Restore the quiet stub for anything after this.
+printf '#!/bin/bash\nexit 0\n' >"$STUB/notify-send"; chmod +x "$STUB/notify-send"
+
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
Both branches of `live-wallpaper-toggle.sh` ran the reload unchecked and notified regardless:

```bash
systemctl --user restart hyprpaper.service
notify-send "Live Wallpaper" "Enabled (30s cycle)" -i "$CACHE_DIR/current_wallpaper"
```

Measured with a systemctl that fails:

```
NOTIFICATION: Live Wallpaper Enabled (30s cycle)
rc=0
```

The setting was written, but hyprpaper never came back, so nothing cycles and the user is told it does.

## The fix

The reload is checked. A failure names the half that did not happen rather than pretending nothing was done:

> Enabled, but hyprpaper did not restart, so nothing cycles until you log in again

**The flag stays set.** The setting was written before the restart and that part did work, so rolling it back would throw away a choice the user made because a separate step failed. The next login applies it.

## How it was found

By sweeping every `notify-send` that reports success for an unchecked command in front of it, rather than reading files one at a time. Three sites came back:

| site | verdict |
| --- | --- |
| `live-wallpaper-toggle.sh` ×2 | fixed here |
| `battery-monitor.sh`, `brightnessctl set` | **left alone**, deliberately |

The battery one is left because the guard directly above it has just read that same device successfully to compare the current brightness. A `set` failing between those two lines is not a case this can reach, and changing it would be churn rather than a fix.

The `apply` branch is also untouched. It runs at login with `|| true` already on it, and reporting a failure to nobody at that point is noise.

## Tests

Nine checks in `live-wallpaper-persistence-test.sh`, covering both directions with a reload that fails and both with one that works. The working pair is the anti-vacuity half: a script that always reported failure would satisfy every failure check on its own.

One check exists only to pin the deliberate decision above: with the reload failed, the flag must still be **on**.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| back to notifying regardless, on | 3 |
| the same on the off branch | 2 |
| the setting is rolled back when the reload fails | 1 |

The third is the one worth having. Rolling the flag back is the obvious-looking thing to do on failure, and it would quietly discard the user's choice.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
