### PR TITLE
Shape the recording indicator like an ordinary module

### DIFF
--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -182,32 +182,24 @@ tooltip label {
 
 /* Nothing at all when nothing is recording.
    waybar-screenrecording.sh emits an empty string then, and a background or
-   padding here would leave an empty pill sitting in the bar next to the prayer
-   times. Everything visible belongs to .active. */
+   padding here would leave an empty block sitting in the bar. Everything
+   visible belongs to .active. */
 #custom-screenrecording {
     min-width: 0;
     margin: 0;
     padding: 0;
     background: transparent;
-    border: none;
 }
 
-/* Recording: the same pill as its neighbour, in the danger colour, so the two
-   read as one row rather than a widget beside a bare glyph. */
+/* Recording: an ordinary module. Same background, padding and top margin as
+   #cpu and the rest, and the 1rem radius #workspaces uses, which is the other
+   item that stands on its own rather than inside a run of them.
+   #custom-muslimtify is deliberately not the model here: its rounded-top shape
+   is particular to that widget. */
 #custom-screenrecording.active {
     background-color: @bg-widget;
     color: @danger;
-    border: 1.5px solid alpha(@danger, 0.35);
-    border-radius: 1.5rem 1.5rem 0.3rem 0.3rem;
-    padding: 0.4rem 1.2rem;
+    border-radius: 1rem;
+    padding: 0.5rem 0.5rem;
     margin: 5px 0 0 0.6rem;
-    text-shadow: 0 0 6px alpha(@danger, 0.4);
-    box-shadow: inset 0 1px 0 alpha(@danger, 0.1), 0 1px 3px alpha(@bg-deep, 0.6);
-    transition: all 300ms ease;
-}
-
-#custom-screenrecording.active:hover {
-    background-color: alpha(@danger, 0.15);
-    border-color: @danger;
-    text-shadow: 0 0 10px alpha(@danger, 0.6);
 }

--- a/test/notify-bar-test.sh
+++ b/test/notify-bar-test.sh
@@ -153,12 +153,32 @@ check "while the idle branch still emits an empty string" \
 active_block=$(sed -n '/^#custom-screenrecording\.active {/,/^}/p' "$WBSTYLE")
 idle_block=$(sed -n '/^#custom-screenrecording {/,/^}/p' "$WBSTYLE")
 
+# It is shaped like an ordinary module, not like its neighbour.
+# custom/muslimtify has a rounded-top shape particular to that widget, and the
+# indicator was briefly given the same one. The background, padding and top
+# margin are read out of the shared rule that covers #cpu and the rest, so this
+# compares against what ships rather than against numbers written down here.
+ordinary_block=$(sed -n '/^#cpu,/,/^}/p' "$WBSTYLE")
+prop() { printf '%s' "$1" | grep -oE "^ *$2: *[^;]+" | tr -d ' ' | sed "s/^$2://"; }
+
 check "the recording state has a background" \
   "$(printf '%s' "$active_block" | grep -c 'background-color')" "1"
-check "and a border, so it reads as a pill like its neighbour" \
-  "$(printf '%s' "$active_block" | grep -c '^    border:')" "1"
-check "and padding to sit the text inside it" \
-  "$(printf '%s' "$active_block" | grep -c '^    padding:')" "1"
+check "and it is the one every other module uses" \
+  "$(prop "$active_block" background-color)" "$(prop "$ordinary_block" background-color)"
+check "with the same padding as they have" \
+  "$(prop "$active_block" padding)" "$(prop "$ordinary_block" padding)"
+check "and the shared rule really was read, so those two are not empty" \
+  "$([[ -n $(prop "$ordinary_block" background-color) ]] && echo read || echo empty)" "read"
+
+# The rounded corner comes from #workspaces, the other item that stands on its
+# own rather than inside a run of modules.
+standalone_block=$(sed -n '/^#workspaces {/,/^}/p' "$WBSTYLE")
+check "and the corner radius of the other standalone item" \
+  "$(prop "$active_block" border-radius)" "$(prop "$standalone_block" border-radius)"
+
+# None of the treatment that belongs to muslimtify.
+check "and none of the shadow or border that widget uses" \
+  "$(printf '%s' "$active_block" | grep -cE 'box-shadow|text-shadow|^ *border:')" "0"
 
 check "the idle state has no background" \
   "$(printf '%s' "$idle_block" | grep -cE 'background-color|^    border: [0-9]')" "0"


### PR DESCRIPTION
#139 gave the indicator `custom/muslimtify`'s treatment: a rounded-top pill with a border, two shadows and a transition. That shape belongs to that widget rather than being a house style, so it did not belong here.

It now takes the shared rule that covers `#cpu` and the rest:

| property | ordinary modules | the indicator |
| --- | --- | --- |
| `background-color` | `@bg-widget` | `@bg-widget` |
| `padding` | `0.5rem 0.5rem` | `0.5rem 0.5rem` |
| `margin` | `5px 0 0 0` | `5px 0 0 0.6rem` |
| `border-radius` | — | `1rem`, from `#workspaces` |

The corner comes from `#workspaces`, which is the other item that stands on its own rather than inside a run of modules. The left margin is the only difference, and it is there to separate it from the prayer times beside it.

The red stays, because that is what marks it as recording rather than as another readout.

Gone: the border, `box-shadow`, `text-shadow` and `transition`.

## Tests

The checks compare against the shared rule and against `#workspaces` **read out of the stylesheet**, not against numbers written into the test, so they follow the stylesheet if it changes rather than pinning today's values.

One check exists only to keep the others honest: the shared rule must actually have been read. A `sed` range matching nothing would otherwise make both comparisons pass on a pair of empty strings, which the third sabotage below demonstrates.

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| muslimtify's treatment comes back | 3 |
| a different background from the other modules | 1 |
| the shared rule can no longer be found | 3, including the anti-vacuity one |

Checked by running waybar against the stylesheet and reading its log rather than by eye. The maintainer's own bar was left alone.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
