### PR TITLE
Move the recording indicator to the left and label it

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -12,9 +12,9 @@
     //   8  custom/screenrecording, sent by .local/bin/screen-record.sh
     //   7, 9, 10 unused
     // Choose the order of the modules
-    "modules-left": ["hyprland/workspaces", "custom/muslimtify"],
+    "modules-left": ["hyprland/workspaces", "custom/muslimtify", "custom/screenrecording"],
     "modules-center": ["hyprland/window"],
-    "modules-right": ["cpu", "memory", "network", "bluetooth", "pulseaudio","pulseaudio#microphone", "backlight", "battery", "custom/screenrecording", "clock", "tray", "custom/lock", "custom/power"],
+    "modules-right": ["cpu", "memory", "network", "bluetooth", "pulseaudio","pulseaudio#microphone", "backlight", "battery", "clock", "tray", "custom/lock", "custom/power"],
     "hyprland/workspaces": {
          "disable-scroll": true,
          "sort-by-name": true,

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -180,13 +180,34 @@ tooltip label {
     box-shadow: inset 0 1px 0 alpha(@warning, 0.15), 0 2px 8px alpha(@warning, 0.2);
 }
 
+/* Nothing at all when nothing is recording.
+   waybar-screenrecording.sh emits an empty string then, and a background or
+   padding here would leave an empty pill sitting in the bar next to the prayer
+   times. Everything visible belongs to .active. */
 #custom-screenrecording {
-    min-width: 12px;
-    margin: 0 7.5px;
+    min-width: 0;
+    margin: 0;
     padding: 0;
+    background: transparent;
+    border: none;
 }
 
+/* Recording: the same pill as its neighbour, in the danger colour, so the two
+   read as one row rather than a widget beside a bare glyph. */
 #custom-screenrecording.active {
+    background-color: @bg-widget;
     color: @danger;
-    text-shadow: 0 0 8px alpha(@danger, 0.5);
+    border: 1.5px solid alpha(@danger, 0.35);
+    border-radius: 1.5rem 1.5rem 0.3rem 0.3rem;
+    padding: 0.4rem 1.2rem;
+    margin: 5px 0 0 0.6rem;
+    text-shadow: 0 0 6px alpha(@danger, 0.4);
+    box-shadow: inset 0 1px 0 alpha(@danger, 0.1), 0 1px 3px alpha(@bg-deep, 0.6);
+    transition: all 300ms ease;
+}
+
+#custom-screenrecording.active:hover {
+    background-color: alpha(@danger, 0.15);
+    border-color: @danger;
+    text-shadow: 0 0 10px alpha(@danger, 0.6);
 }

--- a/.local/bin/waybar-screenrecording.sh
+++ b/.local/bin/waybar-screenrecording.sh
@@ -4,7 +4,7 @@
 # RTMIN+8, which screen-record.sh already sends on both start and stop.
 
 if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
-  echo '{"text": "󰻂", "tooltip": "Recording. Click to stop", "class": "active"}'
+  echo '{"text": "󰻂 recording...", "tooltip": "Recording. Click to stop", "class": "active"}'
 else
   echo '{"text": ""}'
 fi

--- a/migrations/1788860000.sh
+++ b/migrations/1788860000.sh
@@ -1,0 +1,72 @@
+echo "Move the recording indicator to the left, beside the prayer times"
+
+# waybar/config.jsonc is copied once at install and never touched again, so a
+# module hyprsimple moves later does not move on an existing machine. This
+# moves it, surgically, in the file the user already has.
+#
+# Only the two module lists are touched, and only when the module is in
+# modules-right and not already in modules-left. A config that has been
+# rearranged by hand keeps its arrangement.
+#
+# python3 rather than sed. The last time this project moved a waybar module
+# with sed, the pattern matched "hyprland/workspaces" in every list rather than
+# the one it named, and the module landed in two of them.
+
+CONFIG="$HOME/.config/waybar/config.jsonc"
+
+if [[ ! -f $CONFIG ]]; then
+  echo "  No waybar config here, so there is nothing to move."
+  exit 0
+fi
+
+python3 - "$CONFIG" <<'PY'
+import re, sys
+
+path = sys.argv[1]
+text = open(path).read()
+MODULE = '"custom/screenrecording"'
+
+def find_list(name):
+    m = re.search(r'("%s"\s*:\s*)\[([^\]]*)\]' % name, text)
+    return m
+
+left = find_list("modules-left")
+right = find_list("modules-right")
+
+if not left or not right:
+    print("  Could not find both module lists, so nothing was changed.")
+    raise SystemExit(0)
+
+if MODULE in left.group(2):
+    print("  The recording indicator is already on the left.")
+    raise SystemExit(0)
+
+if MODULE not in right.group(2):
+    print("  The recording indicator is not in modules-right, so it was left alone.")
+    raise SystemExit(0)
+
+# Drop it from modules-right, with the comma that goes with it.
+new_right = re.sub(r',\s*' + re.escape(MODULE), '', right.group(2))
+new_right = re.sub(re.escape(MODULE) + r'\s*,\s*', '', new_right)
+if new_right == right.group(2):
+    print("  Could not remove it from modules-right cleanly, so nothing was changed.")
+    raise SystemExit(0)
+
+# Add it to modules-left, after muslimtify when that is there, else at the end.
+items = [i.strip() for i in left.group(2).split(",") if i.strip()]
+target = '"custom/muslimtify"'
+if target in items:
+    items.insert(items.index(target) + 1, MODULE)
+else:
+    items.append(MODULE)
+new_left = ", ".join(items)
+
+out = text[:left.start(2)] + new_left + text[left.end(2):]
+# The right-hand list moved if it sits after the left one, so it is located
+# again in the rewritten text rather than reusing the old offsets.
+right2 = re.search(r'("modules-right"\s*:\s*)\[([^\]]*)\]', out)
+out = out[:right2.start(2)] + new_right + out[right2.end(2):]
+
+open(path, "w").write(out)
+print("  Moved it to modules-left, after the prayer times.")
+PY

