### PR TITLE
Stop the update hanging on an origin that stalls

### DIFF
--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -58,6 +58,73 @@ case "${1-}" in
     ;;
 esac
 
+# Network calls that stop rather than hang.
+#
+# The three git calls below reach out to origin, and none of them was bounded.
+# A connection that stalls mid transfer leaves "Pulling latest hyprsimple..."
+# on screen with no output, no timeout and nothing to say whether it is slow or
+# wedged. Seen doing exactly that: an established connection to github with
+# nothing moving through it for two and a half minutes, while curl to the same
+# host answered in under a second, until it was interrupted by hand.
+#
+# git's own low speed guard rather than an outer timeout. It aborts a transfer
+# that drops below a byte rate for a stretch, which is the stalled case, and it
+# leaves a slow but working transfer alone. A wall clock timeout cannot tell
+# those apart and would cut off someone on a poor connection who was making
+# progress.
+#
+# Both overridable, so a machine on a genuinely slow link can raise them and
+# the suite can drop them to something it need not wait for.
+GIT_STALL_BYTES="${HYPRSIMPLE_GIT_STALL_BYTES:-1000}"
+GIT_STALL_SECONDS="${HYPRSIMPLE_GIT_STALL_SECONDS:-30}"
+
+# Tried again before giving up, because the stall that prompted this cleared on
+# its own: the run that hung was interrupted by hand and the very next one
+# finished in under a second. A failure the user fixes by pressing up and enter
+# is a failure this can absorb.
+#
+# Output is collected per attempt and only emitted once, on success. A retry
+# that appended to a partial answer would corrupt the tag list this feeds.
+GIT_ATTEMPTS="${HYPRSIMPLE_GIT_ATTEMPTS:-3}"
+
+git_net() {
+  local attempt=1 out status
+  out=$(mktemp) || return 1
+  while :; do
+    # The status is taken from git directly, not after an if.
+    #
+    # `if cmd; then ...; fi` with a false condition and no else returns 0, so
+    # reading $? on the line after the fi captured 0 and this function reported
+    # success for a fetch that had failed every attempt. The script then carried
+    # on with a repository it had not updated and printed "hyprsimple is up to
+    # date", which is worse than the hang this was written to replace.
+    git -c "http.lowSpeedLimit=$GIT_STALL_BYTES" \
+        -c "http.lowSpeedTime=$GIT_STALL_SECONDS" \
+        -C "$HYPRSIMPLE_PATH" "$@" >"$out" 2>/dev/null
+    status=$?
+
+    if (( status == 0 )); then
+      cat "$out"
+      rm -f "$out"
+      return 0
+    fi
+
+    if (( attempt >= GIT_ATTEMPTS )); then
+      rm -f "$out"
+      return "$status"
+    fi
+
+    echo -e "${YELLOW}That did not get through. Trying again ($((attempt + 1)) of $GIT_ATTEMPTS)...${NC}" >&2
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+}
+
+stalled_hint() {
+  echo -e "${YELLOW}If that keeps happening, the connection to origin is stalling rather than failing.${NC}" >&2
+  echo "Check the network and run hyprsimple-update again." >&2
+}
+
 # The tag list cannot come from the local repository. The history-shrinking
 # migration deletes every tag ref, and the fetch refspec only covers branches,
 # so a shrunk install has no tags at all and never grows any on its own.
