### PR TITLE
Use the AUR helper already installed, rather than yay

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,6 +157,9 @@ jobs:
       - name: package-install-test
         run: bash test/package-install-test.sh
 
+      - name: aur-helper-test
+        run: bash test/aur-helper-test.sh
+
       - name: notification-idiom-test
         run: bash test/notification-idiom-test.sh
 

--- a/.local/bin/hyprsimple-aur-helper.sh
+++ b/.local/bin/hyprsimple-aur-helper.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Which AUR helper to use. Sourced, never run on its own.
+#
+# Three callers carried their own copy of this, and all three read yay first:
+#
+#   if command -v yay &>/dev/null; then AUR_HELPER="yay"
+#   elif command -v paru &>/dev/null; then AUR_HELPER="paru"
+#
+# so a machine set up around paru ran every hyprsimple package operation
+# through yay from the moment yay appeared for any other reason, and the
+# installer, finding neither, built yay without asking. paru is what CachyOS
+# ships and what several other Arch derivatives ship, so preferring yay meant
+# preferring the helper the user had not chosen, on the machines most likely to
+# have already chosen.
+#
+# Nothing here installs anything. It reports which helper is present and leaves
+# what to do about none of them to the caller, because the three want different
+# things: the installer offers to build one, the updater skips AUR packages,
+# muslimtify stops.
+#
+# Both helpers take -S --needed --noconfirm and mean the same thing by it,
+# which is why the callers can hold one name and pass the same flags.
+
+# The order only settles a machine that has both. paru first, because a machine
+# with both most likely acquired yay as a dependency of something and paru on
+# purpose. HYPRSIMPLE_AUR_HELPER overrides it either way.
+HYPRSIMPLE_AUR_HELPERS=(paru yay)
+
+# Prints the helper to use.
+#
+#   0  a helper was found, and its name is on stdout
+#   1  no helper is installed
+#   2  HYPRSIMPLE_AUR_HELPER names one that is not installed
+#
+# 2 is separate from 1 on purpose. The installer answers "none installed" by
+# building one, and answering an explicit choice that way would install a
+# second helper alongside the one the user asked for and never mention it.
+aur_helper() {
+  local chosen="${HYPRSIMPLE_AUR_HELPER:-}" candidate
+
+  if [[ -n $chosen ]]; then
+    if ! command -v "$chosen" >/dev/null 2>&1; then
+      echo "hyprsimple: HYPRSIMPLE_AUR_HELPER is set to '$chosen', which is not installed." >&2
+      return 2
+    fi
+    printf '%s\n' "$chosen"
+    return 0
+  fi
+
+  for candidate in "${HYPRSIMPLE_AUR_HELPERS[@]}"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}

--- a/.local/bin/hyprsimple-muslimtify.sh
+++ b/.local/bin/hyprsimple-muslimtify.sh
@@ -30,11 +30,23 @@ usage() {
   exit 1
 }
 
