### PR TITLE
Install without standing over the machine

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,6 +160,9 @@ jobs:
       - name: aur-helper-test
         run: bash test/aur-helper-test.sh
 
+      - name: unattended-install-test
+        run: bash test/unattended-install-test.sh
+
       - name: notification-idiom-test
         run: bash test/notification-idiom-test.sh
 

--- a/.local/bin/hyprsimple-aur-helper.sh
+++ b/.local/bin/hyprsimple-aur-helper.sh
@@ -56,3 +56,25 @@ aur_helper() {
   done
   return 1
 }
+
+# The flags that stop a helper asking. --noconfirm on its own is not enough:
+# paru still opens each PKGBUILD for review and yay still asks about diffs,
+# edits and stale build directories, and every one of those waits for a
+# keypress. Per helper, because they spell it differently and passing yay's
+# flags to paru is an error rather than a no-op.
+#
+# One flag per line, for `mapfile`. Building a string and splitting it on
+# spaces would break the first time a flag needs one.
+aur_unattended_flags() {
+  case "$1" in
+  paru)
+    printf '%s\n' --noconfirm --skipreview
+    ;;
+  yay)
+    printf '%s\n' --noconfirm --answerdiff=None --answeredit=None --answerclean=None
+    ;;
+  *)
+    printf '%s\n' --noconfirm
+    ;;
+  esac
+}

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,6 +36,22 @@ To reset a single file to the shipped default at any time:
 hyprsimple-refresh-config hypr/hyprlock.conf
 ```
 
+## The install ran without asking me anything. Can I watch what it does?
+
+Yes. `./install.sh --interactive` restores every confirmation: the two
+`pacman -Syu` upgrades, the official package list, and each AUR package.
+
+The default is unattended because the install takes a while and used to stop a
+dozen times across it, minutes apart, so it needed someone sitting in front of
+the machine for the whole run. It still asks for your sudo password once, at
+the start, and holds it for the rest of the install rather than letting it
+lapse and asking again halfway through.
+
+The trade is real and worth knowing: an unattended `pacman -Syu` answers
+pacman's questions for you, including which packages to replace, and skips the
+Arch news. On a machine that has not been updated in a long time, use
+`--interactive` and read them.
+
 ## Connecting to WiFi says "secrets were required but not provided"
 
 Fixed. `wifi 'Your Network'` now asks for the password when it needs one.
@@ -56,6 +72,7 @@ Run from a keybind or a script rather than a terminal there is nobody to ask,
 so the two-argument form is still the way to do it unattended.
 
 `wifi --help` lists both forms.
+
 
 ## A migration failed. What now?
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ cd hyprsimple
 ./install.sh
 ```
 
+The install asks for your sudo password once, at the start, and then runs to
+the end without stopping. Package operations confirm nothing, so you can start
+it and walk away. It comes back to you once, at the very end, to ask whether to
+log out.
+
+If you would rather read what pacman is about to do, `./install.sh
+--interactive` puts every confirmation back, including the full system upgrade.
+It also asks which AUR helper to build when you have neither paru nor yay,
+instead of taking paru. Whichever helper you already have is the one used
+either way, and `HYPRSIMPLE_AUR_HELPER=yay ./install.sh` settles a machine that
+has both.
+
 > [!WARNING]
 > These dotfiles have only been tested on a fresh Arch Linux install where Hyprland was selected
 > as the desktop during installation. Coming from another desktop environment or compositor

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,101 @@ if [ ! -f /etc/arch-release ]; then
   exit 1
 fi
 
