### PR TITLE
Bring the README up to what the last four fixes changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,18 @@ Older installs have a copy of the templates at `~/.config/hypr/themes/templates`
 
 ## Network
 
-To see the available network interfaces, run `wifi`. To connect to a network, run `wifi <network name>` for example `wifi "MY NETWORK"`
+`wifi` on its own rescans and lists the networks in range. `wifi "MY NETWORK"`
+connects to one: an open network, or one you have joined before, connects
+straight away, and a secured one asks for the password.
+
+From a keybind or a script there is nobody to ask, so pass it instead:
+
+```bash
+wifi "MY NETWORK" "my password"
+```
+
+`wifi --help` lists both forms. It uses NetworkManager if it is running, and
+iwd otherwise.
 
 ## Keybindings
 
@@ -244,6 +255,11 @@ Press **`SUPER + /`** for interactive viewer with fuzzy search.
 The menu offers a region or the whole screen, each with microphone audio,
 system audio, or none. While something is recording it offers to stop instead,
 so the same key both starts and stops.
+
+Recording uses `wl-screenrec` where it can and `wf-recorder` otherwise, and
+NVIDIA machines prefer `wf-recorder`. Only `wf-recorder` is required: it comes
+from the official repositories, so recording still works if the `wl-screenrec`
+build fails during install.
 
 ### Media & Brightness
 
@@ -316,7 +332,7 @@ Most are wired to keybindings or waybar; all can also be run directly from a ter
 
 | Script | Description |
 |--------|-------------|
-| `wifi.sh` | List and connect to WiFi networks |
+| `wifi.sh` | List and connect to WiFi networks, asking for the password when one is needed |
 | `wifi-powersave.sh` | Toggle WiFi power saving (`on` / `off`) |
 | `hotspot.sh` | Create a WiFi hotspot with internet sharing |
 | `setup-dns.sh` | Configure the DNS provider (Cloudflare / Google / DHCP) |


### PR DESCRIPTION
Documentation only. No code changes.

I went through the README against #145, #147, #148 and #150. The install section and the script table were already updated by the changes that needed them, and `readme-keybindings-test.sh` had kept the keybinding tables and the script list honest on its own. Two things were left.

## The Network section was misleading

```
To see the available network interfaces, run `wifi`. To connect to a network, run `wifi <network name>` for example `wifi "MY NETWORK"`
```

No mention of a password anywhere, which was accurate only because joining a secured network did not work at all before #147. Now it asks, so the section says what actually happens, gives the two-argument form for a keybind or a script, and points at `wifi --help`.

## The recording section did not say what is required

`wl-screenrec` is the one package hyprsimple builds from source, and #150 made recording fall back to `wf-recorder` when it is missing. Someone whose `wl-screenrec-git` build failed should not have to guess whether recording still works. Three lines saying which recorder is used, that NVIDIA prefers `wf-recorder`, and that only `wf-recorder` is required.

Also widened the `wifi.sh` row in the script table to mention the password.

All 71 suites pass.