+# Whichever helper is installed. This read yay first, so a paru machine
+# installed muslimtify through yay the moment yay was present for any other
+# reason. Shared with install.sh and hyprsimple-update.sh now.
+AUR_DETECT="$HOME/.local/bin/hyprsimple-aur-helper.sh"
+if [[ -r $AUR_DETECT ]]; then
+  # shellcheck source=/dev/null
+  source "$AUR_DETECT"
+else
+  die "missing helper: hyprsimple-aur-helper.sh. Run hyprsimple-update."
+fi
+
 pick_aur_helper() {
-  if command -v yay >/dev/null 2>&1; then echo yay
-  elif command -v paru >/dev/null 2>&1; then echo paru
-  else die "no AUR helper found (need yay or paru)"
-  fi
+  local helper
+  # aur_helper says on stderr which name it could not find, so the message
+  # here only has to cover the case where nothing is installed at all.
+  helper="$(aur_helper)" || die "no AUR helper found (need paru or yay)"
+  printf '%s\n' "$helper"
 }
 
 reload_waybar() {

--- a/.local/bin/hyprsimple-update.sh
+++ b/.local/bin/hyprsimple-update.sh
@@ -311,18 +311,25 @@ install_missing_packages() {
   $helper -S --needed --noconfirm "${missing[@]}" || true
 }
 
-if command -v yay &>/dev/null; then
-  AUR_HELPER="yay"
-elif command -v paru &>/dev/null; then
-  AUR_HELPER="paru"
-else
-  AUR_HELPER=""
+# Whichever helper is installed, not yay first. Read out of the repo just
+# pulled rather than out of ~/.local/bin, so the update that first ships this
+# file can use it on the same run that delivers it.
+AUR_DETECT="$HYPRSIMPLE_PATH/.local/bin/hyprsimple-aur-helper.sh"
+AUR_HELPER=""
+if [[ -r $AUR_DETECT ]]; then
+  # shellcheck source=/dev/null
+  source "$AUR_DETECT"
+  AUR_HELPER="$(aur_helper)" || AUR_HELPER=""
 fi
 
 echo -e "\n${YELLOW}Checking for newly required packages...${NC}"
 install_missing_packages "$HYPRSIMPLE_PATH/packages.txt" "sudo pacman"
 if [[ -n $AUR_HELPER ]]; then
   install_missing_packages "$HYPRSIMPLE_PATH/aur-packages.txt" "$AUR_HELPER"
+else
+  # Said rather than skipped in silence. An update that reports nothing about
+  # the AUR list reads as an update that found nothing to do there.
+  echo -e "${YELLOW}No AUR helper, so AUR packages were not checked. Install paru or yay.${NC}"
 fi
 
 # ---- Migrations ----------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ These are sourced by other files rather than run directly.
 | `bashrc.sh` / `zsh.sh` / `fish.fish` | Per-shell init (zoxide, fzf, starship, aliases) sourced from your shell's rc file |
 | `terminal.sh` | Detect your login shell and wire the matching init script into its rc file |
 | `hypr-helpers.sh` | Shared hyprpaper helper functions used by the wallpaper scripts |
+| `hyprsimple-aur-helper.sh` | Reports which AUR helper is installed, so the installer, the updater and muslimtify all use the one you already have |
 | `hyprsimple-require.sh` | Loads the helpers a script needs, and stops it rather than letting it run with them missing |
 | `hyprsimple-theme-deliver.sh` | Puts a theme's generated files where each program reads them, shared by the theme switcher and the updater |
 | `hyprsimple-hw-battery.sh` | Exits 0 when this machine has a battery, which is how hyprsimple decides it is a laptop |

--- a/install.sh
+++ b/install.sh
@@ -76,22 +76,63 @@ if [ ! -f /etc/arch-release ]; then
 fi
 
 # Check for AUR helper
-if command -v yay &>/dev/null; then
-  AUR_HELPER="yay"
-elif command -v paru &>/dev/null; then
-  AUR_HELPER="paru"
-else
-  echo -e "${YELLOW}No AUR helper found. Installing yay...${NC}"
-  sudo pacman -Syu
-  sudo pacman -S --needed git base-devel
-  if [[ ! -d "/tmp/yay" ]]; then
-    git clone https://aur.archlinux.org/yay.git /tmp/yay
+#
+# The ladder this used to hold read yay first and then built yay when it found
+# neither, so a paru machine was moved onto yay by installing hyprsimple. The
+# detection is shared with hyprsimple-update.sh and hyprsimple-muslimtify.sh
+# now, because all three had their own copy of it and all three were wrong the
+# same way.
+AUR_DETECT="$DOTFILES_DIR/.local/bin/hyprsimple-aur-helper.sh"
+if [[ ! -r $AUR_DETECT ]]; then
+  echo -e "${RED}Missing $AUR_DETECT, so this clone is incomplete.${NC}"
+  echo -e "${RED}Clone hyprsimple again and re-run this installer.${NC}"
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "$AUR_DETECT"
+
+# `|| status=$?` rather than reading $? on the next line. An `if` whose
+# condition is false and which has no else returns 0, so the status read after
+# it is the `if`'s, not the command's.
+aur_status=0
+AUR_HELPER="$(aur_helper)" || aur_status=$?
+
+if ((aur_status == 2)); then
+  # aur_helper has already said which name it could not find.
+  echo -e "${RED}Install it, or unset HYPRSIMPLE_AUR_HELPER to use whichever is present.${NC}"
+  exit 1
+elif ((aur_status != 0)); then
+  # Which one to build. yay used to be the only answer and it was never asked,
+  # on a machine where the choice belongs to whoever uses it afterwards.
+  AUR_BUILD="paru"
+  if [[ -t 0 ]]; then
+    read -rp "No AUR helper found. Install which one? [paru/yay] (paru) " reply
+    case "${reply,,}" in
+      yay) AUR_BUILD="yay" ;;
+      paru | "") AUR_BUILD="paru" ;;
+      *) echo -e "${YELLOW}Not paru or yay, so installing paru.${NC}" ;;
+    esac
+  else
+    # Under curl-pipe, stdin is the script itself, so reading from it would
+    # consume the installer. Same answer as the prompt's default.
+    echo -e "${YELLOW}No AUR helper found, and nothing here to ask. Installing paru.${NC}"
+    echo -e "${YELLOW}Set HYPRSIMPLE_AUR_HELPER, or install yay first, to use yay instead.${NC}"
   fi
 