+# ======================================
+#  Unattended by default
+# ======================================
+#
+# This install used to stop and wait a dozen times: the sudo password, twice
+# for a full upgrade, once for the official package list, and once per package
+# for the AUR list, each of them minutes apart, so installing hyprsimple meant
+# sitting in front of the machine for the length of it.
+#
+# It was never a decision. Five package operations in this file already passed
+# --noconfirm, including the retry inside install_packages, and four did not.
+# The unattended path was the fallback and the interactive one was the default.
+#
+# --interactive puts the confirmations back for anyone who wants to read what
+# pacman is about to replace.
+UNATTENDED=1
+for arg in "$@"; do
+  case "$arg" in
+  --interactive)
+    UNATTENDED=0
+    ;;
+  -h | --help)
+    cat <<'USAGE'
+Usage: ./install.sh [--interactive]
+
+  (no argument)  Install without stopping to confirm. The sudo password is
+                 asked for once, at the start, and held for the whole run.
+  --interactive  Confirm each package operation, the way pacman does when it
+                 is run by hand.
+USAGE
+    exit 0
+    ;;
+  *)
+    echo -e "${RED}Unknown option: $arg${NC}"
+    echo "Run ./install.sh --help for what this takes."
+    exit 1
+    ;;
+  esac
+done
+
+# Passed to every package operation. An empty array expands to nothing, so the
+# interactive run is the command that was there before this existed.
+CONFIRM=()
+if ((UNATTENDED)); then
+  CONFIRM=(--noconfirm)
+  echo -e "${YELLOW}Installing without confirmations. Pass --interactive to be asked.${NC}"
+  echo ""
+fi
+
+# ======================================
+#  The password, once
+# ======================================
+#
+# sudo forgets after 15 minutes without a sudo call, and a full upgrade or an
+# AUR build takes longer than that, so the install asked again partway through
+# and then sat waiting. Asked once here instead, and refreshed until this
+# script ends.
+#
+# Failing here rather than at the first sudo several minutes in. A machine with
+# no way to authenticate cannot install this, and saying so at the start costs
+# nothing.
+SUDO_KEEPALIVE_PID=""
+
+stop_sudo_keepalive() {
+  [[ -n $SUDO_KEEPALIVE_PID ]] || return 0
+  # The recorded pid, never a pattern. `pkill -f` matches the shell that is
+  # running this script as readily as the loop it is aimed at.
+  kill "$SUDO_KEEPALIVE_PID" 2>/dev/null
+  SUDO_KEEPALIVE_PID=""
+}
+trap stop_sudo_keepalive EXIT
+
+# `sudo -n true` first, so a machine that needs no password is never prompted
+# and a cached credential is reused. `sudo -v` reads from the terminal device
+# rather than stdin, so this is safe under curl-pipe, where stdin is the
+# script.
+if ! sudo -n true 2>/dev/null; then
+  echo -e "${YELLOW}This install needs sudo. You will be asked once, now.${NC}"
+  if ! sudo -v; then
+    echo -e "${RED}Could not authenticate with sudo, so nothing was installed.${NC}"
+    exit 1
+  fi
+fi
+
+# Refreshed every 60 seconds. It stops when this script does: the EXIT trap
+# kills it, and the kill -0 is the backstop for the case where the trap does
+# not run, so a keep-alive can never outlive the install and leave the machine
+# authorised.
+while true; do
+  sleep 60
+  kill -0 "$$" 2>/dev/null || exit
+  sudo -n true 2>/dev/null || exit
+done &
+SUDO_KEEPALIVE_PID=$!
+
 # Check for AUR helper
 #
 # The ladder this used to hold read yay first and then built yay when it found
@@ -105,23 +200,24 @@ elif ((aur_status != 0)); then
   # Which one to build. yay used to be the only answer and it was never asked,
   # on a machine where the choice belongs to whoever uses it afterwards.
   AUR_BUILD="paru"
-  if [[ -t 0 ]]; then
+  # Two reasons not to ask. An unattended run does not stop for questions, and
+  # under curl-pipe stdin is the script itself, so a read there takes the next
+  # line of the installer as its answer rather than waiting for a person.
+  if [[ -t 0 ]] && ((!UNATTENDED)); then
     read -rp "No AUR helper found. Install which one? [paru/yay] (paru) " reply
     case "${reply,,}" in
-      yay) AUR_BUILD="yay" ;;
-      paru | "") AUR_BUILD="paru" ;;
-      *) echo -e "${YELLOW}Not paru or yay, so installing paru.${NC}" ;;
+    yay) AUR_BUILD="yay" ;;
+    paru | "") AUR_BUILD="paru" ;;
+    *) echo -e "${YELLOW}Not paru or yay, so installing paru.${NC}" ;;
     esac
   else
-    # Under curl-pipe, stdin is the script itself, so reading from it would
-    # consume the installer. Same answer as the prompt's default.
-    echo -e "${YELLOW}No AUR helper found, and nothing here to ask. Installing paru.${NC}"
-    echo -e "${YELLOW}Set HYPRSIMPLE_AUR_HELPER, or install yay first, to use yay instead.${NC}"
+    echo -e "${YELLOW}No AUR helper found. Installing paru.${NC}"
+    echo -e "${YELLOW}Set HYPRSIMPLE_AUR_HELPER=yay, or pass --interactive to be asked.${NC}"
   fi
 
   echo -e "${YELLOW}Installing $AUR_BUILD...${NC}"
