### PR TITLE
Put the muslimtify module in modules-left, and only there

### DIFF
--- a/.local/bin/hyprsimple-muslimtify.sh
+++ b/.local/bin/hyprsimple-muslimtify.sh
@@ -95,8 +95,18 @@ cmd_add() {
     backup "$WAYBAR_CONFIG"
 
     # Insert into modules-left after "hyprland/workspaces"
-    sed -i 's|"hyprland/workspaces"\(\s*\)\]|"hyprland/workspaces", "custom/muslimtify"\1]|' "$WAYBAR_CONFIG"
-    sed -i 's|"hyprland/workspaces",|"hyprland/workspaces", "custom/muslimtify",|' "$WAYBAR_CONFIG"
+    #
+    # Addressed to the modules-left line, not applied to the whole file. Both
+    # substitutions matched "hyprland/workspaces" wherever it appeared, and a
+    # config with workspaces in two lists got the module in both:
+    #
+    #   "modules-left":  ["hyprland/workspaces", "custom/muslimtify", "clock"]
+    #   "modules-right": ["hyprland/workspaces", "custom/muslimtify", "tray"]
+    #
+    # so the prayer times showed up twice in the bar. The comment above has
+    # always said modules-left; only the address makes it true.
+    sed -i '/"modules-left"/ s|"hyprland/workspaces"\(\s*\)\]|"hyprland/workspaces", "custom/muslimtify"\1]|' "$WAYBAR_CONFIG"
+    sed -i '/"modules-left"/ s|"hyprland/workspaces",|"hyprland/workspaces", "custom/muslimtify",|' "$WAYBAR_CONFIG"
     # Above two regexes collide if modules-left is just ["hyprland/workspaces"]; dedupe just in case:
     sed -i 's|"custom/muslimtify", "custom/muslimtify"|"custom/muslimtify"|g' "$WAYBAR_CONFIG"
 

--- a/test/muslimtify-and-dns-test.sh
+++ b/test/muslimtify-and-dns-test.sh
@@ -87,6 +87,82 @@ check "a failed cd is reported" "$?" "1"
 after=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'yazi-cwd.*' 2>/dev/null | wc -l)
 check "a failed cd still cleans up its temp file" "$after" "$before"
 
