### PR TITLE
Replace six recording keybinds with one menu

### DIFF
--- a/.config/rofi/record/style.rasi
+++ b/.config/rofi/record/style.rasi
@@ -1,0 +1,9 @@
+@import "hyprsimple/record/style.rasi"
+
+/* This file is yours. hyprsimple copies it once and never touches it again,
+   so anything you change here stays changed. */
+
+/* hyprsimple's default is imported above. Anything you set below wins,
+   property by property, and anything you leave out keeps the default.
+   Put your own settings here rather than above the import, because the
+   later declaration is the one rofi uses. */

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -265,6 +265,9 @@ jobs:
       - name: migration-runner-test
         run: bash test/migration-runner-test.sh
 
+      - name: record-menu-test
+        run: bash test/record-menu-test.sh
+
       # Last on purpose: it audits the suites above rather than the product, so
       # a real failure should be read before its hygiene report.
       - name: suite-hygiene-test

--- a/.local/bin/hyprsimple-record-menu.sh
+++ b/.local/bin/hyprsimple-record-menu.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# The recording menu, opened by SUPER + R.
+#
+# There were six keybinds, one per combination of scope and audio source, and
+# five of them were chords nobody remembers. This is the one key, and the
+# combination is chosen from a list instead.
+#
+# The selection is read back as an index rather than by matching the label.
+# rofi returns the line it displayed, so matching on text ties the dispatch to
+# the wording and to the glyphs in it: renaming an entry, or a font that
+# renders one differently, would silently stop it running. -format i returns
+# the position in the list this script supplied, which cannot drift from it.
+
+RECORDER="$HOME/.local/bin/screen-record.sh"
+THEME="$HOME/.config/rofi/record/style.rasi"
+
+if [[ ! -x $RECORDER ]]; then
+  notify-send -u critical "Recording" "screen-record.sh is missing. Run hyprsimple-update."
+  exit 1
+fi
+
+# Stopping is offered on its own when something is already recording. Showing
+# the six start options then would be offering to start a second recorder while
+# the first holds the screen.
+#
+# The same test screen-record.sh uses, so the menu and the recorder cannot
+# disagree about whether a recording is running.
+if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
+  labels=("  Stop recording")
+  args=("stop")
+  prompt="󰻂"
+else
+  labels=(
+    "  Region, microphone"
+    "  Region, system audio"
+    "  Region, no audio"
+    "󰍹  Whole screen, microphone"
+    "󰍹  Whole screen, system audio"
+    "󰍹  Whole screen, no audio"
+  )
+  args=(
+    "region mic"
+    "region internal"
+    "region none"
+    "output mic"
+    "output internal"
+    "output none"
+  )
+  prompt="󰑊"
+fi
+
+choice=$(printf '%s\n' "${labels[@]}" |
+  rofi -dmenu -i -format i -p "$prompt" -theme "$THEME") || exit 0
+
+# Empty when the menu was dismissed, which is not a failure.
+[[ -n $choice ]] || exit 0
+
+# rofi has been asked for an index, so anything else means it answered in a
+# shape this script did not ask for, and dispatching on it would run whichever
+# entry the number happened to land on.
+if [[ ! $choice =~ ^[0-9]+$ ]] || (( choice >= ${#args[@]} )); then
+  notify-send -u critical "Recording" "The menu returned something unexpected, so nothing was started"
+  exit 1
+fi
+
+# Unquoted on purpose: each entry is a scope and an audio mode, two arguments.
+# shellcheck disable=SC2086
+exec "$RECORDER" ${args[$choice]}

--- a/README.md
+++ b/README.md
@@ -227,12 +227,11 @@ Press **`SUPER + /`** for interactive viewer with fuzzy search.
 
 | Key | Action |
 |-----|--------|
-| `SUPER + R` | Record region with mic audio |
-| `SUPER + SHIFT + R` | Record fullscreen with mic audio |
-| `SUPER + ALT + R` | Record region with system audio |
-| `SUPER + SHIFT + ALT + R` | Record fullscreen with system audio |
-| `SUPER + CTRL + R` | Record region without audio |
-| `SUPER + CTRL + SHIFT + R` | Record fullscreen without audio |
+| `SUPER + R` | Open the recording menu, or stop a recording that is running |
+
+The menu offers a region or the whole screen, each with microphone audio,
+system audio, or none. While something is recording it offers to stop instead,
+so the same key both starts and stops.
 
 ### Media & Brightness
 
@@ -298,6 +297,7 @@ Most are wired to keybindings or waybar; all can also be run directly from a ter
 |--------|-------------|
 | `screenshot.sh` | Take a screenshot (`clipboard` / `window` / `region` / `monitor`) |
 | `screen-record.sh` | Start/stop screen recording (region or output; mic, internal, or no audio) |
+| `hyprsimple-record-menu.sh` | The rofi menu behind `SUPER + R`, which picks what to record and starts or stops it |
 | `screen-record-active.sh` | Report whether a screen recording is currently running |
 
 ### Network

--- a/default/hypr/bindings/recording.lua
+++ b/default/hypr/bindings/recording.lua
@@ -1,9 +1,13 @@
 local home = os.getenv("HOME")
-local rec  = home .. "/.local/bin/screen-record.sh"
 
-hl.bind("SUPER + R",               hl.dsp.exec_cmd(rec .. " region mic"),      { description = "Record Region (Mic)" })
-hl.bind("SUPER + SHIFT + R",       hl.dsp.exec_cmd(rec .. " output mic"),      { description = "Record Screen (Mic)" })
-hl.bind("SUPER + ALT + R",         hl.dsp.exec_cmd(rec .. " region internal"), { description = "Record Region (System Audio)" })
-hl.bind("SUPER + SHIFT + ALT + R", hl.dsp.exec_cmd(rec .. " output internal"), { description = "Record Screen (System Audio)" })
-hl.bind("SUPER + CTRL + R",        hl.dsp.exec_cmd(rec .. " region none"),     { description = "Record Region (No Audio)" })
-hl.bind("SUPER + CTRL + SHIFT + R",hl.dsp.exec_cmd(rec .. " output none"),     { description = "Record Screen (No Audio)" })
+-- One key, and the combination is chosen from a list.
+--
+-- There were six binds here, one per pairing of scope and audio source:
+-- SUPER + R, + SHIFT, + ALT, + SHIFT + ALT, + CTRL, + CTRL + SHIFT. Five of
+-- those are chords nobody remembers, and the keybinding viewer listed all six
+-- as separate entries for what is one action with two choices in it.
+--
+-- The menu also stops a recording that is running, so the same key both starts
+-- and stops and there is nothing to remember about which.
+hl.bind("SUPER + R", hl.dsp.exec_cmd(home .. "/.local/bin/hyprsimple-record-menu.sh"),
+  { description = "Record (menu: region or screen, mic, system audio or none)" })

--- a/default/rofi/record/style.rasi
+++ b/default/rofi/record/style.rasi
@@ -1,0 +1,94 @@
+/* The recording menu, opened by SUPER + R.
+ *
+ * rofi-colors.rasi is a symlink the theme switcher repoints on every theme
+ * change, so this menu repaints itself with the rest of the desktop. Every
+ * colour below comes from it and none is written here, or the menu would keep
+ * one theme's palette while everything else moved.
+ */
+@import "~/.config/rofi/rofi-colors.rasi"
+
+* {
+    font: "Iosevka Nerd Font 13";
+}
+
+configuration {
+    show-icons: false;
+}
+
+window {
+    /* transparency "real" gives the surface an alpha channel. Without it the
+       alpha byte in the palette is ignored and the panel renders solid. */
+    transparency:       "real";
+    location:           center;
+    anchor:             center;
+    width:              460px;
+    border-radius:      16px;
+    background-color:   @background;
+    border:             2px;
+    border-color:       @selected;
+}
+
+/* -theme replaces rofi's base theme outright, so an element left unset falls
+   back to rofi's built-in light defaults. Naming the children keeps the panel
+   on the theme's own surface. */
+mainbox {
+    spacing:            0px;
+    background-color:   transparent;
+    children:           [ "inputbar", "listview" ];
+}
+
+inputbar {
+    padding:            14px 16px;
+    background-color:   transparent;
+    text-color:         @foreground;
+    children:           [ "prompt", "entry" ];
+}
+
+prompt {
+    padding:            0px 8px 0px 0px;
+    background-color:   transparent;
+    text-color:         @selected;
+}
+
+entry {
+    background-color:   transparent;
+    text-color:         @foreground;
+    cursor:             text;
+    placeholder:        "Filter...";
+    placeholder-color:  @background-alt;
+}
+
+listview {
+    columns:            1;
+    /* Six entries when idle, one when a recording is running. fixed-height
+       false lets the panel shrink to whichever it is showing rather than
+       leaving four empty rows under a single Stop. */
+    lines:              6;
+    fixed-height:       false;
+    scrollbar:          false;
+    padding:            0px 8px 8px 8px;
+    spacing:            2px;
+    background-color:   transparent;
+}
+
+element {
+    padding:            9px 12px;
+    border-radius:      8px;
+    background-color:   transparent;
+    text-color:         @foreground;
+}
+
+/* The selection is marked with @selected, the theme accent, rather than with
+   @background-alt alone. background-alt comes from color0, which sits close to
+   the panel in most of the shipped themes, so a fill on its own is hard to
+   see. */
+element selected.normal {
+    background-color:   @background-alt;
+    text-color:         @selected;
+}
+
+element-text {
+    background-color:   transparent;
+    text-color:         inherit;
+    vertical-align:     0.5;
+}

--- a/migrations/1788880000.sh
+++ b/migrations/1788880000.sh
@@ -1,0 +1,38 @@
+echo "Add the recording menu's rofi stub"
+
+# ~/.config/rofi is copied once at install and never touched again, so a menu
+# added later has no stub on a machine that already exists and SUPER + R would
+# open rofi with no theme at all: its built-in light default, on a dark
+# desktop.
+#
+# The stub is the same shape as the other menus': one import of the shipped
+# style through the hyprsimple symlink, and room underneath for the user's own
+# settings. The style itself lives in default/rofi and updates on its own.
+
+STUB_DIR="$HOME/.config/rofi/record"
+STUB="$STUB_DIR/style.rasi"
+
+if [[ -e $STUB ]]; then
+  echo "  You already have $STUB, so it was left alone."
+  exit 0
+fi
+
+if [[ ! -d $HOME/.config/rofi ]]; then
+  echo "  No rofi config here, so there is nothing to add to."
+  exit 0
+fi
+
+mkdir -p "$STUB_DIR"
+cat >"$STUB" <<'STUBEOF'
+@import "hyprsimple/record/style.rasi"
+
+/* This file is yours. hyprsimple copies it once and never touches it again,
+   so anything you change here stays changed. */
+
+/* hyprsimple's default is imported above. Anything you set below wins,
+   property by property, and anything you leave out keeps the default.
+   Put your own settings here rather than above the import, because the
+   later declaration is the one rofi uses. */
+STUBEOF
+
+echo "  Added $STUB, so SUPER + R opens the menu in your theme's colours."

--- a/test/record-menu-test.sh
+++ b/test/record-menu-test.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# Checks the recording menu behind SUPER + R.
+#
+# There were six keybinds, one per pairing of scope and audio source, five of
+# them chords. This is one key and a list. The suite drives the menu with a
+# stubbed rofi and a stubbed recorder, so no menu opens and nothing records.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/.local/bin"
+MENU="$BIN/hyprsimple-record-menu.sh"
+STYLE="$REPO/default/rofi/record/style.rasi"
+STUB_STYLE="$REPO/.config/rofi/record/style.rasi"
+BINDS="$REPO/default/hypr/bindings/recording.lua"
+MIGRATION="$REPO/migrations/1788880000.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+STUB="$TMP/bin"; mkdir -p "$STUB"
+HOME_DIR="$TMP/home"; mkdir -p "$HOME_DIR/.local/bin" "$HOME_DIR/.config/rofi/record"
+
+# rofi records what it was fed and answers with whatever the test chose. It
+# never runs the real one: that would open a menu on the screen of whoever is
+# running the suite, which has happened here before.
+cat >"$STUB/rofi" <<'STUBEOF'
+#!/bin/bash
+cat >"$ROFI_INPUT"
+printf '%s' "$*" >"$ROFI_ARGS"
+printf '%s' "${ROFI_PICK:-}"
+STUBEOF
+cat >"$HOME_DIR/.local/bin/screen-record.sh" <<'STUBEOF'
+#!/bin/bash
+printf 'screen-record.sh %s\n' "$*" >>"$REC_LOG"
+STUBEOF
+cat >"$STUB/notify-send" <<'STUBEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUBEOF
+chmod +x "$STUB"/* "$HOME_DIR/.local/bin/screen-record.sh"
+cp "$MENU" "$HOME_DIR/.local/bin/"
+cp "$STUB_STYLE" "$HOME_DIR/.config/rofi/record/style.rasi"
+
+INPUT="$TMP/menu-input"; ARGS="$TMP/rofi-args"
+LOG="$TMP/recorder"; NLOG="$TMP/notifications"
+
+recording() {
+  if [[ $1 == yes ]]; then printf '#!/bin/bash\nexit 0\n' >"$STUB/pgrep"
+  else printf '#!/bin/bash\nexit 1\n' >"$STUB/pgrep"; fi
+  chmod +x "$STUB/pgrep"
+}
+
+open_menu() {
+  : >"$LOG"; : >"$NLOG"
+  ROFI_INPUT="$INPUT" ROFI_ARGS="$ARGS" ROFI_PICK="${1-}" \
+    REC_LOG="$LOG" NOTIFY_LOG="$NLOG" HOME="$HOME_DIR" \
+    PATH="$STUB:/usr/bin:/bin" bash "$HOME_DIR/.local/bin/hyprsimple-record-menu.sh" \
+    >/dev/null 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+# ---- one key, not six -------------------------------------------------------
+
+lua_code() { sed 's/^[[:space:]]*--.*//' "$BINDS"; }
+check "there is one recording keybind" "$(lua_code | grep -c 'hl.bind')" "1"
+check "and it is SUPER + R" "$(lua_code | grep -c 'hl.bind("SUPER + R"')" "1"
+check "and it opens the menu rather than the recorder" \
+  "$(lua_code | grep -c 'hyprsimple-record-menu.sh')" "1"
+check "so no bind passes a scope and audio mode itself any more" \
+  "$(lua_code | grep -cE 'screen-record\.sh (region|output)')" "0"
+
+# ---- the six combinations, chosen by index ----------------------------------
+#
+# Each entry is picked in turn and the recorder's arguments read back. The
+# mapping is the whole point of the menu, so every row is exercised rather than
+# one of them standing for the rest.
+
+recording no
+declare -a expected=(
+  "region mic" "region internal" "region none"
+  "output mic" "output internal" "output none"
+)
+
+open_menu 0
+check "the idle menu offers six ways to record" "$(wc -l <"$INPUT")" "6"
+
+wrong=()
+for i in "${!expected[@]}"; do
+  open_menu "$i"
+  got=$(sed 's/^screen-record.sh //' "$LOG")
+  [[ $got == "${expected[$i]}" ]] || wrong+=("$i wanted '${expected[$i]}' got '$got'")
+done
+wrong_str=""; (( ${#wrong[@]} > 0 )) && wrong_str="$(printf '%s; ' "${wrong[@]}")"
+check "every entry starts the recorder it names" "$wrong_str" ""
+
+# The labels have to say which is which, or the list is six unlabelled rows.
+open_menu 0
+check "the menu names region and whole screen" \
+  "$(grep -cE 'Region|Whole screen' "$INPUT")" "6"
+check "and names all three audio sources" \
+  "$(grep -cE 'microphone|system audio|no audio' "$INPUT")" "6"
+
+# ---- while recording, it offers to stop -------------------------------------
+
+recording yes
+open_menu 0
+check "with a recording running the menu offers one thing" "$(wc -l <"$INPUT")" "1"
+check "and that thing is stopping" "$(grep -c 'Stop recording' "$INPUT")" "1"
+check "which stops the recorder" "$(grep -c 'screen-record.sh stop' "$LOG")" "1"
+check "and it does not offer to start another" \
+  "$(grep -cE 'Region|Whole screen' "$INPUT")" "0"
+
+# ---- an answer that is not an index is refused ------------------------------
+#
+# rofi is asked for an index, so a label back means it answered in a shape this
+# script did not ask for. Dispatching on it would run whichever entry the
+# number happened to land on.
+
+recording no
+open_menu "  Region, microphone"
+check "a label instead of an index starts nothing" "$(wc -c <"$LOG")" "0"
+check "and says so" "$(grep -c 'something unexpected' "$NLOG")" "1"
+check "and exits non-zero" \
+  "$([[ $(cat "$TMP/rc") != "0" ]] && echo nonzero || echo zero)" "nonzero"
+
+open_menu 99
+check "an index past the end of the list starts nothing" "$(wc -c <"$LOG")" "0"
+check "and says so too" "$(grep -c 'something unexpected' "$NLOG")" "1"
+
+# Dismissing is not a failure and must be silent.
+open_menu ""
+check "dismissing the menu starts nothing" "$(wc -c <"$LOG")" "0"
+check "and says nothing" "$(wc -c <"$NLOG")" "0"
+check "and exits 0" "$(cat "$TMP/rc")" "0"
+
+# ---- it asks rofi for the themed style --------------------------------------
+
+recording no
+open_menu 0
+check "the menu is drawn with the record style, not rofi's default" \
+  "$(grep -c -- '-theme .*/.config/rofi/record/style.rasi' "$ARGS")" "1"
+check "and asks for an index rather than the line it displayed" \
+  "$(grep -c -- '-format i' "$ARGS")" "1"
+
+# ---- the style follows the theme -------------------------------------------
+#
+# Every colour comes from rofi-colors.rasi, which the theme switcher repoints
+# on each theme change. A colour written into this file would keep one theme's
+# palette while the rest of the desktop moved.
+
+# Comments stripped first. The block at the top of the file explains why the
+# palette is imported, and counting that explanation as a second import made
+# this read 2 where it wanted 1.
+style_code() { python3 -c "
+import re, sys
+print(re.sub(r'/\*.*?\*/', '', open(sys.argv[1]).read(), flags=re.S))
+" "$STYLE"; }
+
+check "the style imports the theme's palette" \
+  "$(style_code | grep -c 'rofi-colors.rasi')" "1"
+check "and hard codes no colour of its own" \
+  "$(style_code | grep -cE '#[0-9A-Fa-f]{3,8}')" "0"
+check "while still setting the colours it needs, from that palette" \
+  "$([[ $(style_code | grep -cE '@(background|foreground|selected|background-alt)') -ge 8 ]] && echo enough || echo few)" "enough"
+
+# The stub the script actually loads imports the shipped style.
+check "the user's stub imports the shipped style" \
+  "$(grep -c '@import "hyprsimple/record/style.rasi"' "$STUB_STYLE")" "1"
+
+# rofi parses it. -dump-theme reads a theme and prints it without opening a
+# window, so this cannot reach anyone's screen.
+#
+# HOME and XDG_CONFIG_HOME both point at a fixture, and the palette in it is
+# this suite's own. The style imports ~/.config/rofi/rofi-colors.rasi, and
+# without the redirection that resolved against the maintainer's real palette,
+# so the check would have read whatever theme they happened to be on rather
+# than proving the style resolves against the palette it is given.
+ROFI_HOME="$TMP/rofihome"
+mkdir -p "$ROFI_HOME/.config/rofi"
+cat >"$ROFI_HOME/.config/rofi/rofi-colors.rasi" <<'PALETTEEOF'
+* {
+    background:     #11223344;
+    background-tr:  #11223322;
+    background-alt: #55667788;
+    foreground:     #99aabbFF;
+    selected:       #ccddeeFF;
+    active:         #ccddeeFF;
+    urgent:         #ccddeeFF;
+}
+PALETTEEOF
+
+if command -v rofi >/dev/null 2>&1; then
+  if HOME="$ROFI_HOME" XDG_CONFIG_HOME="$ROFI_HOME/.config" \
+     rofi -dump-theme -theme "$STYLE" >"$TMP/dump" 2>"$TMP/dumperr"; then
+    pass "rofi parses the style"
+    check "and the window colour resolves from the palette rather than a literal" \
+      "$(grep -c 'background-color: *var(background)' "$TMP/dump")" "1"
+    # The fixture palette is the one that was read, not the real one. If the
+    # import had resolved elsewhere these values would not be here.
+    # rofi normalises hex to rgba in its dump, so the fixture's values are
+    # looked for in that form. 17, 34, 51 is #112233 and cannot have come from
+    # any shipped theme's palette.
+    # The value appears once in the * block and again wherever it is used, so
+    # this asks that it is there at all rather than pinning how many times.
+    check "and the palette it read is the fixture's, not the machine's" \
+      "$([[ $(grep -c 'rgba ( 17, 34, 51' "$TMP/dump") -ge 1 ]] && echo fixture || echo elsewhere)" \
+      "fixture"
+  else
+    fail "rofi refused the style: $(head -1 "$TMP/dumperr")"
+  fi
+else
+  pass "rofi is not installed here, so the style is not parsed"
+fi
+
+# ---- the migration adds the stub to a machine that already exists -----------
+
+mig_home="$TMP/mighome"; mkdir -p "$mig_home/.config/rofi"
+HOME="$mig_home" bash "$MIGRATION" >"$TMP/migout" 2>&1
+check "the migration writes the stub" \
+  "$([[ -f $mig_home/.config/rofi/record/style.rasi ]] && echo written || echo missing)" "written"
+check "byte for byte the same as the shipped one" \
+  "$(cmp -s "$STUB_STYLE" "$mig_home/.config/rofi/record/style.rasi" && echo same || echo differs)" "same"
+
+before=$(cat "$mig_home/.config/rofi/record/style.rasi")
+HOME="$mig_home" bash "$MIGRATION" >"$TMP/migout2" 2>&1
+check "running it again leaves the file alone" \
+  "$([[ $(cat "$mig_home/.config/rofi/record/style.rasi") == "$before" ]] && echo unchanged || echo edited)" "unchanged"
+check "and says why" "$(grep -c 'left alone' "$TMP/migout2")" "1"
+
+mkdir -p "$TMP/norofi"
+HOME="$TMP/norofi" bash "$MIGRATION" >"$TMP/migout3" 2>&1
+check "a home with no rofi config is left alone" \
+  "$([[ -e $TMP/norofi/.config/rofi ]] && echo created || echo none)" "none"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
There were six recording binds, one per pairing of scope and audio source:

```
SUPER + R                  region, mic
SUPER + SHIFT + R          screen, mic
SUPER + ALT + R            region, system
SUPER + SHIFT + ALT + R    screen, system
SUPER + CTRL + R           region, none
SUPER + CTRL + SHIFT + R   screen, none
```

Five of those are chords nobody remembers, and the keybinding viewer listed all six as separate entries for what is one action with two choices in it.

`SUPER + R` now opens a rofi menu. It offers a region or the whole screen, each with microphone audio, system audio, or none. **While something is recording it offers to stop instead**, so the same key both starts and stops and there is nothing to remember about which.

## The selection is an index, not a label

rofi returns the line it displayed, so dispatching on text ties the mapping to the wording and to the glyphs in it: renaming an entry, or a font rendering one differently, would silently stop it working. `-format i` returns the position in the list this script supplied, which cannot drift from it.

An answer that is not an index in range is refused and reported, rather than being used to pick whichever entry the number happened to land on.

## It follows the theme

Every colour comes from `rofi-colors.rasi`, the symlink the theme switcher repoints on each theme change, and **none is written into the style**, so the menu repaints with the rest of the desktop. Verified by parsing it: `background-color: var(background)`, resolved against the palette rather than a literal.

It uses the pattern the keybindings and theme-picker menus already follow: the real style in `default/rofi/record/`, and a small stub under `~/.config/rofi/record/` importing it through the `hyprsimple` symlink, so updates reach the styling while the user keeps somewhere to override it.

`~/.config/rofi` is copied once at install, so a migration writes that stub on a machine that already exists. Without it `SUPER + R` would open rofi with its built-in **light** theme on a dark desktop.

## Tests

New `test/record-menu-test.sh`, registered in CI, 34 checks. rofi and the recorder are both stubbed, so no menu opens and nothing records. All six mappings are exercised rather than one standing for the rest.

`suite-hygiene-test.sh` caught the first version of the style check: a suite that runs rofi must isolate `XDG_CONFIG_HOME`, because rofi resolves imports against the real config directory. My `-dump-theme` check was reading **the maintainer's live palette**, so it would have passed whatever the style said. It now points `HOME` and `XDG_CONFIG_HOME` at a fixture with a palette of its own, and asserts the values that came back are the fixture's. Removing that isolation turns the check red.

Three sabotages:

| sabotage | checks failed |
| --- | --- |
| dispatch by matching the label instead of the index | 7 |
| the menu offers starts while a recording is running | 4 |
| a colour is written into the style instead of coming from the palette | 2 |

Full sweep: 69 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