-  sudo pacman -Syu
-  sudo pacman -S --needed git base-devel
+  sudo pacman -Syu "${CONFIRM[@]}"
+  sudo pacman -S --needed "${CONFIRM[@]}" git base-devel
   # A build directory left behind by an earlier run holds that run's checkout,
   # and reusing it silently builds whatever it happens to contain. Cloning
   # fresh into a directory of our own costs nothing and cannot be a stale or
@@ -129,10 +225,17 @@ elif ((aur_status != 0)); then
   AUR_BUILD_DIR="$(mktemp -d)"
   git clone --depth 1 "https://aur.archlinux.org/$AUR_BUILD.git" "$AUR_BUILD_DIR/$AUR_BUILD"
   cd "$AUR_BUILD_DIR/$AUR_BUILD"
-  makepkg -si --noconfirm
+  makepkg -si "${CONFIRM[@]}"
   cd "$DOTFILES_DIR"
   rm -rf "$AUR_BUILD_DIR"
   AUR_HELPER="$AUR_BUILD"
+fi
+
+# Per helper, and only when the run is unattended. paru and yay each need
+# more than --noconfirm before they stop waiting for a keypress.
+AUR_CONFIRM=()
+if ((UNATTENDED)); then
+  mapfile -t AUR_CONFIRM < <(aur_unattended_flags "$AUR_HELPER")
 fi
 
 echo -e "${GREEN}Using AUR helper: $AUR_HELPER${NC}"
@@ -516,8 +619,8 @@ install_package_list() {
 # Install official packages
 echo -e "${YELLOW}Installing official packages...${NC}"
 if [ -f "$DOTFILES_DIR/packages.txt" ]; then
-  sudo pacman -Syu
-  install_package_list "$DOTFILES_DIR/packages.txt" sudo pacman -S
+  sudo pacman -Syu "${CONFIRM[@]}"
+  install_package_list "$DOTFILES_DIR/packages.txt" sudo pacman -S "${CONFIRM[@]}"
 else
   echo -e "${RED}packages.txt not found!${NC}"
   exit 1
@@ -526,8 +629,8 @@ fi
 # Install AUR packages
 echo -e "${YELLOW}Installing AUR packages...${NC}"
 if [ -f "$DOTFILES_DIR/aur-packages.txt" ]; then
-  $AUR_HELPER -Syu || true
-  install_package_list "$DOTFILES_DIR/aur-packages.txt" "$AUR_HELPER" -S
+  $AUR_HELPER -Syu "${AUR_CONFIRM[@]}" || true
+  install_package_list "$DOTFILES_DIR/aur-packages.txt" "$AUR_HELPER" -S "${AUR_CONFIRM[@]}"
 else
   echo -e "${YELLOW}aur-packages.txt not found, skipping AUR packages${NC}"
 fi

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,31 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+UNATTENDED=1
+for arg in "$@"; do
+  case "$arg" in
+  --interactive)
+    UNATTENDED=0
+    ;;
+  -h | --help)
+    cat <<'USAGE'
+Usage: ./install.sh [--interactive]
+
+  (no argument)  Install without stopping to confirm. The sudo password is
+                 asked for once, at the start, and held for the whole run.
+  --interactive  Confirm each package operation, the way pacman does when it
+                 is run by hand.
+USAGE
+    exit 0
+    ;;
+  *)
+    echo -e "${RED}Unknown option: $arg${NC}"
+    echo "Run ./install.sh --help for what this takes."
+    exit 1
+    ;;
+  esac
+done
+
 # ======================================
 #  Logging & error reporting
 # ======================================
@@ -89,33 +114,12 @@ fi
 # The unattended path was the fallback and the interactive one was the default.
 #
 # --interactive puts the confirmations back for anyone who wants to read what
