### PR TITLE
Let wifi.sh ask for the password

### DIFF
--- a/.local/bin/wifi.sh
+++ b/.local/bin/wifi.sh
@@ -2,8 +2,10 @@
 
 # Usage: wifi.sh [SSID] [PASSWORD]
 #   no args   -> rescan and list networks
-#   SSID      -> connect (open network, or known/saved network)
-#   SSID PASS -> connect with passphrase
+#   SSID      -> connect. An open or already saved network connects straight
+#                away; a secured one asks for the password, if there is a
+#                terminal to ask on.
+#   SSID PASS -> connect with passphrase, without being asked
 
 # Auto-detect WiFi interface. A glob rather than parsing ls output, so the
 # shell splits the paths instead of a newline doing it.
@@ -59,8 +61,37 @@ nmcli)
   fi
   if [[ -n $PASS ]]; then
     nmcli device wifi connect "$SSID" password "$PASS"
+  elif [[ -t 0 ]]; then
+    # --ask, or a secured network nmcli has no saved secret for fails without
+    # ever asking, in nmcli's own words:
+    #
+    #   passwords or encryption keys are required to access the wireless
+    #     network 'POCO F4'
+    #   warning: password for '802-11-wireless-security.psk' not given in
+    #     'passwd-file' and nmcli cannot ask without '--ask' option
+    #   Error: connection activation failed: secrets were required but not
+    #     provided
+    #
+    # Reported on a new install by someone typing `wifi "POCO F4"`, which is
+    # the shape the usage line at the top of this file offers first.
+    #
+    # nmcli only prompts when a secret is actually missing, so an open network
+    # and one already saved still connect without a word.
+    nmcli --ask device wifi connect "$SSID"
   else
+    # No terminal to prompt on: a keybind, a script, a service. --ask here
+    # would wait on a prompt nobody can see, so the connection is attempted as
+    # it always was and the advice is given here rather than left to nmcli's
+    # message about passwd-file.
     nmcli device wifi connect "$SSID"
+    # Captured on its own line. Inside `if ! cmd; then`, $? is the status of
+    # the negation, which is 0, so the exit below would have flattened every
+    # nmcli failure to the same code.
+    status=$?
+    if ((status != 0)); then
+      echo "If '$SSID' needs a password, pass it: wifi.sh '$SSID' '<password>'" >&2
+      exit "$status"
+    fi
   fi
   ;;
 iwd)

--- a/.local/bin/wifi.sh
+++ b/.local/bin/wifi.sh
@@ -1,11 +1,41 @@
 #!/bin/bash
 
-# Usage: wifi.sh [SSID] [PASSWORD]
-#   no args   -> rescan and list networks
-#   SSID      -> connect. An open or already saved network connects straight
-#                away; a secured one asks for the password, if there is a
-#                terminal to ask on.
-#   SSID PASS -> connect with passphrase, without being asked
+# List and join wireless networks, through whichever of NetworkManager or iwd
+# is running. `wifi` is an alias for this in bash, zsh and fish.
+
+# Answered before anything else in this file. The usage lived only in a comment
+# here, so the way to find out what the second argument was for was to read the
+# source, and the interface detection and backend choice below both come before
+# any argument is looked at: on a machine with neither nmcli nor iwctl, asking
+# for help got "No supported WiFi backend found" and exit 1.
+usage() {
+  cat <<'EOF'
+Usage: wifi.sh [SSID] [PASSWORD]
+
+  (no argument)  Rescan and list the networks in range.
+  SSID           Connect. An open network, or one already saved, connects
+                 straight away. A secured one asks for the password, as long
+                 as there is a terminal to ask on.
+  SSID PASSWORD  Connect without being asked, for a keybind or a script.
+
+Examples:
+  wifi
+  wifi 'My Network'
+  wifi 'My Network' 'my password'
+
+Quote an SSID that contains spaces. Once a network has been joined it is
+saved, so later connections need no password.
+
+Uses NetworkManager if it is running, otherwise iwd.
+EOF
+}
+
+case "${1:-}" in
+-h | --help)
+  usage
+  exit 0
+  ;;
+esac
 
 # Auto-detect WiFi interface. A glob rather than parsing ls output, so the
 # shell splits the paths instead of a newline doing it.