-  cd /tmp/yay
+  echo -e "${YELLOW}Installing $AUR_BUILD...${NC}"
+  sudo pacman -Syu
+  sudo pacman -S --needed git base-devel
+  # A build directory left behind by an earlier run holds that run's checkout,
+  # and reusing it silently builds whatever it happens to contain. Cloning
+  # fresh into a directory of our own costs nothing and cannot be a stale or
+  # someone else's /tmp/yay.
+  AUR_BUILD_DIR="$(mktemp -d)"
+  git clone --depth 1 "https://aur.archlinux.org/$AUR_BUILD.git" "$AUR_BUILD_DIR/$AUR_BUILD"
+  cd "$AUR_BUILD_DIR/$AUR_BUILD"
   makepkg -si --noconfirm
   cd "$DOTFILES_DIR"
-  AUR_HELPER="yay"
+  rm -rf "$AUR_BUILD_DIR"
+  AUR_HELPER="$AUR_BUILD"
 fi
 
 echo -e "${GREEN}Using AUR helper: $AUR_HELPER${NC}"

--- a/test/aur-helper-test.sh
+++ b/test/aur-helper-test.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+# Which AUR helper hyprsimple uses.
+#
+# install.sh, hyprsimple-update.sh and hyprsimple-muslimtify.sh each carried
+# their own copy of the same ladder, and all three read yay first:
+#
+#   if command -v yay &>/dev/null; then AUR_HELPER="yay"
+#   elif command -v paru &>/dev/null; then AUR_HELPER="paru"
+#
+# so a machine set up around paru was run through yay the moment yay appeared
+# for any other reason, and the installer, finding neither, built yay without
+# asking. Reported by a CachyOS user, where paru is what the distribution
+# ships.
+#
+# Nothing here installs a package, contacts the AUR or runs pacman. Every
+# acting command is a stub, and the helper detection itself needs no external
+# command at all, so those checks run with a PATH holding only the stubs.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$REPO/.local/bin/hyprsimple-aur-helper.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+check "the shared detection ships" "$([[ -r $HELPER ]] && echo present || echo missing)" "present"
+
+# ---- a PATH holding exactly the helpers named ------------------------------
+#
+# Built fresh each time. A directory reused between cases would keep the
+# previous case's helper on the PATH and every later check would read the same
+# answer for the wrong reason.
+#
+# /usr/bin is deliberately not on the PATH these produce. The first version of
+# this suite appended it so the lifted block could reach mktemp, and the
+# maintainer's own paru sits there: every "with neither installed" case found
+# it and passed for the wrong reason, and the two cases that build a helper
+# built nothing and were reported as ok. Only the few real tools the lifted
+# code needs are linked in, by name.
+REAL_TOOLS=(mktemp rm)
+
+stub_path() {
+  local dir="$TMP/path.$RANDOM.$$"
+  mkdir -p "$dir"
+  local name tool
+  for tool in "${REAL_TOOLS[@]}"; do
+    ln -sf "$(command -v "$tool")" "$dir/$tool"
+  done
+  for name in "$@"; do
+    printf '#!/bin/bash\nprintf %%s "%s"\n' "$name" >"$dir/$name"
+    chmod +x "$dir/$name"
+  done
+  printf '%s' "$dir"
+}
+
+# bash is found through PATH, and these PATHs do not have it. Absolute, so the
+# lifted blocks run under the same shell as this suite.
+BASH_BIN="$(command -v bash)"
+
+# Runs aur_helper with only the named helpers reachable. stdout, stderr and the
+# exit status are kept apart, because the whole point of the return codes is
+# that the caller can tell them apart.
+#
+# `set -u` on purpose: hyprsimple-muslimtify.sh runs under it, and a bare
+# $HYPRSIMPLE_AUR_HELPER would abort there and nowhere else.
+ask() {
+  local override="$1"; shift
+  local dir; dir="$(stub_path "$@")"
+  local script="$TMP/ask.sh"
+  cat >"$script" <<'ASKEOF'
+set -u
+source "$1"
+aur_helper >"$2" 2>"$3"
+exit $?
+ASKEOF
+  # Always set, empty when there is no override, because an empty value is
+  # exactly what the helper has to treat as "not chosen".
+  HYPRSIMPLE_AUR_HELPER="$override" PATH="$dir" \
+    "$BASH_BIN" "$script" "$HELPER" "$TMP/out" "$TMP/err"
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+ask "" paru
+check "with only paru installed, paru is used" "$(cat "$TMP/out")" "paru"
+check "and it says so without complaint" "$(cat "$TMP/err")" ""
+check "and reports success" "$(cat "$TMP/rc")" "0"
+
+ask "" yay
+check "with only yay installed, yay is used" "$(cat "$TMP/out")" "yay"
+
+# The finding itself.
+ask "" paru yay
+check "with both installed, paru is used rather than yay" "$(cat "$TMP/out")" "paru"
+
+ask "yay" paru yay
+check "and HYPRSIMPLE_AUR_HELPER=yay picks yay back" "$(cat "$TMP/out")" "yay"
+ask "paru" paru yay
+check "and HYPRSIMPLE_AUR_HELPER=paru picks paru" "$(cat "$TMP/out")" "paru"
+
+# An override naming something absent is its own answer, not "none installed".
+# The installer builds a helper when it finds none, and doing that here would
+# install a second helper beside the one that was asked for.
+ask "nosuch" paru yay
+check "an override naming an uninstalled helper fails" "$(cat "$TMP/rc")" "2"
+check "and names it" "$(grep -c "nosuch" "$TMP/err")" "1"
+check "and prints no helper to use" "$(cat "$TMP/out")" ""
+
+ask "" # nothing installed at all
+check "with neither installed, it reports none found" "$(cat "$TMP/rc")" "1"
+check "and prints nothing" "$(cat "$TMP/out")" ""
+check "and says nothing, leaving the message to the caller" "$(cat "$TMP/err")" ""
+
+# Anti-vacuity. Every check above rests on the stub directory being what
+# decides the answer, and a PATH that reached the real machine would make the
+# "neither installed" case read whatever is really there.
+dir_both="$(stub_path paru yay)"
+check "the stub directory is what the answers come from" \
+  "$(PATH="$dir_both" command -v paru)" "$dir_both/paru"
+
+# ---- install.sh, lifted --------------------------------------------------
+#
+# install.sh cannot be sourced: it installs packages at the top level. The
+# block under test is taken out of the shipped file rather than restated here,
+# so a change to it is a change to what runs below.
+
+sed -n '/^# Check for AUR helper$/,/^echo ""$/p' "$REPO/install.sh" >"$TMP/block.sh"
+check "the AUR block was lifted out of install.sh" \
+  "$(grep -c 'Using AUR helper' "$TMP/block.sh")" "1"
+check "and it is the whole block, down to the build" \
+  "$(grep -c 'makepkg' "$TMP/block.sh")" "1"
+
+# Stubs for everything the build path would run. Each logs, none acts. The git
+# one creates the directory it was asked to fetch into, because the block cds
+# there afterwards and a stub that logged and did nothing would fail for a
+# reason that has nothing to do with the choice being tested.
+BUILD_STUBS="$TMP/buildstubs"
+mkdir -p "$BUILD_STUBS"
+cat >"$BUILD_STUBS/git" <<'GITEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$FETCH_LOG"
+for arg; do :; done
+mkdir -p "$arg"
+GITEOF
+cat >"$BUILD_STUBS/makepkg" <<'MPEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$BUILD_LOG"
+MPEOF
+cat >"$BUILD_STUBS/sudo" <<'SUDOEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$PACMAN_LOG"
+SUDOEOF
+chmod +x "$BUILD_STUBS"/*
+
+# Runs the lifted block with the named helpers present. mktemp, printf and the
+# rest come from /usr/bin, so the stubs go in front of it rather than replacing
+# it, and the helper names are stubbed there too.
+run_block() {
+  local override="$1"; shift
+  local dir; dir="$(stub_path "$@")"
+  cp "$BUILD_STUBS"/* "$dir/"
+  : >"$TMP/fetch"; : >"$TMP/build"; : >"$TMP/pacman"
+  FETCH_LOG="$TMP/fetch" BUILD_LOG="$TMP/build" PACMAN_LOG="$TMP/pacman" \
+    DOTFILES_DIR="$REPO" RED='' GREEN='' YELLOW='' NC='' \
+    HYPRSIMPLE_AUR_HELPER="$override" PATH="$dir" \
+    "$BASH_BIN" "$TMP/block.sh" >"$TMP/out" 2>&1 </dev/null
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+run_block "" paru
+check "the installer uses an existing paru" "$(grep -c 'Using AUR helper: paru' "$TMP/out")" "1"
+check "and builds nothing" "$(wc -l <"$TMP/build" | tr -d ' ')" "0"
+check "and fetches nothing" "$(wc -l <"$TMP/fetch" | tr -d ' ')" "0"
+check "and exits 0" "$(cat "$TMP/rc")" "0"
+
+run_block "" yay
+check "and an existing yay" "$(grep -c 'Using AUR helper: yay' "$TMP/out")" "1"
+check "still building nothing" "$(wc -l <"$TMP/build" | tr -d ' ')" "0"
+
+run_block "" paru yay
+check "with both present the installer uses paru" \
+  "$(grep -c 'Using AUR helper: paru' "$TMP/out")" "1"
+
+run_block yay paru yay
+check "and honours HYPRSIMPLE_AUR_HELPER" "$(grep -c 'Using AUR helper: yay' "$TMP/out")" "1"
+
+run_block nosuch paru
+check "an override naming nothing installed stops the install" \
+  "$([[ $(cat "$TMP/rc") != "0" ]] && echo stopped || echo continued)" "stopped"
+check "rather than quietly building a second helper" \
+  "$(wc -l <"$TMP/build" | tr -d ' ')" "0"
+
+# ---- with neither installed ------------------------------------------------
+
+run_block ""
+check "with neither installed the installer builds one" \
+  "$(wc -l <"$TMP/build" | tr -d ' ')" "1"
+check "and it is paru, not yay" "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "1"
+check "and yay is not fetched" "$(grep -c 'aur.archlinux.org/yay' "$TMP/fetch")" "0"
+check "and it says which one it chose before doing it" \
+  "$(grep -c 'Installing paru\.\.\.' "$TMP/out")" "1"
+check "and reports paru as the helper in use" \
+  "$(grep -c 'Using AUR helper: paru' "$TMP/out")" "1"
+
+# The fetch used to go to a fixed /tmp/yay and skip the fetch entirely when
+# that directory already existed, so a half-finished earlier run, or another
+# user's directory of the same name, was built instead.
+check "the build directory is not a fixed path in /tmp" \
+  "$(sed 's/^[[:space:]]*#.*//' "$REPO/install.sh" | grep -c '/tmp/yay')" "0"
+check "and is made fresh each time" "$(grep -c 'mktemp -d' "$TMP/block.sh")" "1"
+
+# ---- the prompt ------------------------------------------------------------
+#
+# Only when a terminal is attached. Under curl-pipe stdin is the installer
+# itself, and a read there consumes the next line of the script.
+check "the prompt is guarded by a terminal check" \
+  "$(grep -c -- '-t 0' "$TMP/block.sh")" "1"
+
+SCRIPT_BIN="$(command -v script || true)"
+if [[ -n $SCRIPT_BIN ]]; then
+  run_on_pty() {
+    local answer="$1"; shift
+    local dir; dir="$(stub_path)"
+    cp "$BUILD_STUBS"/* "$dir/"
+    # script(1) linked in rather than its directory added to the PATH. Adding
+    # /usr/bin back is what put the real paru in front of these cases again,
+    # and each of them silently stopped testing the prompt.
+    ln -sf "$SCRIPT_BIN" "$dir/script"
+    : >"$TMP/fetch"; : >"$TMP/build"; : >"$TMP/pacman"
+    printf '%s\n' "$answer" |
+      FETCH_LOG="$TMP/fetch" BUILD_LOG="$TMP/build" PACMAN_LOG="$TMP/pacman" \
+      DOTFILES_DIR="$REPO" RED='' GREEN='' YELLOW='' NC='' HYPRSIMPLE_AUR_HELPER='' \
+      PATH="$dir" \
+      "$SCRIPT_BIN" -qec "$BASH_BIN $TMP/block.sh" /dev/null >"$TMP/out" 2>&1
+  }
+
+  run_on_pty yay
+  check "asked at a terminal, an answer of yay builds yay" \
+    "$(grep -c 'aur.archlinux.org/yay' "$TMP/fetch")" "1"
+  check "and not paru" "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "0"
+
+  run_on_pty ""
+  check "and an empty answer takes the default, paru" \
+    "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "1"
+
+  run_on_pty "PARU"
+  check "and the answer is read whatever its case" \
+    "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "1"
+
+  run_on_pty "banana"
+  check "an answer that is neither falls back to paru rather than stopping" \
+    "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "1"
+  check "and says it did not understand" "$(grep -c 'Not paru or yay' "$TMP/out")" "1"
+else
+  pass "skipped the prompt checks: no script(1) to give the block a terminal"
+fi
+
+# ---- hyprsimple-update.sh, lifted ------------------------------------------
+
+sed -n '/^AUR_DETECT="\$HYPRSIMPLE_PATH/,/^fi$/p' \
+  "$REPO/.local/bin/hyprsimple-update.sh" >"$TMP/update-block.sh"
+check "the detection was lifted out of hyprsimple-update.sh" \
+  "$(grep -c 'aur_helper' "$TMP/update-block.sh")" "1"
+printf 'printf "%%s" "$AUR_HELPER"\n' >>"$TMP/update-block.sh"
+
+update_picks() {
+  local dir; dir="$(stub_path "$@")"
+  PATH="$dir" HYPRSIMPLE_PATH="$REPO" HYPRSIMPLE_AUR_HELPER='' \
+    "$BASH_BIN" "$TMP/update-block.sh" 2>/dev/null
+}
+
+check "the update uses an existing paru" "$(update_picks paru)" "paru"
+check "and picks paru over yay" "$(update_picks paru yay)" "paru"
+check "and leaves the helper empty when there is none" "$(update_picks)" ""
+
+# An update that checks no AUR packages has to say so. Silence reads as an
+# update that looked and found nothing to do.
+check "and the update says when it skipped the AUR list" \
+  "$(grep -c 'AUR packages were not checked' "$REPO/.local/bin/hyprsimple-update.sh")" "1"
+
+# ---- nothing carries its own ladder any more -------------------------------
+#
+# The point of one detection is that there is one. Comments stripped, because
+# the shared helper and two of its callers quote the old ladder in theirs.
+
+offenders=()
+for script in "$REPO/install.sh" "$REPO/.local/bin"/*.sh; do
+  [[ $script == *hyprsimple-aur-helper.sh ]] && continue
+  sed 's/^[[:space:]]*#.*//' "$script" | grep -qE 'command -v (yay|paru)' &&
+    offenders+=("$(basename "$script")")
+done
+offenders_str=""
+(( ${#offenders[@]} > 0 )) && offenders_str="$(printf '%s ' "${offenders[@]}")"
+check "no script looks for a helper on its own" "$offenders_str" ""
+
+users=0
+for script in "$REPO/install.sh" "$REPO/.local/bin/hyprsimple-update.sh" \
+  "$REPO/.local/bin/hyprsimple-muslimtify.sh"; do
+  grep -q 'hyprsimple-aur-helper.sh' "$script" && users=$((users + 1))
+done
+check "and all three callers use the shared one" "$users" "3"
+
+# It only reaches an installed machine if the delivery loops take it, and both
+# of them take *.sh by glob rather than by name.
+check "install.sh delivers .local/bin by glob, so the helper goes with it" \
+  "$(grep -c '\.local/bin"/\*\.sh' "$REPO/install.sh")" "1"
+check "and hyprsimple-update.sh refreshes it the same way" \
+  "$(grep -c '\.local/bin"/\*\.sh' "$REPO/.local/bin/hyprsimple-update.sh")" "1"
+
+# muslimtify stops rather than carrying on with pick_aur_helper undefined.
+check "muslimtify stops when the shared detection is missing" \
+  "$(grep -c 'missing helper: hyprsimple-aur-helper.sh' "$REPO/.local/bin/hyprsimple-muslimtify.sh")" "1"
+
+if (( failures > 0 )); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Reported on a machine that already has paru: installing hyprsimple pulls in yay.

## What was wrong

`install.sh`, `hyprsimple-update.sh` and `hyprsimple-muslimtify.sh` each carried their own copy of the same ladder, and all three read yay first:

```bash
if command -v yay &>/dev/null; then AUR_HELPER="yay"
elif command -v paru &>/dev/null; then AUR_HELPER="paru"
```

So a machine set up around paru was run through yay the moment yay appeared for any other reason, and the installer, finding neither, cloned and built yay without asking. paru is what CachyOS ships, so this hits the machines most likely to have already made the choice.

## What it does now

One detection, `.local/bin/hyprsimple-aur-helper.sh`, sourced by all three. It reports which helper is installed and leaves what to do about none of them to the caller, because the three want different things: the installer offers to build one, the updater skips the AUR list, muslimtify stops.

- Whichever helper is installed is the one used. paru first when both are there, and `HYPRSIMPLE_AUR_HELPER` overrides it either way.
- An override naming something not installed is its own answer, separate from "none installed". Treating it as none would have had the installer build a second helper alongside the one that was asked for and say nothing about it.
- With neither installed the installer asks which to build, defaulting to paru, and takes paru without asking when there is no terminal. The prompt sits behind `[[ -t 0 ]]`, so curl-pipe does not consume the installer.
- The build no longer reuses a fixed `/tmp/yay`. That directory holds an earlier run's checkout, or another user's, and was built without a word.
- An update that finds no helper now says the AUR list was not checked, rather than skipping it in silence.

## Tests

`test/aur-helper-test.sh`, 51 checks, registered in the workflow. Nothing in it installs a package, contacts the AUR or runs pacman.

The PATH each case builds holds only the stubs and two real tools by name. The first version appended `/usr/bin` so the lifted block could reach `mktemp`, and the maintainer's own paru sits there: every "with neither installed" case found it, and the two cases that build a helper built nothing and reported ok.

The installer block and the updater's detection are lifted out of the shipped files rather than restated, and the prompt is driven through a pty so the terminal branch is really taken.

Four sabotages, each caught:

| sabotage | checks that failed |
| --- | --- |
| yay preferred again | 3 |
| installer builds yay when it finds none | 5 |
| the override ignored | 6 |
| a caller grows its own ladder back | 1 |

No migration. Both delivery loops take `.local/bin/*.sh` by glob, so the new helper reaches an existing install on the next update, on the same run that first uses it.