-# pacman is about to replace.
-UNATTENDED=1
-for arg in "$@"; do
-  case "$arg" in
-  --interactive)
-    UNATTENDED=0
-    ;;
-  -h | --help)
-    cat <<'USAGE'
-Usage: ./install.sh [--interactive]
-
-  (no argument)  Install without stopping to confirm. The sudo password is
-                 asked for once, at the start, and held for the whole run.
-  --interactive  Confirm each package operation, the way pacman does when it
-                 is run by hand.
-USAGE
-    exit 0
-    ;;
-  *)
-    echo -e "${RED}Unknown option: $arg${NC}"
-    echo "Run ./install.sh --help for what this takes."
-    exit 1
-    ;;
-  esac
-done
-
-# Passed to every package operation. An empty array expands to nothing, so the
+# pacman is about to replace. It is parsed at the top of this file rather than
+# here, because the logging block between the two truncates install.log, and
+# --help is exactly what someone runs while looking at a failed install whose
+# log the failure message told them to attach.
+#
+# Passed to every package operation. An empty array expands to nothing, so an
 # interactive run is the command that was there before this existed.
 CONFIRM=()
 if ((UNATTENDED)); then

--- a/test/aur-helper-test.sh
+++ b/test/aur-helper-test.sh
@@ -165,13 +165,18 @@ chmod +x "$BUILD_STUBS"/*
 # Runs the lifted block with the named helpers present. mktemp, printf and the
 # rest come from /usr/bin, so the stubs go in front of it rather than replacing
 # it, and the helper names are stubbed there too.
+# UNATTENDED is set by install.sh's argument parsing, above the lifted block,
+# so the block cannot see it unless it is passed in. Defaulting it to 1 here
+# matches a plain ./install.sh.
 run_block() {
   local override="$1"; shift
+  local unattended="${RUN_BLOCK_UNATTENDED:-1}"
   local dir; dir="$(stub_path "$@")"
   cp "$BUILD_STUBS"/* "$dir/"
   : >"$TMP/fetch"; : >"$TMP/build"; : >"$TMP/pacman"
   FETCH_LOG="$TMP/fetch" BUILD_LOG="$TMP/build" PACMAN_LOG="$TMP/pacman" \
     DOTFILES_DIR="$REPO" RED='' GREEN='' YELLOW='' NC='' \
+    UNATTENDED="$unattended" \
     HYPRSIMPLE_AUR_HELPER="$override" PATH="$dir" \
     "$BASH_BIN" "$TMP/block.sh" >"$TMP/out" 2>&1 </dev/null
   printf '%s' "$?" >"$TMP/rc"
@@ -240,12 +245,12 @@ if [[ -n $SCRIPT_BIN ]]; then
     printf '%s\n' "$answer" |
       FETCH_LOG="$TMP/fetch" BUILD_LOG="$TMP/build" PACMAN_LOG="$TMP/pacman" \
       DOTFILES_DIR="$REPO" RED='' GREEN='' YELLOW='' NC='' HYPRSIMPLE_AUR_HELPER='' \
-      PATH="$dir" \
+      UNATTENDED=0 PATH="$dir" \
       "$SCRIPT_BIN" -qec "$BASH_BIN $TMP/block.sh" /dev/null >"$TMP/out" 2>&1
   }
 
   run_on_pty yay
-  check "asked at a terminal, an answer of yay builds yay" \
+  check "asked at an interactive terminal, an answer of yay builds yay" \
     "$(grep -c 'aur.archlinux.org/yay' "$TMP/fetch")" "1"
   check "and not paru" "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "0"
 
@@ -261,6 +266,24 @@ if [[ -n $SCRIPT_BIN ]]; then
   check "an answer that is neither falls back to paru rather than stopping" \
     "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "1"
   check "and says it did not understand" "$(grep -c 'Not paru or yay' "$TMP/out")" "1"
+  # The default run does not ask at all, terminal or not. A prompt that only
+  # a plain ./install.sh reaches is exactly the thing being removed here, and
+  # the non-tty checks above cannot see it: they take the same branch for the
+  # wrong reason.
+  RUN_BLOCK_UNATTENDED=1
+  dir="$(stub_path)"
+  cp "$BUILD_STUBS"/* "$dir/"
+  ln -sf "$SCRIPT_BIN" "$dir/script"
+  : >"$TMP/fetch"; : >"$TMP/build"; : >"$TMP/pacman"
+  printf 'yay\n' |
+    FETCH_LOG="$TMP/fetch" BUILD_LOG="$TMP/build" PACMAN_LOG="$TMP/pacman" \
+    DOTFILES_DIR="$REPO" RED='' GREEN='' YELLOW='' NC='' HYPRSIMPLE_AUR_HELPER='' \
+    UNATTENDED=1 PATH="$dir" \
+    "$SCRIPT_BIN" -qec "$BASH_BIN $TMP/block.sh" /dev/null >"$TMP/out" 2>&1
+  check "an unattended run at a terminal does not stop to ask" \
+    "$(grep -c 'Install which one' "$TMP/out")" "0"
+  check "and builds paru, ignoring the answer nobody was asked for" \
+    "$(grep -c 'aur.archlinux.org/paru' "$TMP/fetch")" "1"
 else
   pass "skipped the prompt checks: no script(1) to give the block a terminal"
 fi

--- a/test/unattended-install-test.sh
+++ b/test/unattended-install-test.sh
@@ -84,10 +84,19 @@ fi
 # argument parsing is lifted out of the shipped file, so what runs below is
 # what ships.
 
-sed -n '/^UNATTENDED=1$/,/^fi$/p' "$INSTALL" >"$TMP/args.sh"
+# Two pieces, because they sit apart in the file: the parsing is above the
+# logging block, which truncates install.log, so --help cannot destroy the log
+# of the failed install someone is looking at.
+{
+  sed -n '/^UNATTENDED=1$/,/^done$/p' "$INSTALL"
+  sed -n '/^CONFIRM=()$/,/^fi$/p' "$INSTALL"
+} >"$TMP/args.sh"
 check "the argument parsing was lifted out of install.sh" \
   "$(grep -c -- '--interactive)' "$TMP/args.sh")" "1"
 check "and it carries the flag array it sets" "$(grep -c 'CONFIRM=(--noconfirm)' "$TMP/args.sh")" "1"
+check "and the parsing really does come before the log is truncated" \
+  "$([[ $(grep -n '^UNATTENDED=1$' "$INSTALL" | cut -d: -f1) -lt $(grep -n '^: >"\$INSTALL_LOG"$' "$INSTALL" | cut -d: -f1) ]] && echo before || echo after)" \
+  "before"
 
 cat >>"$TMP/args.sh" <<'TAILEOF'
 printf 'unattended=%s flags=%s\n' "$UNATTENDED" "${CONFIRM[*]}"

--- a/test/unattended-install-test.sh
+++ b/test/unattended-install-test.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# Installing without standing over the machine.
+#
+# The install stopped and waited a dozen times: the sudo password, twice for a
+# full upgrade, once for the official package list, and once per package for
+# the AUR list, each of them minutes apart. It was never a decision. Five
+# package operations in install.sh already passed --noconfirm, including the
+# retry inside install_packages, and four did not, so the fallback path was
+# unattended and the default one was not.
+#
+# The rule rather than the four instances: every package operation in
+# install.sh confirms nothing unless --interactive was asked for. A pacman call
+# added later without it is caught here rather than by someone waiting on it.
+#
+# Nothing here installs a package or calls sudo for real. sudo, pacman, git and
+# makepkg are stubs, and the PATH each case builds does not reach /usr/bin.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$REPO/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+BASH_BIN="$(command -v bash)"
+
+# ---- every package operation confirms nothing -------------------------------
+#
+# Read out of the file rather than listed here. Whole-line comments are
+# stripped, because this suite and install.sh both quote the old commands in
+# theirs.
+
+mapfile -t package_ops < <(
+  sed 's/^[[:space:]]*#.*//' "$INSTALL" |
+    grep -nE '(sudo pacman -S|sudo pacman -Syu|AUR_HELPER"? -S|makepkg -si|install_package_list )' |
+    grep -vE 'pacman -Qq|pacman -Si|pacman-conf|^[0-9]+:install_package_list\(\)'
+)
+
+if ((${#package_ops[@]} < 8)); then
+  fail "found ${#package_ops[@]} package operations in install.sh, which is fewer than there are"
+else
+  pass "found ${#package_ops[@]} package operations in install.sh"
+fi
+
+# Each has to carry one of the three: the literal flag, or one of the arrays
+# that holds it. The arrays are how an --interactive run puts the questions
+# back, so they count as confirming nothing by default.
+unconfirmed=()
+for op in "${package_ops[@]}"; do
+  [[ $op == *'--noconfirm'* ]] && continue
+  [[ $op == *'${CONFIRM[@]}'* ]] && continue
+  [[ $op == *'${AUR_CONFIRM[@]}'* ]] && continue
+  unconfirmed+=("${op%%:*}")
+done
+unconfirmed_str=""
+((${#unconfirmed[@]} > 0)) && unconfirmed_str="$(printf '%s ' "${unconfirmed[@]}")"
+check "no package operation stops to confirm, by line number" "$unconfirmed_str" ""
+
+# Anti-vacuity. The check above passes for a file with no package operations at
+# all, and would keep passing for a grep that had quietly stopped matching. A
+# floor rather than the exact count, which says nothing about confirmations and
+# would fail the day a package operation is added or removed.
+pacman_ops="$(printf '%s\n' "${package_ops[@]}" | grep -c 'pacman')"
+if ((pacman_ops < 6)); then
+  fail "only $pacman_ops of them invoke pacman, so this is not reading install.sh"
+else
+  pass "$pacman_ops of them invoke pacman"
+fi
+
+# ---- --interactive puts them back -------------------------------------------
+#
+# install.sh cannot be sourced: it installs packages at the top level. The
+# argument parsing is lifted out of the shipped file, so what runs below is
+# what ships.
+
+sed -n '/^UNATTENDED=1$/,/^fi$/p' "$INSTALL" >"$TMP/args.sh"
+check "the argument parsing was lifted out of install.sh" \
+  "$(grep -c -- '--interactive)' "$TMP/args.sh")" "1"
+check "and it carries the flag array it sets" "$(grep -c 'CONFIRM=(--noconfirm)' "$TMP/args.sh")" "1"
+
+cat >>"$TMP/args.sh" <<'TAILEOF'
+printf 'unattended=%s flags=%s\n' "$UNATTENDED" "${CONFIRM[*]}"
+TAILEOF
+
+parse() {
+  RED='' YELLOW='' NC='' "$BASH_BIN" "$TMP/args.sh" "$@" >"$TMP/out" 2>&1
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+parse
+check "a plain install is unattended" "$(grep -c 'unattended=1 flags=--noconfirm' "$TMP/out")" "1"
+check "and says so, so it is not a surprise" \
+  "$(grep -c 'Installing without confirmations' "$TMP/out")" "1"
+check "and exits 0" "$(cat "$TMP/rc")" "0"
+
+parse --interactive
+check "--interactive confirms every operation" "$(grep -c 'unattended=0 flags=$' "$TMP/out")" "1"
+check "and does not announce an unattended run" \
+  "$(grep -c 'Installing without confirmations' "$TMP/out")" "0"
+
+parse --help
+check "--help explains both" "$(grep -c 'interactive' "$TMP/out")" "2"
+check "and exits 0" "$(cat "$TMP/rc")" "0"
+
+parse --unattended
+check "an option that does not exist stops rather than being ignored" \
+  "$(cat "$TMP/rc")" "1"
+check "and names it" "$(grep -c 'Unknown option: --unattended' "$TMP/out")" "1"
+
+# ---- the password, once -----------------------------------------------------
+
+sed -n '/^SUDO_KEEPALIVE_PID=""$/,/^SUDO_KEEPALIVE_PID=\$!$/p' "$INSTALL" >"$TMP/sudo.sh"
+check "the sudo block was lifted out of install.sh" \
+  "$(grep -c 'if ! sudo -v; then' "$TMP/sudo.sh")" "1"
+check "and it ends with the keep-alive it starts" \
+  "$(grep -c 'SUDO_KEEPALIVE_PID=\$!' "$TMP/sudo.sh")" "1"
+
+cat >>"$TMP/sudo.sh" <<'TAILEOF'
+printf '%s' "$SUDO_KEEPALIVE_PID" >"$KEEPALIVE_PID"
+TAILEOF
+
+# A sudo that logs how it was called. The mode file decides whether the
+# cached-credential probe succeeds, whether the prompt succeeds, or neither.
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+cat >"$STUB/sudo" <<'SUDOEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SUDO_LOG"
+mode="$(cat "$SUDO_MODE")"
+case "$1" in
+-n) [[ $mode == cached ]] ;;
+-v) [[ $mode != refuses ]] ;;
+*) true ;;
+esac
+SUDOEOF
+chmod +x "$STUB/sudo"
+for tool in sleep kill cat; do
+  [[ -e /usr/bin/$tool ]] && ln -sf "/usr/bin/$tool" "$STUB/$tool"
+done
+
+run_sudo_block() {
+  printf '%s' "$1" >"$TMP/mode"
+  : >"$TMP/sudocalls"
+  : >"$TMP/keepalive"
+  SUDO_LOG="$TMP/sudocalls" SUDO_MODE="$TMP/mode" KEEPALIVE_PID="$TMP/keepalive" \
+    RED='' YELLOW='' NC='' PATH="$STUB" \
+    "$BASH_BIN" "$TMP/sudo.sh" >"$TMP/out" 2>&1 </dev/null
+  printf '%s' "$?" >"$TMP/rc"
+}
+
+run_sudo_block cached
+check "a cached credential is reused without a prompt" \
+  "$(grep -c -- '-v' "$TMP/sudocalls")" "0"
+check "and the probe that decided it does not prompt either" \
+  "$(grep -c -- '-n true' "$TMP/sudocalls")" "1"
+check "and nothing is said about a password" \
+  "$(grep -c 'asked once' "$TMP/out")" "0"
+
+run_sudo_block prompts
+check "with no cached credential it asks, once" \
+  "$(grep -c -- '-v' "$TMP/sudocalls")" "1"
+check "and says the asking is over" "$(grep -c 'asked once, now' "$TMP/out")" "1"
+check "and carries on" "$(cat "$TMP/rc")" "0"
+
+run_sudo_block refuses
+check "a machine that cannot authenticate stops" \
+  "$([[ $(cat "$TMP/rc") != "0" ]] && echo stopped || echo continued)" "stopped"
+check "before installing anything" "$(grep -c 'nothing was installed' "$TMP/out")" "1"
+
+# The keep-alive must not outlive the install. A refresher left running is a
+# machine that stays sudo-authorised after the script that needed it is gone.
+run_sudo_block cached
+keepalive="$(cat "$TMP/keepalive")"
+if [[ ! $keepalive =~ ^[0-9]+$ ]]; then
+  fail "the keep-alive recorded no pid, so this check is testing nothing"
+else
+  pass "the keep-alive recorded its pid, $keepalive"
+  # The pid is the recorded one, never a pattern: pkill -f matches the shell
+  # running this suite as readily as the loop it is aimed at.
+  check "and it is gone once the script that started it has exited" \
+    "$(kill -0 "$keepalive" 2>/dev/null && echo running || echo gone)" "gone"
+fi
+
+check "the trap that kills it is on EXIT, so it runs on failure too" \
+  "$(sed 's/^[[:space:]]*#.*//' "$INSTALL" | grep -c 'trap stop_sudo_keepalive EXIT')" "1"
+check "and it kills a recorded pid rather than matching a pattern" \
+  "$(sed 's/^[[:space:]]*#.*//' "$INSTALL" | grep -c 'pkill')" "0"
+
+# ---- the AUR helper is told to stop asking too -------------------------------
+#
+# --noconfirm alone is not enough. paru opens each PKGBUILD for review and yay
+# asks about diffs and edits, and both wait for a keypress.
+
+# shellcheck source=/dev/null
+source "$REPO/.local/bin/hyprsimple-aur-helper.sh"
+check "paru is told to skip the review" \
+  "$(aur_unattended_flags paru | grep -c -- '--skipreview')" "1"
+check "and yay to answer its own questions" \
+  "$(aur_unattended_flags yay | grep -c -- '--answerdiff=None')" "1"
+check "and both are told not to confirm" \
+  "$( { aur_unattended_flags paru; aur_unattended_flags yay; } | grep -c -- '--noconfirm')" "2"
+check "and a helper this project does not know still gets the one flag it can" \
+  "$(aur_unattended_flags something-else)" "--noconfirm"
+
+# One flag per line. Building a string and splitting on spaces breaks the first
+# time a flag needs one.
+check "the flags come back one per line, for mapfile" \
+  "$(aur_unattended_flags yay | wc -l | tr -d ' ')" "4"
+
+# ---- what is still asked, and only at the end -------------------------------
+#
+# The logout prompt is the last line of the installer, after everything is
+# installed, so leaving it there does not make anyone wait on the install. It
+# is checked here so that it stays the only one.
+mapfile -t prompts < <(sed 's/^[[:space:]]*#.*//' "$INSTALL" | grep -n 'read -rp')
+check "install.sh has three prompts left, and no more" "${#prompts[@]}" "3"
+check "the closing logout, which is the last line and blocks nothing" \
+  "$(printf '%s\n' "${prompts[@]}" | grep -c 'Logout to take effect')" "1"
+check "the AUR choice, which an unattended run never reaches" \
+  "$(printf '%s\n' "${prompts[@]}" | grep -c 'Install which one')" "1"
+check "and the uncommitted-changes one, which only a checkout being worked on hits" \
+  "$(printf '%s\n' "${prompts[@]}" | grep -c 'Continue and install HEAD')" "1"
+
+# ---- documented -------------------------------------------------------------
+
+# A floor on each. Pinning the exact count would fail whenever a paragraph is
+# rewrapped, which says nothing about whether the flag is documented.
+for doc in README.md FAQ.md; do
+  mentions="$(grep -c -- '--interactive' "$REPO/$doc")"
+  if ((mentions < 1)); then
+    fail "$doc does not mention --interactive, so the flag is undocumented"
+  else
+    pass "$doc documents --interactive"
+  fi
+done
+check "and the README says the password is asked for once" \
+  "$(grep -c 'sudo password once' "$REPO/README.md")" "1"
+check "and the FAQ says what an unattended upgrade gives up" \
+  "$(grep -c 'including which packages to replace' "$REPO/FAQ.md")" "1"
+
+if ((failures > 0)); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Re-opening #146, which never reached `main`.

#146 was stacked on #145 and had its base set to `use-the-aur-helper-already-installed`. #145 merged into `main` first, and #146 then merged into that now-stale branch. GitHub marks it MERGED, and none of its commits are on `main`: `git show origin/main:install.sh | grep -c UNATTENDED` returns 0.

Same work, rebased onto `main`. The one conflict was in `FAQ.md`, where #147 had added its entry in the same place. Both entries are kept.

## What was wrong

The install stopped and waited a dozen times, minutes apart, so installing hyprsimple meant sitting in front of the machine for the length of it:

- the **sudo password**, and then again partway through. sudo forgets after 15 minutes without a call, and a `pacman -Syu` or an AUR build takes longer than that. Nothing primed or held it.
- **four package operations** that asked `Proceed? [Y/n]`, while five others in the same file already passed `--noconfirm`. The retry inside `install_packages` was one of the five, so the fallback path was unattended and the default one was not.
- the **AUR list**, once per package, plus paru's PKGBUILD review.

## What it does now

`./install.sh` confirms nothing. The password is asked for once, at the start, and refreshed until the script ends.

- `--interactive` puts every question back, including the two `pacman -Syu` upgrades.
- `--help` says so. An unknown option stops rather than being ignored.
- paru and yay get the flags that actually silence them. `--noconfirm` alone leaves paru opening each PKGBUILD and yay asking about diffs and edits, both of which wait for a keypress.
- A machine that cannot authenticate fails at the start, not several minutes in.
- The keep-alive dies with the script, through an EXIT trap plus a `kill -0` backstop in the loop. It kills a recorded pid, never a `pkill -f` pattern, which matches the shell running the installer as readily as the loop it is aimed at.

Three prompts are left, and none makes you wait on the install: the closing logout is the last line, the AUR choice is only reached when you have neither helper (unattended takes paru), and the uncommitted-changes one only fires in a checkout being worked on.

`--help` is parsed above the logging block, because that block truncates `install.log`, which is the file the failure message tells you to attach.

## The trade

An unattended `pacman -Syu` answers pacman's questions for you, including which packages to replace, and skips the Arch news. That is written down in the FAQ with the advice to use `--interactive` on a machine that has not been updated in a long time.

## Tests

`test/unattended-install-test.sh`, 34 checks, registered in the workflow. Nothing installs a package or calls sudo for real.

The central one is a rule rather than a list: every package operation in `install.sh` is read out of the file and has to carry `--noconfirm` or one of the two flag arrays, so a pacman call added later without it is caught here rather than by someone waiting on it. The argument parsing and the sudo block are lifted out of the shipped file and run.

Five sabotages, each caught:

| sabotage | checks that failed |
| --- | --- |
| a package operation goes back to confirming | 1 |
| the keep-alive outlives the install | 2 |
| a machine that cannot authenticate carries on | 3 |
| paru goes back to opening every PKGBUILD | 1 |
| `--interactive` stops working | 2 |

The keep-alive one found the process still running after the script had exited, rather than only reading the trap out of the source.

All 71 suites and shellcheck pass locally on the rebased branch.