--- a/test/notify-bar-test.sh
+++ b/test/notify-bar-test.sh
@@ -120,6 +120,113 @@ b_zero=$(bar_of 0); b_full=$(bar_of 100)
 check "brightness builds the same bar at 0" "$b_zero" "$zero"
 check "and at 100" "$b_full" "$full"
 
+# --- the recording indicator sits on the left and says what it is ------------
+#
+# It used to be a bare glyph between the battery and the clock, which reads as
+# an unexplained dot. It is a labelled pill beside the prayer times now.
+
+WBCONF="$REPO/.config/waybar/config.jsonc"
+WBSTYLE="$REPO/.config/waybar/style.css"
+RECSCRIPT="$BIN/waybar-screenrecording.sh"
+RECMIGRATION="$REPO/migrations/1788860000.sh"
+
+modules_line() { grep -m1 "\"$1\"" "$WBCONF"; }
+
+check "the indicator is in modules-left" \
+  "$(modules_line modules-left | grep -c 'custom/screenrecording')" "1"
+check "and no longer in modules-right" \
+  "$(modules_line modules-right | grep -c 'custom/screenrecording')" "0"
+check "and it comes after the prayer times, not before" \
+  "$(modules_line modules-left | grep -cE 'custom/muslimtify".*custom/screenrecording')" "1"
+
+# The label, read out of the script that emits it.
+check "the module says what it is rather than showing a bare glyph" \
+  "$(grep -c 'recording\.\.\.' "$RECSCRIPT")" "1"
+check "and still carries the active class the styling keys off" \
+  "$(grep -c '"class": "active"' "$RECSCRIPT")" "1"
+check "while the idle branch still emits an empty string" \
+  "$(grep -c '{"text": ""}' "$RECSCRIPT")" "1"
+
+# The background belongs to .active only. The idle module emits an empty
+# string, and padding or a background on the bare id would leave an empty pill
+# in the bar next to the prayer times.
+active_block=$(sed -n '/^#custom-screenrecording\.active {/,/^}/p' "$WBSTYLE")
+idle_block=$(sed -n '/^#custom-screenrecording {/,/^}/p' "$WBSTYLE")
+
+check "the recording state has a background" \
+  "$(printf '%s' "$active_block" | grep -c 'background-color')" "1"
+check "and a border, so it reads as a pill like its neighbour" \
+  "$(printf '%s' "$active_block" | grep -c '^    border:')" "1"
+check "and padding to sit the text inside it" \
+  "$(printf '%s' "$active_block" | grep -c '^    padding:')" "1"
+
+check "the idle state has no background" \
+  "$(printf '%s' "$idle_block" | grep -cE 'background-color|^    border: [0-9]')" "0"
+check "and no padding, so nothing shows when nothing is recording" \
+  "$(printf '%s' "$idle_block" | grep -c 'padding: 0')" "1"
+
+# Anti-vacuity: both blocks were actually found. A sed range that matched
+# nothing would satisfy every idle check above.
+check "both style blocks were read, so those checks are not empty" \
+  "$([[ -n $active_block && -n $idle_block ]] && echo both || echo missing)" "both"
+
+# --- the migration moves it in a config that already exists ------------------
+#
+# waybar/config.jsonc is copied once at install and never touched again, so a
+# module hyprsimple moves later does not move on an existing machine.
+
+mig_home="$TMP/wbhome"
+mkdir -p "$mig_home/.config/waybar"
+cat >"$mig_home/.config/waybar/config.jsonc" <<'JSONEOF'
+{
+    "modules-left": ["hyprland/workspaces", "custom/muslimtify"],
+    "modules-center": ["hyprland/window"],
+    "modules-right": ["battery", "custom/screenrecording", "clock"],
+    "custom/screenrecording": { "exec": "x" }
+}
+JSONEOF
+before_rest=$(grep -v 'modules-left\|modules-right' "$mig_home/.config/waybar/config.jsonc")
+
+HOME="$mig_home" bash "$RECMIGRATION" >"$TMP/wbout" 2>&1
+
+check "the migration puts it in modules-left" \
+  "$(grep -m1 'modules-left' "$mig_home/.config/waybar/config.jsonc" | grep -c 'custom/screenrecording')" "1"
+check "after the prayer times" \
+  "$(grep -m1 'modules-left' "$mig_home/.config/waybar/config.jsonc" | grep -cE 'custom/muslimtify".*custom/screenrecording')" "1"
+check "and takes it out of modules-right" \
+  "$(grep -m1 'modules-right' "$mig_home/.config/waybar/config.jsonc" | grep -c 'custom/screenrecording')" "0"
+check "leaving no stray comma behind" \
+  "$(grep -m1 'modules-right' "$mig_home/.config/waybar/config.jsonc" | grep -cE ',\s*,|\[\s*,|,\s*\]')" "0"
+check "and changing nothing else in the file" \
+  "$([[ $(grep -v 'modules-left\|modules-right' "$mig_home/.config/waybar/config.jsonc") == "$before_rest" ]] && echo same || echo changed)" "same"
+
+# Run twice: it must not move it again or report work it did not do.
+HOME="$mig_home" bash "$RECMIGRATION" >"$TMP/wbout2" 2>&1
+check "running it again says it is already there" \
+  "$(grep -c 'already on the left' "$TMP/wbout2")" "1"
+check "and does not add a second copy" \
+  "$(grep -c 'custom/screenrecording' "$mig_home/.config/waybar/config.jsonc")" "2"
+
+# A config that has been rearranged by hand keeps its arrangement.
+hand_home="$TMP/wbhand"
+mkdir -p "$hand_home/.config/waybar"
+cat >"$hand_home/.config/waybar/config.jsonc" <<'JSONEOF'
+{
+    "modules-left": ["hyprland/workspaces"],
+    "modules-right": ["battery", "clock"]
+}
+JSONEOF
+hand_before=$(cat "$hand_home/.config/waybar/config.jsonc")
+HOME="$hand_home" bash "$RECMIGRATION" >"$TMP/wbout3" 2>&1
+check "a config without the module in modules-right is left alone" \
+  "$([[ $(cat "$hand_home/.config/waybar/config.jsonc") == "$hand_before" ]] && echo unchanged || echo edited)" "unchanged"
+check "and says so" "$(grep -c 'not in modules-right' "$TMP/wbout3")" "1"
+
+# No waybar config at all must not fail.
+mkdir -p "$TMP/wbnone"
+HOME="$TMP/wbnone" bash "$RECMIGRATION" >/dev/null 2>&1
+check "a home with no waybar config exits 0" "$?" "0"
+
 if (( failures > 0 )); then
   printf '\n%s check(s) failed\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