@@ -65,7 +132,7 @@ esac
 # their numbers. A plain `sort -V` puts every unprefixed tag below every
 # prefixed one, which is only accidentally right while the newest tag has a v.
 latest_release_tag() {
-  git -C "$HYPRSIMPLE_PATH" ls-remote --tags origin |
+  git_net ls-remote --tags origin |
     sed 's|.*refs/tags/||; s|\^{}$||' | sort -u |
     awk '{ key = $0; sub(/^v/, "", key); print key "\t" $0 }' |
     sort -V | tail -1 | cut -f2
@@ -121,8 +188,9 @@ if [[ -d $HYPRSIMPLE_PATH/.git ]]; then
     # git prints "! [rejected] (would clobber existing tag)" and still exits 0,
     # so a re-pointed release would leave the install on the old commit while
     # this script reported success.
-    git -C "$HYPRSIMPLE_PATH" fetch --quiet --force --depth 1 origin tag "$tag" || {
+    git_net fetch --quiet --force --depth 1 origin tag "$tag" || {
       echo -e "${RED}Could not fetch $tag from origin.${NC}"
+      stalled_hint
       exit 1
     }
     git -C "$HYPRSIMPLE_PATH" checkout --quiet --detach "$tag"
@@ -132,8 +200,10 @@ if [[ -d $HYPRSIMPLE_PATH/.git ]]; then
     # the shallow boundary to the new tip, which disconnects the commit this
     # install is on and turns the fast-forward below into "refusing to merge
     # unrelated histories". A plain fetch keeps the boundary and stays shallow.
-    if ! git -C "$HYPRSIMPLE_PATH" fetch --quiet origin "$target"; then
-      echo -e "${RED}origin has no branch called '$target'.${NC}"
+    if ! git_net fetch --quiet origin "$target"; then
+      echo -e "${RED}Could not fetch '$target' from origin.${NC}"
+      echo "Either origin has no branch by that name, or the fetch did not complete." >&2
+      stalled_hint
       exit 1
     fi
     if [[ $target == "$current_branch" ]]; then

--- a/test/update-channel-test.sh
+++ b/test/update-channel-test.sh
@@ -163,9 +163,16 @@ before=$(git -C "$INSTALL" rev-parse HEAD)
 run_update no-such-branch
 check "an unknown branch fails" "$(rc)" 1
 check "an unknown branch leaves the install alone" "$(git -C "$INSTALL" rev-parse HEAD)" "$before"
-if grep -q "no branch called 'no-such-branch'" "$TMP/out"; then
+# The branch has to be named, whatever the wording around it. The message used
+# to assert the cause outright, "origin has no branch called X", and a fetch
+# that stalled produced that same line about a branch that exists. It says which
+# fetch failed and offers both causes now.
+if grep -q "no-such-branch" "$TMP/out"; then
   pass "an unknown branch is named in the error"
 else fail "an unknown branch is named in the error"; fi
+if grep -q "no branch by that name" "$TMP/out"; then
+  pass "and a missing branch is still offered as the cause"
+else fail "and a missing branch is still offered as the cause"; fi
 
 run_update --nonsense
 check "an unknown option fails" "$(rc)" 1
@@ -174,6 +181,127 @@ check "--help exits 0" "$(rc)" 0
 
 # --- the shrink must survive all of it --------------------------------------
 check "the install is still shallow" "$(git -C "$INSTALL" rev-parse --is-shallow-repository)" true
+
+# ---- a stalled origin stops instead of hanging -------------------------------
+#
+# The three git calls that reach origin were unbounded. A connection that
+# stalls mid transfer left "Pulling latest hyprsimple..." on screen with no
+# output, no timeout and nothing to say whether it was slow or wedged. Seen
+# doing exactly that on a real machine: an established connection to github
+# with nothing moving through it for two and a half minutes, while curl to the
+# same host answered in under a second, until it was interrupted by hand.
+#
+# Driven against a server that accepts and then sends nothing, which is that
+# stall, rather than against a refused or missing port. A refusal fails fast on
+# its own and would prove nothing about the guard.
+
+STALL_LOG="$TMP/stall-server.log"
+STALL_PIDFILE="$TMP/stall-server.pid"
+cat >"$TMP/stallserver.py" <<'PYEOF'
+import socket, sys
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", 0))
+s.listen(16)
+print(s.getsockname()[1], flush=True)
+held = []
+while True:
+    c, _ = s.accept()
+    held.append(c)  # accepted, never answered, never closed
+PYEOF
+
+python3 "$TMP/stallserver.py" >"$STALL_LOG" 2>/dev/null &
+printf '%s' "$!" >"$STALL_PIDFILE"
+# By recorded pid, never by pattern. pkill -f matches the command line of
+# whatever shell is running this suite, and a pattern that appears in that
+# command line kills the suite itself.
+kill_stall_server() {
+  local pid
+  pid=$(cat "$STALL_PIDFILE" 2>/dev/null) || return 0
+  [[ -n $pid ]] && kill "$pid" 2>/dev/null
+  : >"$STALL_PIDFILE"
+}
+trap 'kill_stall_server; rm -rf "$TMP"' EXIT
+
+stall_port=""
+for _ in $(seq 1 50); do
+  stall_port=$(head -1 "$STALL_LOG" 2>/dev/null)
+  [[ -n $stall_port ]] && break
+  sleep 0.1
+done
+
+if [[ -z $stall_port ]]; then
+  fail "the stalling server did not start, so the guard is not being tested"
+else
+  pass "a stalling server is listening on port $stall_port"
+
+  stall_install="$TMP/stall-install"
+  must_be_fixture "$stall_install"
+  git init -q "$stall_install"
+  git -C "$stall_install" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$stall_install" branch -M main
+  git -C "$stall_install" remote add origin "http://127.0.0.1:$stall_port/x.git"
+
+  started=$(date +%s)
+  HOME="$FAKE_HOME" HYPRSIMPLE_PATH="$stall_install" PATH="$STUB:$PATH" \
+    HYPRSIMPLE_GIT_STALL_SECONDS=3 HYPRSIMPLE_GIT_STALL_BYTES=1000 \
+    HYPRSIMPLE_GIT_ATTEMPTS=2 \
+    timeout 40 bash "$UPDATE" main >"$TMP/stall-out" 2>&1
+  stall_rc=$?
+  elapsed=$(( $(date +%s) - started ))
+
+  check "a stalled origin does not hang the update" \
+    "$([[ $stall_rc == 124 ]] && echo hung || echo stopped)" "stopped"
+  check "and it stops near the guard rather than much later (${elapsed}s)" \
+    "$([[ $elapsed -lt 20 ]] && echo prompt || echo late)" "prompt"
+  check "and exits non-zero" \
+    "$([[ $stall_rc != "0" ]] && echo nonzero || echo zero)" "nonzero"
+  check "and says the fetch did not complete" \
+    "$(grep -c 'did not complete' "$TMP/stall-out")" "1"
+  check "and names stalling as the thing to look at" \
+    "$(grep -c 'stalling rather than failing' "$TMP/stall-out")" "1"
+
+  # The half that matters most: a fetch that never got through must not leave
+  # the run reporting success. The first version of the retry read $? on the
+  # line after an if whose condition had failed, which in bash is 0, so it
+  # returned success for a fetch that failed every attempt and the script went
+  # on to print "hyprsimple is up to date" against a repository it had not
+  # updated. That is worse than the hang it replaced.
+  check "a fetch that never got through is not reported as up to date" \
+    "$(grep -c 'up to date' "$TMP/stall-out")" "0"
+  check "and the run does not claim a version it did not fetch" \
+    "$(grep -c 'Now on hyprsimple' "$TMP/stall-out")" "0"
+
+  # It really did try more than once, or the retry is not being exercised.
+  check "and it tried again before giving up" \
+    "$(grep -c 'Trying again' "$TMP/stall-out")" "1"
+
+  # Without the guard the same fetch is still running when the cap fires, which
+  # is what makes the checks above about the guard and not about the server.
+  started=$(date +%s)
+  timeout 8 git -C "$stall_install" fetch --quiet origin main >/dev/null 2>&1
+  bare_rc=$?
+  check "the same fetch unguarded is still hanging when it is cut off" \
+    "$([[ $bare_rc == 124 ]] && echo hanging || echo stopped)" "hanging"
+  check "and it used the whole window rather than failing early" \
+    "$([[ $(( $(date +%s) - started )) -ge 7 ]] && echo whole || echo early)" "whole"
+
+  kill_stall_server
+fi
+
+# All three calls that reach origin go through the guard, not just the one the
+# checks above happen to exercise.
+update_code() { sed 's/^[[:space:]]*#.*//' "$UPDATE"; }
+check "no call to origin bypasses the guard" \
+  "$(update_code | grep -cE 'git -C "\$HYPRSIMPLE_PATH" (fetch|ls-remote)')" "0"
+check "and the guard is used by all three of them" \
+  "$(update_code | grep -cE 'git_net (fetch|ls-remote)')" "3"
+check "the number of attempts is bounded and overridable" \
+  "$(update_code | grep -c 'HYPRSIMPLE_GIT_ATTEMPTS')" "1"
+check "and it sets both halves of git's low speed check" \
+  "$(update_code | grep -c 'http.lowSpeedLimit')" "1"
+check "and the time half too" \
+  "$(update_code | grep -c 'http.lowSpeedTime')" "1"
 
 if ((failures > 0)); then
   printf '\n%d check(s) failed\n' "$failures" >&2


### PR DESCRIPTION
`hyprsimple-update.sh` makes three calls to origin and **none of them was bounded**:

```
line  68  git ls-remote --tags origin
line 124  git fetch --quiet --force --depth 1 origin tag
line 135  git fetch --quiet origin "$target"
```

A connection that stalls mid transfer left `Pulling latest hyprsimple...` on screen with no output, no timeout, and nothing to say whether it was slow or wedged.

## Seen on a live machine

Caught while it was happening:

| observation | result |
| --- | --- |
| `git fetch` process age | 149 seconds |
| its TCP connection to github | ESTABLISHED, zero bytes queued |
| `curl https://github.com` | 200 in 0.6s |
| `ls-remote` from another clone of the same repo | instant |

So origin was reachable and that one connection was simply wedged. It ended by being interrupted by hand, and the very next run finished in under a second.

## The fix

**A low speed guard, not an outer timeout.** git aborts a transfer that drops below a byte rate for a stretch, which is the stalled case, and leaves a slow but working transfer alone. A wall clock timeout cannot tell those apart and would cut off someone on a poor connection who was making progress.

**Retried before giving up**, because that stall cleared on its own. A failure the user fixes by pressing up and enter is one this can absorb. Output is collected per attempt and emitted once on success, so a retry cannot append to a partial answer and corrupt the tag list.

The branch fetch also stopped asserting its own cause. It said "origin has no branch called X", and a stall produced that line about a branch that exists. It now says which fetch failed and offers both causes.

Before and after, against a server that accepts and sends nothing:

```
unbounded:  still running when cut off at 12s
guarded:    gave up on its own at 3s, exit 128
full script: exit 1 in 1s, with the reason and what to do
```

## A bug I nearly shipped inside this fix

My first retry read the status like this:

```bash
if git ...; then
  return 0
fi
status=$?          # 0, always
```

**An `if` whose condition fails and which has no `else` returns 0.** So `git_net` reported success for a fetch that failed every attempt, and the script printed `hyprsimple is up to date` against a repository it had not updated. That is worse than the hang it was replacing.

Caught by running it, not by reading it. The status is now taken from git directly, and two checks pin it:

- a fetch that never got through is not reported as up to date
- the run does not claim a version it did not fetch

Restoring the exact broken form turns **7 checks red**.

## Tests

Driven against a server that accepts and then sends nothing, which is that stall, rather than a refused port that fails fast on its own and would prove nothing. A control check confirms the same fetch **unguarded** is still hanging when the test cuts it off, so the result is about the guard and not the server.

The server is killed by recorded pid. `pkill -f` matches the command line of whatever shell is running the suite, which has already killed one of my own runs this session.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