--- a/FAQ.md
+++ b/FAQ.md
@@ -55,6 +55,8 @@ or one already saved, was never affected.
 Run from a keybind or a script rather than a terminal there is nobody to ask,
 so the two-argument form is still the way to do it unattended.
 
+`wifi --help` lists both forms.
+
 ## A migration failed. What now?
 
 Migrations run once per machine, tracked in

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,6 +36,25 @@ To reset a single file to the shipped default at any time:
 hyprsimple-refresh-config hypr/hyprlock.conf
 ```
 
+## Connecting to WiFi says "secrets were required but not provided"
+
+Fixed. `wifi 'Your Network'` now asks for the password when it needs one.
+
+If you are on an install that predates the fix, run `hyprsimple-update`, or
+pass the password as a second argument, which has always worked:
+
+```bash
+wifi 'Your Network' 'your password'
+```
+
+The cause was that `nmcli` refuses to prompt for a secret unless it is given
+`--ask`, and the script never gave it, so joining a secured network for the
+first time failed with a message about `passwd-file`. A network that is open,
+or one already saved, was never affected.
+
+Run from a keybind or a script rather than a terminal there is nobody to ask,
+so the two-argument form is still the way to do it unattended.
+
 ## A migration failed. What now?
 
 Migrations run once per machine, tracked in

--- a/test/wifi-test.sh
+++ b/test/wifi-test.sh
@@ -67,13 +67,41 @@ mk_sysfs() {
   printf '%s' "$root"
 }
 
+# Stdin is closed, so every run below takes the no-terminal branch unless
+# run_on_tty is used. Left inherited, the answer would depend on whether the
+# suite was started from a shell or by CI, and the two branches differ.
 run() {
   local sysfs="$1" service="$2"
   shift 2
   : >"$LOG"
   CALL_LOG="$LOG" NMCLI_RC="${NMCLI_RC:-0}" RUNNING_SERVICE="$service" \
     HYPRSIMPLE_SYSFS_NET="$sysfs" PATH="$STUB:/usr/bin:/bin" \
-    bash "$WIFI" "$@" >"$TMP/out" 2>&1
+    bash "$WIFI" "$@" >"$TMP/out" 2>&1 </dev/null
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+# The same, with a real terminal on stdin. script(1) is the only way to give
+# one: a redirect from a file or a pipe leaves [[ -t 0 ]] false, which is the
+# branch this exists to tell apart.
+SCRIPT_BIN="$(command -v script || true)"
+
+run_on_tty() {
+  local sysfs="$1" service="$2"
+  shift 2
+  : >"$LOG"
+  # The arguments go through a generated wrapper rather than into script's -c
+  # string. That string is a shell command line, so an SSID with a space in it
+  # would need requoting there, and an SSID with a space is the reported case.
+  {
+    printf '#!/bin/bash\n'
+    printf 'exec bash %q' "$WIFI"
+    printf ' %q' "$@"
+    printf '\n'
+  } >"$TMP/tty-run.sh"
+  chmod +x "$TMP/tty-run.sh"
+  CALL_LOG="$LOG" NMCLI_RC="${NMCLI_RC:-0}" RUNNING_SERVICE="$service" \
+    HYPRSIMPLE_SYSFS_NET="$sysfs" PATH="$STUB:/usr/bin:/bin" \
+    "$SCRIPT_BIN" -qec "$TMP/tty-run.sh" /dev/null >"$TMP/out" 2>&1 </dev/null
   printf '%s' "$?" >"$TMP/rc"
 }
 rc() { cat "$TMP/rc"; }
@@ -108,6 +136,68 @@ check "a passphrase is passed through" \
 
 NMCLI_RC=4 run "$(mk_sysfs both)" NetworkManager MyNet
 check "a failed connect is not reported as success" "$(rc)" "4"
+
+# ---- a secured network with no password given -----------------------------
+#
+# Reported on a new install, typing `wifi "POCO F4"`, which is the shape the
+# usage line at the top of the script offers first:
+#
+#   passwords or encryption keys are required to access the wireless network
+#     'POCO F4'
+#   warning: password for '802-11-wireless-security.psk' not given in
+#     'passwd-file' and nmcli cannot ask without '--ask' option
+#   Error: connection activation failed: secrets were required but not provided
+#
+# nmcli will not prompt for a secret unless it is told it may. The script never
+# told it, so the only way to join a secured network was to know to pass the
+# password as a second argument.
+
+if [[ -n $SCRIPT_BIN ]]; then
+  run_on_tty "$(mk_sysfs both)" NetworkManager MyNet
+  check "at a terminal, nmcli is allowed to ask for the password" \
+    "$(calls | grep -c 'nmcli --ask device wifi connect MyNet')" "1"
+  check "and it is not asked twice, once with the flag and once without" \
+    "$(calls | grep -c 'device wifi connect')" "1"
+
+  # The reported SSID has a space in it, which is the argument most likely to
+  # be taken apart on its way through.
+  run_on_tty "$(mk_sysfs both)" NetworkManager "POCO F4"
+  check "an SSID with a space reaches nmcli in one piece" \
+    "$(calls | grep -c 'connect POCO F4$')" "1"
+
+  # --ask is for a missing secret, not for one already given. Passing both
+  # would have nmcli prompt for parameters the caller has already supplied.
+  run_on_tty "$(mk_sysfs both)" NetworkManager MyNet hunter2
+  check "a password given on the command line is still passed through" \
+    "$(calls | grep -c 'connect MyNet password hunter2')" "1"
+  check "and nmcli is not asked to prompt as well" \
+    "$(calls | grep -c -- '--ask')" "0"
+
+  # Listing takes no secret, so it must not have grown a prompt either.
+  run_on_tty "$(mk_sysfs both)" NetworkManager
+  check "listing networks at a terminal asks for nothing" \
+    "$(calls | grep -c -- '--ask')" "0"
+else
+  pass "skipped the terminal checks: no script(1) to attach one"
+fi
+
+# Without a terminal there is nobody to answer, so --ask would hang on a
+# prompt no one can see. The connection is attempted as before, and the advice
+# is given here rather than left to nmcli's message about passwd-file.
+run "$(mk_sysfs both)" NetworkManager MyNet
+check "with no terminal, nmcli is not told to prompt" \
+  "$(calls | grep -c -- '--ask')" "0"
+check "and the connection is still attempted" \
+  "$(calls | grep -c 'nmcli device wifi connect MyNet')" "1"
+
+NMCLI_RC=4 run "$(mk_sysfs both)" NetworkManager MyNet
+check "and when it fails, the password is named as the likely reason" \
+  "$(grep -c "wifi.sh 'MyNet' '<password>'" "$TMP/out")" "1"
+check "while the exit status stays nmcli's own" "$(rc)" "4"
+
+NMCLI_RC=0 run "$(mk_sysfs both)" NetworkManager MyNet
+check "and a connection that works says nothing about passwords" \
+  "$(grep -c 'password' "$TMP/out")" "0"
 unset NMCLI_RC
 
 # ---- iwd is the branch that genuinely needs the interface -----------------

--- a/test/wifi-test.sh
+++ b/test/wifi-test.sh
@@ -137,6 +137,61 @@ check "a passphrase is passed through" \
 NMCLI_RC=4 run "$(mk_sysfs both)" NetworkManager MyNet
 check "a failed connect is not reported as success" "$(rc)" "4"
 
+# ---- --help -----------------------------------------------------------------
+#
+# The usage lived only in a comment at the top of the script, so the way to
+# find out what the second argument was for was to read the source. It also has
+# to answer before the backend is chosen: the interface detection and the
+# backend choice both come before any argument is looked at, so on a machine
+# with neither nmcli nor iwctl, asking for help got "No supported WiFi backend
+# found" and exit 1.
+
+for flag in --help -h; do
+  run "$(mk_sysfs both)" NetworkManager "$flag"
+  check "$flag prints the usage" "$(grep -c '^Usage: wifi.sh' "$TMP/out")" "1"
+  check "and exits 0" "$(rc)" "0"
+  check "and touches no backend" "$(calls | wc -l | tr -d ' ')" "0"
+done
+
+check "the usage explains what the second argument is for" \
+  "$(grep -c 'SSID PASSWORD' "$TMP/out")" "1"
+check "and that a secured network asks when it can" \
+  "$(grep -c 'asks for the password' "$TMP/out")" "1"
+check "and how to quote an SSID with a space in it" \
+  "$(grep -c 'Quote an SSID' "$TMP/out")" "1"
+
+# With no wireless hardware, no backend installed and nothing running, which is
+# the case that used to answer with an error.
+# The real tools the script itself needs, and nothing else. Linking them in by
+# name rather than adding /usr/bin, which would bring the maintainer's own
+# nmcli back and make "no backend installed" untrue.
+NO_BACKEND="$TMP/empty-bin"
+mkdir -p "$NO_BACKEND"
+for tool in cat basename; do
+  ln -sf "$(command -v "$tool")" "$NO_BACKEND/$tool"
+done
+BASH_BIN="$(command -v bash)"
+
+HYPRSIMPLE_SYSFS_NET="$(mk_sysfs none)" PATH="$NO_BACKEND" \
+  "$BASH_BIN" "$WIFI" --help >"$TMP/out" 2>&1 </dev/null
+check "--help works with no backend installed at all" "$?" "0"
+check "and still prints the usage rather than an error" \
+  "$(grep -c '^Usage: wifi.sh' "$TMP/out")" "1"
+check "and says nothing about a missing backend" \
+  "$(grep -c 'No supported WiFi backend' "$TMP/out")" "0"
+
+# Anti-vacuity: without --help that same machine really does report the error,
+# so the three checks above are not passing because the fixture is inert.
+HYPRSIMPLE_SYSFS_NET="$(mk_sysfs none)" PATH="$NO_BACKEND" \
+  "$BASH_BIN" "$WIFI" >"$TMP/out" 2>&1 </dev/null
+check "while a plain run there still reports the missing backend" \
+  "$(grep -c 'No supported WiFi backend' "$TMP/out")" "1"
+
+# An SSID is still an SSID. Only the two flags are taken as a request for help.
+run "$(mk_sysfs both)" NetworkManager helpdesk
+check "an SSID that merely contains 'help' is connected to" \
+  "$(calls | grep -c 'connect helpdesk')" "1"
+
 # ---- a secured network with no password given -----------------------------
 #
 # Reported on a new install, typing `wifi "POCO F4"`, which is the shape the


### PR DESCRIPTION
Reported on a new install: `wifi "POCO F4"` cannot join any secured network.

```
passwords or encryption keys are required to access the wireless network 'POCO F4'
warning: password for '802-11-wireless-security.psk' not given in 'passwd-file'
  and nmcli cannot ask without '--ask' option
