### PR TITLE
Label the indicator Recording, and give it room

### DIFF
--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -200,6 +200,10 @@ tooltip label {
     background-color: @bg-widget;
     color: @danger;
     border-radius: 1rem;
-    padding: 0.5rem 0.5rem;
+    /* The vertical half matches every other module, so the row lines up. The
+       horizontal half is wider on purpose: this one carries a word rather than
+       a short readout, and at the shared 0.5rem the text sat hard against the
+       rounded corner. */
+    padding: 0.5rem 1.1rem;
     margin: 5px 0 0 0.6rem;
 }

--- a/.local/bin/waybar-screenrecording.sh
+++ b/.local/bin/waybar-screenrecording.sh
@@ -4,7 +4,7 @@
 # RTMIN+8, which screen-record.sh already sends on both start and stop.
 
 if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
-  echo '{"text": "󰻂 recording...", "tooltip": "Recording. Click to stop", "class": "active"}'
+  echo '{"text": "󰻂 Recording", "tooltip": "Recording. Click to stop", "class": "active"}'
 else
   echo '{"text": ""}'
 fi

--- a/test/notify-bar-test.sh
+++ b/test/notify-bar-test.sh
@@ -141,7 +141,11 @@ check "and it comes after the prayer times, not before" \
 
 # The label, read out of the script that emits it.
 check "the module says what it is rather than showing a bare glyph" \
-  "$(grep -c 'recording\.\.\.' "$RECSCRIPT")" "1"
+  "$(grep -c '󰻂 Recording' "$RECSCRIPT")" "1"
+check "with no trailing ellipsis, which reads as a thing still starting" \
+  "$(grep -c 'Recording\.\.\.' "$RECSCRIPT")" "0"
+check "and a capital R, matching the tooltip beside it" \
+  "$(grep -c '"text": "󰻂 recording' "$RECSCRIPT")" "0"
 check "and still carries the active class the styling keys off" \
   "$(grep -c '"class": "active"' "$RECSCRIPT")" "1"
 check "while the idle branch still emits an empty string" \
@@ -165,8 +169,25 @@ check "the recording state has a background" \
   "$(printf '%s' "$active_block" | grep -c 'background-color')" "1"
 check "and it is the one every other module uses" \
   "$(prop "$active_block" background-color)" "$(prop "$ordinary_block" background-color)"
-check "with the same padding as they have" \
-  "$(prop "$active_block" padding)" "$(prop "$ordinary_block" padding)"
+# The vertical half matches, so the row lines up. The horizontal half is wider
+# on purpose: this module carries a word rather than a short readout, and at
+# the shared 0.5rem the text sat hard against the rounded corner.
+pad_v() { printf '%s' "$1" | awk '{print $1}'; }
+pad_h() { printf '%s' "$1" | awk '{print $2}'; }
+rem() { printf '%s' "${1%rem}"; }
+
+active_pad=$(sed -n '/^#custom-screenrecording\.active {/,/^}/p' "$WBSTYLE" |
+  grep -oE '^ *padding: *[^;]+' | sed 's/.*padding: *//')
+ordinary_pad=$(sed -n '/^#cpu,/,/^}/p' "$WBSTYLE" |
+  grep -oE '^ *padding: *[^;]+' | sed 's/.*padding: *//')
+
+check "both padding declarations were read" \
+  "$([[ -n $active_pad && -n $ordinary_pad ]] && echo both || echo missing)" "both"
+check "the vertical padding matches the other modules, so the row lines up" \
+  "$(pad_v "$active_pad")" "$(pad_v "$ordinary_pad")"
+check "and the horizontal padding is wider, because this one carries a word" \
+  "$(awk -v a="$(rem "$(pad_h "$active_pad")")" -v b="$(rem "$(pad_h "$ordinary_pad")")" \
+      'BEGIN { print (a > b) ? "wider" : "not wider" }')" "wider"
 check "and the shared rule really was read, so those two are not empty" \
   "$([[ -n $(prop "$ordinary_block" background-color) ]] && echo read || echo empty)" "read"
 


### PR DESCRIPTION
Three changes to the recording indicator, as asked.

| | before | after |
| --- | --- | --- |
| text | `󰻂 recording...` | `󰻂 Recording` |
| horizontal padding | `0.5rem`, the shared value | `1.1rem` |
| vertical padding | `0.5rem` | `0.5rem`, unchanged |

**Capitalised**, matching the tooltip beside it, which has always read "Recording. Click to stop".

**The ellipsis is gone.** It read as something still starting up rather than something under way, which is the opposite of what the module means.

**Wider horizontally, unchanged vertically.** The vertical half still matches every other module so the row lines up. The horizontal half is wider because this one carries a word rather than a short readout, and at the shared `0.5rem` the text sat hard against the rounded corner.

## The padding check had to change shape

It compared the whole `padding` value against the shared rule, which no longer holds. Asserting the new exact pair would just pin today's number and fail the next time either changed, so it now compares the two halves separately:

- vertical, against the shared rule
- horizontal, as **greater than** the shared rule

Both are still read out of the stylesheet rather than written into the test, and a check asserts both declarations were found so the comparisons cannot pass on empty strings.

## Tests

Four sabotages, each red on exactly the thing it breaks:

| sabotage | check that failed |
| --- | --- |
| the ellipsis comes back | no trailing ellipsis |
| lowercase `r` | the label, and the capital-R check |
| horizontal padding drops to the shared value | horizontal is wider |
| vertical padding drifts off the row | vertical matches the other modules |

Verified by running the module script and reading what it emits, and by launching waybar against the stylesheet and reading its log. The maintainer's own bar was left alone.

Full sweep: 68 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