+# --- the module goes into modules-left, and only there -----------------------
+#
+# The two substitutions matched "hyprland/workspaces" wherever it appeared, so a
+# config with workspaces in two lists got the module in both and the prayer
+# times showed up twice in the bar:
+#
+#   "modules-left":  ["hyprland/workspaces", "custom/muslimtify", "clock"]
+#   "modules-right": ["hyprland/workspaces", "custom/muslimtify", "tray"]
+#
+# The comment above them has always said modules-left. Only the address makes
+# it true.
+#
+# The substitutions are read out of the script rather than copied here, so this
+# exercises what ships.
+# Only the ones between the injection comment and the module definition that
+# follows it. Taking every substitution mentioning custom/muslimtify also took
+# the two that remove it, which stripped the module straight back out and made
+# five checks fail for a reason that had nothing to do with the fix.
+mapfile -t inject_seds < <(
+  sed -n '/Insert into modules-left/,/Insert module definition/p' \
+    "$BIN/hyprsimple-muslimtify.sh" |
+    grep -oE "sed -i '[^']*'" |
+    sed "s/^sed -i '//; s/'$//"
+)
+if (( ${#inject_seds[@]} != 3 )); then
+  fail "read ${#inject_seds[@]} injection substitutions out of the script, and there are three"
+else
+  pass "read the three injection substitutions out of the script"
+fi
+
+apply_injection() {
+  local file="$1" expr
+  for expr in "${inject_seds[@]}"; do
+    sed -i "$expr" "$file"
+  done
+}
+
+two_lists="$TMP/waybar-two-lists.jsonc"
+cat >"$two_lists" <<'JSONEOF'
+{
+    "modules-left": ["hyprland/workspaces", "clock"],
+    "modules-center": ["hyprland/window"],
+    "modules-right": ["hyprland/workspaces", "tray"],
+    "custom/power": { "format": "x" }
+}
+JSONEOF
+apply_injection "$two_lists"
+
+check "with workspaces in two lists, modules-left gets the module" \
+  "$(grep -c '"modules-left".*custom/muslimtify' "$two_lists")" "1"
+check "and modules-right does not" \
+  "$(grep -c '"modules-right".*custom/muslimtify' "$two_lists")" "0"
+check "so the module appears exactly once" \
+  "$(grep -c 'custom/muslimtify' "$two_lists")" "1"
+
+# Anti-vacuity: the injection still does something on an ordinary config, and
+# on the shape where modules-left holds nothing but workspaces.
+ordinary="$TMP/waybar-ordinary.jsonc"
+cat >"$ordinary" <<'JSONEOF'
+{
+    "modules-left": ["hyprland/workspaces", "clock"],
+    "modules-right": ["tray"]
+}
+JSONEOF
+apply_injection "$ordinary"
+check "an ordinary config still gets the module" \
+  "$(grep -c '"modules-left".*custom/muslimtify' "$ordinary")" "1"
+
+solo="$TMP/waybar-solo.jsonc"
+printf '{\n    "modules-left": ["hyprland/workspaces"],\n    "modules-right": ["clock"]\n}\n' >"$solo"
+apply_injection "$solo"
+check "and so does one whose modules-left holds only workspaces" \
+  "$(grep -c '"modules-left".*custom/muslimtify' "$solo")" "1"
+check "without doubling it, which the dedupe is there for" \
+  "$(grep -c 'custom/muslimtify' "$solo")" "1"
+
 if (( failures > 0 )); then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
The two substitutions that inject the module matched `"hyprland/workspaces"` **wherever it appeared** in the waybar config, not on the modules-left line:

```bash
# Insert into modules-left after "hyprland/workspaces"
sed -i 's|"hyprland/workspaces"\(\s*\)\]|"hyprland/workspaces", "custom/muslimtify"\1]|' "$WAYBAR_CONFIG"
sed -i 's|"hyprland/workspaces",|"hyprland/workspaces", "custom/muslimtify",|' "$WAYBAR_CONFIG"
```

A config with workspaces in two lists gets the module in both, so the prayer times show up twice in the bar:

```
"modules-left":  ["hyprland/workspaces", "custom/muslimtify", "clock"]
"modules-right": ["hyprland/workspaces", "custom/muslimtify", "tray"]
```

The comment above them has always said modules-left. Only the address makes it true.

## Reachability

Anyone who has moved or duplicated the workspaces module, which is an ordinary thing to do to a waybar config and which nothing here discourages. Narrower than the last few, and I would rather say so than dress it up.

## How it was found

By sweeping every `sed -i` in the shipped scripts for a pattern with nothing anchoring it. Of the eight:

| site | verdict |
| --- | --- |
| `hyprsimple-refresh-waybar.sh`, `hyprsimple-theme-deliver.sh` | anchored |
| `theme-switcher.sh` | anchored in #125, for this same reason |
| `hyprsimple-muslimtify.sh` ×5 | two inject, and both matched too much |

The three removal substitutions are deliberately left global: removing the module from every list it is in is the right behaviour.

## Tests

Six checks in `muslimtify-and-dns-test.sh`. The substitutions are read **out of the script** rather than copied into the suite, so this exercises what ships.

Three of the six are anti-vacuity: an ordinary config still gets the module, a config whose modules-left holds only workspaces still gets it, and it is not doubled there.

Two sabotages, both red:

| sabotage | checks failed |
| --- | --- |
| the address is dropped from both | 2 |
| the address is dropped from just one | 2 |

The second matters: one address alone is not enough, and a partial fix would otherwise look complete.

## A fixture fault of my own

My first extraction took **every** substitution mentioning `custom/muslimtify`, which included the two that **remove** it. Those stripped the module straight back out and five checks failed for a reason that had nothing to do with the change. It now reads only the three between the injection comment and the module definition, and asserts there are exactly three.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
