### PR TITLE
Give the region entries an icon, and check every entry has one

### DIFF
--- a/.local/bin/hyprsimple-record-menu.sh
+++ b/.local/bin/hyprsimple-record-menu.sh
@@ -27,14 +27,14 @@ fi
 # The same test screen-record.sh uses, so the menu and the recorder cannot
 # disagree about whether a recording is running.
 if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
-  labels=("  Stop recording")
+  labels=("󰓛  Stop recording")
   args=("stop")
   prompt="󰻂"
 else
   labels=(
-    "  Region, microphone"
-    "  Region, system audio"
-    "  Region, no audio"
+    "󰗆  Region, microphone"
+    "󰗆  Region, system audio"
+    "󰗆  Region, no audio"
     "󰍹  Whole screen, microphone"
     "󰍹  Whole screen, system audio"
     "󰍹  Whole screen, no audio"

--- a/test/record-menu-test.sh
+++ b/test/record-menu-test.sh
@@ -111,6 +111,85 @@ check "the menu names region and whole screen" \
 check "and names all three audio sources" \
   "$(grep -cE 'microphone|system audio|no audio' "$INPUT")" "6"
 
+# Every entry begins with an icon, and the icon is a real character.
+#
+# Three of them shipped with nothing there. The label read "  Region,
+# microphone" with two leading spaces where the glyph should be, because the
+# character was lost on the way into the file rather than because the font
+# lacked it. Nothing noticed: the menu worked, the dispatch was by index, and
+# the only sign was a gap in the list.
+#
+# The first character of each label is read out of the script and checked to be
+# in the private use area the Nerd Font icons live in, which a space or a
+# letter is not.
+glyph_report=$(python3 - "$MENU" <<'PYEOF'
+import re, sys
+
+labels = []
+for line in open(sys.argv[1]):
+    m = re.search(r'"([^"]*(?:Region|Whole screen|Stop)[^"]*)"', line)
+    if m:
+        labels.append(m.group(1))
+
+if len(labels) < 7:
+    print(f"only {len(labels)} labels found")
+    raise SystemExit(0)
+
+bad = [l for l in labels if not l or not (0xE000 <= ord(l[0]) <= 0xF8FF or 0xF0000 <= ord(l[0]) <= 0xFFFFD)]
+print("blank: " + ", ".join(repr(l) for l in bad) if bad else "all glyphed")
+PYEOF
+)
+check "every menu entry starts with an icon" "$glyph_report" "all glyphed"
+
+# The two kinds are told apart by their icon, not only by their words.
+region_cp=$(python3 -c "
+import re,sys
+for line in open(sys.argv[1]):
+    m = re.search(r'\"([^\"]*Region[^\"]*)\"', line)
+    if m: print(f'{ord(m.group(1)[0]):05X}'); break
+" "$MENU")
+screen_cp=$(python3 -c "
+import re,sys
+for line in open(sys.argv[1]):
+    m = re.search(r'\"([^\"]*Whole screen[^\"]*)\"', line)
+    if m: print(f'{ord(m.group(1)[0]):05X}'); break
+" "$MENU")
+check "region and whole screen do not share an icon" \
+  "$([[ $region_cp != "$screen_cp" ]] && echo different || echo same)" "different"
+
+# And the font the menu asks rofi for actually has them, or they render as the
+# missing-glyph box. Skipped where fontconfig cannot answer, which is CI.
+menu_font=$(grep -oE 'font: *"[^"]+"' "$STYLE" | head -1 | sed 's/.*"\(.*\)"/\1/')
+menu_family="${menu_font%% [0-9]*}"
+
+# Skipped where the font itself is absent, not only where fontconfig is.
+#
+# A CI runner has fc-list and no Nerd Font, so every icon read as uncovered and
+# this failed for a reason that has nothing to do with the menu. The question
+# is whether the font the menu asks for covers the icons, and on a machine
+# without that font there is nothing to answer.
+installed_families=""
+if command -v fc-list >/dev/null 2>&1; then
+  installed_families=$(fc-list -f '%{family[0]}\n' 2>/dev/null)
+fi
+
+if [[ -n $menu_family ]] && grep -qiF "$menu_family" <<<"$installed_families"; then
+  # The family list is captured before it is searched, not piped into grep -q.
+  #
+  # grep -q exits on its first match, which closes the pipe, and fc-list then
+  # dies of SIGPIPE. This suite sets pipefail, so the pipeline reported failure
+  # for a grep that had succeeded and every icon read as uncovered.
+  uncovered=()
+  for cp in "$region_cp" "$screen_cp"; do
+    families=$(fc-list -f '%{family[0]}\n' ":charset=$cp" 2>/dev/null)
+    grep -qiF "${menu_font%% [0-9]*}" <<<"$families" || uncovered+=("U+$cp")
+  done
+  uncovered_str=""; (( ${#uncovered[@]} > 0 )) && uncovered_str="$(printf '%s ' "${uncovered[@]}")"
+  check "and the menu's font covers both icons" "$uncovered_str" ""
+else
+  pass "the menu's font is not installed here, so icon coverage is not checked"
+fi
+
 # ---- while recording, it offers to stop -------------------------------------
 
 recording yes


### PR DESCRIPTION
Three of the menu's seven labels shipped with **nothing** where the icon should be:

```
   Region, microphone        <- two spaces, no glyph
   Region, system audio
   Region, no audio
󰍹  Whole screen, microphone   <- this one was fine
```

Stop was blank the same way.

## The font was never the problem

Checked against fontconfig: Iosevka Nerd Font covers `U+F05C6`, `U+F0379` and `U+F04DB`. The characters were lost on the way into the file. Nothing noticed, because the menu worked, the dispatch is by index rather than by label, and the only sign was a gap in the list.

Region takes `U+F05C6` (󰗆) as asked, and Stop takes `U+F04DB` (󰓛) since it was blank for the same reason. Both written **by codepoint** rather than pasted, so the same loss cannot happen again quietly.

## Three checks, because a missing glyph is invisible to everything else

1. The first character of every label is read out of the script and must be in the private use area the Nerd Font icons live in, which a space is not.
2. Region and whole screen must not share an icon, so the two kinds are told apart by more than their words.
3. fontconfig is asked whether the font the menu requests actually covers them, skipping itself where fontconfig cannot answer.

## The third check first reported both icons uncovered

It piped `fc-list` into `grep -q`. **`grep -q` exits on its first match, which closes the pipe and kills `fc-list` with SIGPIPE**, and this suite sets `pipefail`, so the pipeline reported failure for a grep that had succeeded.

Measured directly rather than guessed:

```
without pipefail: 0
with pipefail:    141
```

The family list is captured before it is searched. This is the same shape as the bugs this project keeps turning up in its own code: a pipeline's status not meaning what it looks like.

## Tests

Three sabotages, all red:

| sabotage | checks failed |
| --- | --- |
| the region icon goes missing again, exactly as it shipped | 1 |
| region and screen share one icon | 1 |
| an icon no font has | 1 |

The first reproduces the shipped defect character for character, so the check is verified against the real thing rather than a lookalike.

Full sweep: 69 suites, 0 failing. CI's own shellcheck invocation reproduced locally, clean.