The recording indicator was a bare glyph between the battery and the clock, which reads as an unexplained dot on the bar. Three changes, as asked:

| | before | after |
| --- | --- | --- |
| place | `modules-right`, between battery and clock | `modules-left`, straight after the prayer times |
| text | `󰻂` | `󰻂 recording...` |
| styling | colour and a glow, no background | the same pill as its neighbour, in the danger colour |

## The background is on the active state only

`waybar-screenrecording.sh` emits an empty string when nothing is recording. Padding or a background on the bare `#custom-screenrecording` would leave an **empty pill sitting in the bar** next to the prayer times, all the time. Everything visible belongs to `.active`, and there is a check pinning that.

## Reaching a machine that already exists

`waybar/config.jsonc` is copied once at install and never touched again, so a module moved here does not move on an installed machine. A migration moves it in the file the user already has: only when it is in `modules-right` and not already on the left, inserted after `custom/muslimtify` when that is present, and changing nothing else.

**python3 rather than sed for that move.** The last time this project shifted a waybar module with sed, the pattern matched `"hyprland/workspaces"` in every list rather than the one it named and the module landed in two of them, which was #137 two merges ago.

## Verified by running waybar, not by reading

Both files were checked by launching waybar against them with a recorded pid and reading its log: no CSS complaint, no config complaint. The migration was then run against a **copy of a real installed config**, and waybar accepts the result.

The maintainer's own bar was untouched throughout, confirmed after each run.

## Tests

Twenty-one checks in `notify-bar-test.sh`, covering the position, the label, the idle and active styling, and the migration against four shapes: a stock config, the same config twice, a config where the module is not in `modules-right`, and a home with no waybar config at all.

One check exists only to keep the others honest: both style blocks must have been found, since a `sed` range matching nothing would satisfy every idle check on its own.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the background goes on the bare id, so an empty pill shows when idle | 1 |
| the module goes back to `modules-right` | 3 |
| the migration moves it but mangles the rest of the file | 1 |

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