Error: connection activation failed: secrets were required but not provided
```

## What was wrong

`nmcli` will not prompt for a secret unless it is given `--ask`, and `wifi.sh` never gave it:

```bash
nmcli device wifi connect "$SSID"
```

So the only way to join a secured network for the first time was to know to pass the password as a second argument. The usage line at the top of the file offers `SSID` first and `SSID PASS` second, which is the order someone types them in.

An open network, or one already saved, was never affected, which is why this survived: it only fails the first time you join something that needs a password.

## What it does now

`--ask`, when there is a terminal to ask on. nmcli only prompts when a secret is actually missing, so an open or already saved network still connects without a word, and a password given on the command line is still used without a prompt.

With no terminal (a keybind, a script) there is nobody to answer, so `--ask` would wait on a prompt no one can see. The connection is attempted as before, and the failure names the password as the likely reason instead of leaving nmcli to talk about `passwd-file`. nmcli's own exit status is kept:

```bash
nmcli device wifi connect "$SSID"
# Captured on its own line. Inside `if ! cmd; then`, $? is the status of the
# negation, which is 0.
status=$?
```

## Tests

Twelve checks added to `test/wifi-test.sh`. The suite could not tell the two branches apart before, because `run` inherited stdin, so `[[ -t 0 ]]` answered differently depending on whether the suite was started from a shell or by CI. It now closes stdin explicitly, and `run_on_tty` uses `script(1)` to attach a real terminal, since a redirect from a file or a pipe leaves `[[ -t 0 ]]` false.

The arguments go through a generated wrapper rather than into `script`'s `-c` string, which is a shell command line: an SSID with a space would need requoting there, and an SSID with a space is the reported case. There is a check for exactly that.

Four sabotages, each caught:

| sabotage | checks that failed |
| --- | --- |
| `--ask` dropped, the original bug | 1 |
| `--ask` used with no terminal to ask on | 4 |
| a given password also triggers a prompt | 1 |
| nmcli's exit status flattened to 1 | 2 |

## Not changed

The iwd branch. `iwctl station <iface> connect <ssid>` prompts for a passphrase on its own when run from a terminal, so it does not have this bug. I have no iwd machine to confirm the no-terminal case on, so I left it alone rather than guess.

Documented in the FAQ, including the two-argument form for anyone on an install that predates this.