### PR TITLE
Switch audio to a bluetooth device when one connects

### DIFF
--- a/.config/systemd/user/hyprsimple-audio-autoswitch.service
+++ b/.config/systemd/user/hyprsimple-audio-autoswitch.service
@@ -1,0 +1,26 @@
+# This file is yours: hyprsimple copies it once and never touches it again.
+# Run `systemctl --user daemon-reload` after editing.
+#
+# Turn the whole thing off with
+#   systemctl --user disable --now hyprsimple-audio-autoswitch.service
+
+[Unit]
+Description=Switch audio output to a bluetooth device when one connects
+After=graphical-session.target
+# Stops with the session, the same rule battery-monitor.service follows. A
+# watcher outliving the compositor would send notifications into a bus with no
+# display.
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/hyprsimple-audio-autoswitch.sh
+# `pactl subscribe` ends when pipewire-pulse restarts, which happens on its own
+# and is not a failure. Restarting is how this survives that.
+Restart=always
+RestartSec=2
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+
+[Install]
+WantedBy=graphical-session.target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,6 +163,9 @@ jobs:
       - name: unattended-install-test
         run: bash test/unattended-install-test.sh
 
+      - name: audio-autoswitch-test
+        run: bash test/audio-autoswitch-test.sh
+
       - name: notification-idiom-test
         run: bash test/notification-idiom-test.sh
 

--- a/.local/bin/hyprsimple-audio-autoswitch.sh
+++ b/.local/bin/hyprsimple-audio-autoswitch.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Move audio to a Bluetooth output when one connects.
+#
+# WirePlumber chooses the default sink by priority, and a bluetooth sink
+# outranks the built-in one on its own: measured on this project's own hardware,
+# priority.session 1010 against 1009. So on a fresh install a headset takes over
+# by itself and there is nothing to do.
+#
+# What stops that is an explicitly chosen default. find-selected-default-node.lua
+# in WirePlumber 0.5 does
+#
+#   if current_configured_node == name then
+#     priority = 30000 + priority
+#
+# to whatever default.configured.audio.sink names, so the chosen sink scores
+# 31009 and no bluetooth device can ever outrank it. audio-switch.sh, on
+# SUPER + F10, writes that key through `pactl set-default-sink`. Pressing the
+# audio switch once therefore turned bluetooth auto-switching off for good, on
+# every machine, and nothing said so. Reported as a headset that connects and
+# then gets no sound.
+#
+# Only on appearance. A device already connected when this starts is left where
+# it is, and a switch away from it by hand is not undone, because either would
+# be this script arguing with the person using it.
+
+set -uo pipefail
+
+# Overridable so the suite can point them at stubs without a PATH that could
+# reach the real ones.
+PACTL="${HYPRSIMPLE_PACTL:-pactl}"
+
+bluez_sinks() {
+  # Names only, one per line. `list short` rather than the json form: this runs
+  # on every sink event, and it needs no jq.
+  "$PACTL" list short sinks 2>/dev/null | cut -f2 | grep '^bluez_output\.' || true
+}
+
+describe() {
+  local name="$1" description
+  description=$("$PACTL" list sinks 2>/dev/null |
+    awk -v n="$name" '$1 == "Name:" && $2 == n { found = 1 }
+                      found && $1 == "Description:" { $1 = ""; sub(/^ /, ""); print; exit }')
+  printf '%s' "${description:-$name}"
+}
+
+switch_to() {
+  local name="$1"
+  # Checked, not assumed. The sink list this came from is a moment old, and a
+  # headset that drops in between leaves the sound where it was while a
+  # notification claims it moved. audio-switch.sh had that exact bug once.
+  if "$PACTL" set-default-sink "$name" 2>/dev/null; then
+    notify-send "Audio Output" "Switched to: $(describe "$name")" -t 2000
+  fi
+}
+
+# What was already connected when this started, so the first event does not
+# read every existing device as new.
+known=" $(bluez_sinks | tr '\n' ' ')"
+
+# `pactl subscribe` prints a line per event and never exits on its own. The
+# unit restarts it, which is what covers pipewire-pulse itself restarting.
+"$PACTL" subscribe 2>/dev/null | while read -r event; do
+  case "$event" in
+  *"on sink"*) ;;
+  *) continue ;;
+  esac
+
+  now=" $(bluez_sinks | tr '\n' ' ')"
+  for sink in $now; do
+    case "$known" in
+    *" $sink "*) continue ;;
+    esac
+    switch_to "$sink"
+  done
+  known="$now"
+done

--- a/FAQ.md
+++ b/FAQ.md
@@ -98,6 +98,43 @@ paru -S wl-screenrec-git   # or yay -S
 >
 > No package owns that symlink, so delete it once `rust` is rebuilt. Taking Arch's own build with `sudo pacman -S extra/rust` fixes it with no workaround to remember, at the cost of the CachyOS optimisations.
 
+## My bluetooth headset is connected but the sound still comes out of the speakers
+
+Fixed, and worth knowing why, because it is hyprsimple's own doing and it sticks.
+
+WirePlumber chooses the default output by priority, and a bluetooth sink already outranks the built-in one. On the machine this was reported from, `priority.session` reads 1010 for the headset and 1009 for the speakers, so a headset takes over by itself on a fresh install.
+
+What stops it is an explicitly chosen output. WirePlumber's `find-selected-default-node.lua` does
+
+```lua
+if current_configured_node == name then
+  priority = 30000 + priority
+```
+
+to whatever `default.configured.audio.sink` names, so the chosen output scores 31009 and no bluetooth device can outrank it. `SUPER + F10` writes that key through `pactl set-default-sink`. Pressing the audio switch once therefore turned bluetooth auto-switching off permanently, on every machine, and nothing said so.
+
+A user service now watches for a bluetooth output appearing and switches to it. Only on appearance, so a device already connected is left where it is, and switching away from it by hand is not undone.
+
+If you are on an install that predates the fix, run `hyprsimple-update` and the migration enables it. To switch by hand in the meantime, press `SUPER + F10`, or:
+
+```bash
+wpctl set-default "$(pactl list short sinks | grep bluez_output | cut -f1 | head -1)"
+```
+
+To see what is pinned:
+
+```bash
+cat ~/.local/state/wireplumber/default-nodes
+```
+
+The `default.configured.audio.sink.0`, `.1` and so on below it are the previous choices, kept as a fallback chain for when the current one is gone.
+
+To turn the auto-switching off:
+
+```bash
+systemctl --user disable --now hyprsimple-audio-autoswitch.service
+```
+
 ## A migration failed. What now?
 
 Migrations run once per machine, tracked in `~/.local/state/hyprsimple/migrations`. When one fails you are asked whether to skip it. Skipping records it under `.../migrations/skipped/` and continues.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ To change one, copy it to `~/.config/hypr/themes/templates.user/` under the same
 
 Older installs have a copy of the templates at `~/.config/hypr/themes/templates`. That directory is no longer read, and an update removes it once every file in it is one hyprsimple shipped. If you had edited one, the whole directory is left alone and you are told which file it was, so you can move it to `templates.user/`.
 
+## Audio
+
+Connecting a bluetooth headset or speaker moves the sound to it. Switching by
+hand with `SUPER + F10` still wins while that device stays connected, and the
+next one to connect takes over again. Turn it off with
+
+```bash
+systemctl --user disable --now hyprsimple-audio-autoswitch.service
+```
+
 ## Network
 
 `wifi` on its own rescans and lists the networks in range. `wifi "MY NETWORK"`
@@ -332,6 +342,7 @@ Most are wired to keybindings or waybar; all can also be run directly from a ter
 
 | Script | Description |
 |--------|-------------|
+| `hyprsimple-audio-autoswitch.sh` | Move the sound to a bluetooth device when one connects, run as a user service |
 | `wifi.sh` | List and connect to WiFi networks, asking for the password when one is needed |
 | `wifi-powersave.sh` | Toggle WiFi power saving (`on` / `off`) |
 | `hotspot.sh` | Create a WiFi hotspot with internet sharing |

--- a/install.sh
+++ b/install.sh
@@ -984,6 +984,17 @@ if [ -f "$HOME/.config/systemd/user/battery-monitor.timer" ]; then
   echo -e "${GREEN}Battery monitor enabled${NC}"
 fi
 
+# Bluetooth audio auto-switching.
+#
+# enable, not enable --now, for the reason above: the unit is wanted by
+# graphical-session.target, which is not up while the installer runs.
+if [ -f "$HOME/.config/systemd/user/hyprsimple-audio-autoswitch.service" ]; then
+  echo -e "${YELLOW}Enabling bluetooth audio auto-switching...${NC}"
+  systemctl --user daemon-reload
+  systemctl --user enable hyprsimple-audio-autoswitch.service
+  echo -e "${GREEN}Bluetooth audio auto-switching enabled${NC}"
+fi
+
 # hyprsunset, through the unit its own package ships rather than a bare uwsm
 # scope. autostart.lua used to run `uwsm app -- hyprsunset`, which has no
 # restart policy at all, and hyprsunset does not survive a suspend: measured on

--- a/migrations/1788970000.sh
+++ b/migrations/1788970000.sh
@@ -1,0 +1,51 @@
+echo "Switch audio to a bluetooth device when one connects"
+
+# WirePlumber picks the default sink by priority and a bluetooth sink already
+# outranks the built-in one: 1010 against 1009, measured on the machine this was
+# reported from. So on a fresh install a headset takes over by itself.
+#
+# What stops that is an explicitly chosen default. find-selected-default-node.lua
+# in WirePlumber 0.5 adds 30000 to whatever default.configured.audio.sink names,
+# so the chosen sink scores 31009 and no bluetooth device can outrank it.
+# audio-switch.sh, on SUPER + F10, writes that key through
+# `pactl set-default-sink`. Pressing the audio switch once therefore turned
+# bluetooth auto-switching off for good, and nothing said so. Reported as a
+# headset that connects, appears as a sink, and gets no sound.
+#
+# A watcher now sets a bluetooth sink as the default when one appears. Only on
+# appearance, so a device already connected is left where it is and a switch
+# away from it by hand is not undone.
+
+UNIT_DIR="$HOME/.config/systemd/user"
+UNIT="$UNIT_DIR/hyprsimple-audio-autoswitch.service"
+SHIPPED="$HYPRSIMPLE_PATH/.config/systemd/user/hyprsimple-audio-autoswitch.service"
+
+if [[ ! -f $SHIPPED ]]; then
+  echo "  The unit is not in this install, so there is nothing to enable."
+  exit 0
+fi
+
+# A file already there is either a previous run of this migration or someone's
+# own, and neither is ours to overwrite. The unit is copied rather than
+# symlinked because everything under ~/.config/systemd/user is yours to edit,
+# which is what its header says.
+if [[ -e $UNIT ]]; then
+  echo "  You already have $UNIT, so it was left alone."
+else
+  mkdir -p "$UNIT_DIR"
+  cp "$SHIPPED" "$UNIT"
+fi
+
+systemctl --user daemon-reload 2>/dev/null || true
+systemctl --user enable hyprsimple-audio-autoswitch.service &>/dev/null || true
+
+# Started now only when a session is up. Run from a TTY there is nothing to
+# watch and no bus to notify on.
+if systemctl --user is-active graphical-session.target &>/dev/null; then
+  systemctl --user start hyprsimple-audio-autoswitch.service &>/dev/null || true
+  echo "  A bluetooth headset now takes over the sound when it connects."
+else
+  echo "  Enabled it. Your next login starts it."
+fi
+
+echo "  Turn it off with: systemctl --user disable --now hyprsimple-audio-autoswitch.service"

--- a/test/audio-autoswitch-test.sh
+++ b/test/audio-autoswitch-test.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+# Audio moving to a bluetooth device when one connects.
+#
+# WirePlumber picks the default sink by priority and a bluetooth sink already
+# outranks the built-in: 1010 against 1009, read off the machine this was
+# reported from. What stops it taking over is an explicitly chosen default.
+# find-selected-default-node.lua in WirePlumber 0.5 does
+#
+#   if current_configured_node == name then
+#     priority = 30000 + priority
+#
+# so the chosen sink scores 31009 and no bluetooth device can outrank it.
+# audio-switch.sh writes that key through `pactl set-default-sink`, so pressing
+# SUPER + F10 once turned bluetooth auto-switching off for good.
+#
+# Nothing here touches the real audio. pactl and notify-send are stubs, the
+# script is pointed at the stub through HYPRSIMPLE_PACTL rather than by PATH
+# alone, and the PATH each run gets holds only the stubs plus the few real
+# tools the script runs, linked in by name. /usr/bin is never on it: a probe
+# that left it there is how a real command got run on the maintainer's own
+# machine once.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCHER="$REPO/.local/bin/hyprsimple-audio-autoswitch.sh"
+UNIT="$REPO/.config/systemd/user/hyprsimple-audio-autoswitch.service"
+MIGRATION="$REPO/migrations/1788970000.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP:?}"' EXIT
+
+failures=0
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+check() {
+  if [[ $2 == "$3" ]]; then pass "$1"
+  else printf 'not ok - %s (want %s, got %s)\n' "$1" "$3" "$2" >&2; failures=$((failures + 1)); fi
+}
+for helper in pass fail check; do
+  declare -F "$helper" >/dev/null || { printf 'not ok - helper %s missing\n' "$helper" >&2; exit 1; }
+done
+
+BASH_BIN="$(command -v bash)"
+
+# The real tools the watcher runs, read out of it rather than listed from
+# memory. One missing from the list looks exactly like a bug in the watcher.
+mapfile -t needed < <(
+  sed 's/^[[:space:]]*#.*//' "$WATCHER" |
+    grep -oE '\b(cut|grep|tr|awk|sed|tail|cat)\b' | sort -u
+)
+if ((${#needed[@]} < 4)); then
+  fail "read ${#needed[@]} real tools out of the watcher, which is fewer than it runs"
+else
+  pass "linking ${#needed[@]} real tools into the restricted PATH"
+fi
+
+STUB="$TMP/bin"
+mkdir -p "$STUB"
+for tool in "${needed[@]}"; do ln -sf "$(command -v "$tool")" "$STUB/$tool"; done
+# The stubs below are shell scripts of their own and run a few tools the
+# watcher does not. Linked separately, so the list read out of the watcher
+# stays a statement about the watcher.
+for tool in cat sed tail cmp; do
+  [[ -e $STUB/$tool ]] || ln -sf "$(command -v "$tool")" "$STUB/$tool"
+done
+
+# A pactl that answers from files and acts on nothing.
+#
+# `list short sinks` walks a scripted timeline one step per call. The watcher
+# reads the sink list once at startup and once per sink event, and those calls
+# are sequential, so a counter is deterministic where a clock or a shared file
+# written by the event stream would race.
+cat >"$STUB/pactl" <<'PACTLEOF'
+#!/bin/bash
+case "$1" in
+subscribe)
+  cat "$EVENTS_FILE"
+  ;;
+set-default-sink)
+  printf '%s\n' "$2" >>"$SWITCH_LOG"
+  exit "${SET_DEFAULT_RC:-0}"
+  ;;
+list)
+  if [[ $2 == short && $3 == sinks ]]; then
+    step=$(cat "$STEP_FILE")
+    step=$((step + 1))
+    printf '%s' "$step" >"$STEP_FILE"
+    line=$(sed -n "${step}p" "$STEPS_FILE")
+    [[ -z $line ]] && line=$(tail -1 "$STEPS_FILE")
+    [[ $line == "-" ]] && exit 0
+    i=0
+    for s in $line; do
+      i=$((i + 1))
+      printf '%s\t%s\tmodule\ts16le\tRUNNING\n' "$i" "$s"
+    done
+  elif [[ $2 == sinks ]]; then
+    cat "$DESC_FILE"
+  fi
+  ;;
+esac
+PACTLEOF
+cat >"$STUB/notify-send" <<'NOTIFYEOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+NOTIFYEOF
+chmod +x "$STUB/pactl" "$STUB/notify-send"
+
+BUILTIN="alsa_output.pci-0000_00_1f.3.analog-stereo"
+HEADSET="bluez_output.DC_50_85_59_6F_C0.1"
+OTHER_BT="bluez_output.AA_BB_CC_DD_EE_FF.1"
+
+cat >"$TMP/desc" <<DESCEOF
+Sink #59
+	Name: $BUILTIN
+	Description: Built-in Audio Analog Stereo
+Sink #68
+	Name: $HEADSET
+	Description: Monster Airstar M500
+Sink #70
+	Name: $OTHER_BT
+	Description: Someone Elses Speaker
+DESCEOF
+
+# steps: one line per `list short sinks` call, the first being startup.
+# events: one line per line pactl subscribe emits.
+run_watcher() {
+  local steps="$1" events="$2"
+  printf '%s\n' "$steps" >"$TMP/steps"
+  printf '%s\n' "$events" >"$TMP/events"
+  printf '0' >"$TMP/step"
+  : >"$TMP/switches"
+  : >"$TMP/notifications"
+  STEPS_FILE="$TMP/steps" EVENTS_FILE="$TMP/events" STEP_FILE="$TMP/step" \
+    DESC_FILE="$TMP/desc" SWITCH_LOG="$TMP/switches" NOTIFY_LOG="$TMP/notifications" \
+    SET_DEFAULT_RC="${SET_DEFAULT_RC:-0}" \
+    HYPRSIMPLE_PACTL="$STUB/pactl" PATH="$STUB" \
+    "$BASH_BIN" "$WATCHER" >/dev/null 2>&1
+}
+switches() { cat "$TMP/switches"; }
+notifications() { cat "$TMP/notifications"; }
+
+SINK_EVENT="Event 'new' on sink #68"
+
+# ---- anti-vacuity, before anything rests on the stubs ----------------------
+#
+# Every check below is about which sink the watcher chooses. A PATH that could
+# reach the real pactl would be choosing sinks on this machine instead.
+check "the real pactl is unreachable from the restricted PATH" \
+  "$(PATH="$STUB" command -v pactl)" "$STUB/pactl"
+check "and the watcher is pointed at the stub explicitly as well" \
+  "$(grep -c 'HYPRSIMPLE_PACTL' "$WATCHER")" "1"
+
+# ---- a headset connecting ---------------------------------------------------
+
+run_watcher "$BUILTIN
+$BUILTIN $HEADSET" "$SINK_EVENT"
+check "a bluetooth sink appearing becomes the default" "$(switches)" "$HEADSET"
+check "and it is announced by description, not by node name" \
+  "$(notifications | grep -c 'Switched to: Monster Airstar M500')" "1"
+
+# ---- what must not happen ---------------------------------------------------
+
+run_watcher "$BUILTIN $HEADSET
+$BUILTIN $HEADSET" "$SINK_EVENT"
+check "a headset already connected at startup is left alone" "$(switches)" ""
+check "and nothing is announced" "$(notifications)" ""
+
+run_watcher "$BUILTIN
+$BUILTIN $HEADSET
+$BUILTIN $HEADSET" "$SINK_EVENT
+$SINK_EVENT"
+check "a sink already switched to is not switched to twice" "$(switches)" "$HEADSET"
+
+run_watcher "$BUILTIN
+$BUILTIN $HEADSET
+$BUILTIN" "$SINK_EVENT
+$SINK_EVENT"
+check "and a headset going away switches nothing" "$(switches)" "$HEADSET"
+
+# Reconnecting is an appearance again, which is the case a naive "seen once"
+# check would get wrong.
+run_watcher "$BUILTIN
+$BUILTIN $HEADSET
+$BUILTIN
+$BUILTIN $HEADSET" "$SINK_EVENT
+$SINK_EVENT
+$SINK_EVENT"
+check "a headset that reconnects takes over again" \
+  "$(switches | tr '\n' ' ')" "$HEADSET $HEADSET "
+
+run_watcher "$BUILTIN
+$BUILTIN alsa_output.usb-some-dac" "$SINK_EVENT"
+check "a new sink that is not bluetooth is ignored" "$(switches)" ""
+
+run_watcher "$BUILTIN
+$BUILTIN $HEADSET" "Event 'change' on source #60
+Event 'new' on client #123"
+check "events that are not about sinks are ignored" "$(switches)" ""
+
+# ---- the switch is checked, not assumed -------------------------------------
+#
+# The sink list is a moment old. A headset that drops in between leaves the
+# sound where it was, and audio-switch.sh once announced that as a move.
+SET_DEFAULT_RC=1 run_watcher "$BUILTIN
+$BUILTIN $HEADSET" "$SINK_EVENT"
+SET_DEFAULT_RC=0
+check "a failed switch is attempted" "$(switches)" "$HEADSET"
+check "but never announced as a success" "$(notifications | grep -c 'Switched to')" "0"
+
+# ---- two devices ------------------------------------------------------------
+
+run_watcher "$BUILTIN
+$BUILTIN $HEADSET
+$BUILTIN $HEADSET $OTHER_BT" "$SINK_EVENT
+$SINK_EVENT"
+check "a second bluetooth device appearing takes over in turn" \
+  "$(switches | tr '\n' ' ')" "$HEADSET $OTHER_BT "
+
+# ---- the unit ---------------------------------------------------------------
+
+check "the unit ships" "$([[ -f $UNIT ]] && echo present || echo missing)" "present"
+check "it restarts, because pactl subscribe ends when pipewire-pulse does" \
+  "$(grep -c '^Restart=always' "$UNIT")" "1"
+check "and stops with the session, like the battery monitor" \
+  "$(grep -c '^PartOf=graphical-session.target' "$UNIT")" "1"
+check "and starts with it" "$(grep -c '^WantedBy=graphical-session.target' "$UNIT")" "1"
+check "and runs the watcher" \
+  "$(grep -c 'ExecStart=%h/.local/bin/hyprsimple-audio-autoswitch.sh' "$UNIT")" "1"
+check "and says how to turn it off" "$(grep -c 'systemctl --user disable' "$UNIT")" "1"
+
+check "install.sh enables it" \
+  "$(sed 's/^[[:space:]]*#.*//' "$REPO/install.sh" | grep -c 'systemctl --user enable hyprsimple-audio-autoswitch.service')" "1"
+# enable, not enable --now: the unit is wanted by graphical-session.target and
+# the installer runs where that target is not up. The battery timer carries the
+# same rule and the same comment.
+check "and does not start it during the install" \
+  "$(sed 's/^[[:space:]]*#.*//' "$REPO/install.sh" | grep -c 'enable --now hyprsimple-audio-autoswitch')" "0"
+
+# ---- the migration, for installs that already exist -------------------------
+#
+# ~/.config is copied once and never overwritten, so a new unit reaches an
+# existing machine only through a migration.
+
+H="$TMP/home"
+mkdir -p "$H"
+run_migration() {
+  HOME="$H" HYPRSIMPLE_PATH="$REPO" PATH="$STUB:$(dirname "$BASH_BIN")" \
+    "$BASH_BIN" "$MIGRATION" >"$TMP/mig" 2>&1
+}
+# systemctl is stubbed for the migration only. Without it the migration would
+# reach the maintainer's own session manager.
+printf '#!/bin/bash\nexit 1\n' >"$STUB/systemctl"
+chmod +x "$STUB/systemctl"
+
+run_migration
+check "the migration delivers the unit" \
+  "$([[ -f $H/.config/systemd/user/hyprsimple-audio-autoswitch.service ]] && echo delivered || echo missing)" \
+  "delivered"
+check "and it is the shipped one" \
+  "$(cmp -s "$UNIT" "$H/.config/systemd/user/hyprsimple-audio-autoswitch.service" && echo same || echo different)" "same"
+check "and it says how to turn it off" "$(grep -c 'disable --now' "$TMP/mig")" "1"
+
+# Run twice: a migration that rewrites on every run would overwrite an edit.
+printf 'my own version\n' >"$H/.config/systemd/user/hyprsimple-audio-autoswitch.service"
+run_migration
+check "a unit already there is left exactly as it was" \
+  "$(cat "$H/.config/systemd/user/hyprsimple-audio-autoswitch.service")" "my own version"
+check "and it says so rather than silently skipping" \
+  "$(grep -c 'left alone' "$TMP/mig")" "1"
+
+# ---- documented -------------------------------------------------------------
+
+for doc in README.md FAQ.md; do
+  if grep -q 'hyprsimple-audio-autoswitch.service' "$REPO/$doc"; then
+    pass "$doc says how to turn it off"
+  else
+    fail "$doc does not mention the service, so there is no way to find it"
+  fi
+done
+check "and the FAQ explains why it was stuck, not just how to fix it" \
+  "$(grep -c '30000 + priority' "$REPO/FAQ.md")" "1"
+
+if ((failures > 0)); then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
Reported: headset connected, browser still playing through the speakers. It is hyprsimple's fault, and it is sticky.

## What was wrong

WirePlumber chooses the default sink by priority, and a bluetooth sink already outranks the built-in one. Read off the reporting machine:

```
Built-in Audio Analog Stereo: priority.session=1009
Monster Airstar M500:         priority.session=1010
```

So on a fresh install a headset takes over by itself and there is nothing to do. What stops it is an explicitly chosen default. `find-selected-default-node.lua` in WirePlumber 0.5:

```lua
if current_configured_node == name then
  priority = 30000 + priority
```

That +30000 goes to whatever `default.configured.audio.sink` names, so the chosen sink scores 31009 and no bluetooth device can ever outrank it.

`audio-switch.sh`, on `SUPER + F10`, writes exactly that key through `pactl set-default-sink`. **Pressing hyprsimple's audio switch once turns bluetooth auto-switching off permanently**, on every machine, and nothing says so. The reporting machine's state file showed the pin on the speakers with the whole history stacked below it:

```
default.configured.audio.sink=alsa_output.pci-0000_00_1f.3.analog-stereo
default.configured.audio.sink.0=...
```

## What it does now

A user service watches for a bluetooth sink appearing and makes it the default.

Only on appearance. A device already connected when the watcher starts is left where it is, and switching away from it by hand is not undone, because either would be the watcher arguing with the person using it. Reconnecting counts as appearing again, so a headset that drops and comes back takes over again.

The switch is checked before it is announced. The sink list is a moment old, and a headset that drops in between leaves the sound where it was. `audio-switch.sh` had that exact bug once, which is why it is a check here rather than a hope.

`Restart=always`, because `pactl subscribe` ends when pipewire-pulse restarts and that is not a failure. `PartOf=graphical-session.target`, the rule `battery-monitor.service` already follows, so a watcher never outlives the compositor and notifies into a bus with no display.

Off with `systemctl --user disable --now hyprsimple-audio-autoswitch.service`, said in the unit header, the migration output, the README and the FAQ.

A migration delivers and enables it on existing installs, since `~/.config` is copied once and never overwritten. It refuses to touch a unit already there.

## Tests

`test/audio-autoswitch-test.sh`, 27 checks, registered in the workflow. Nothing touches the real audio: `pactl` and `notify-send` are stubs, the watcher is pointed at the stub through `HYPRSIMPLE_PACTL` as well as by PATH, and the PATH holds only the stubs plus the few real tools linked in by name. `/usr/bin` is never on it.

`pactl list short sinks` is answered from a scripted timeline, one step per call, because the watcher reads the list once at startup and once per sink event and those calls are sequential. A shared file written by the event stream would have raced.

Four sabotages, each caught:

| sabotage | checks that failed |
| --- | --- |
| startup list not recorded, so it grabs on start | 7 |
| a failed switch announced as a success | 1 |
| it grabs any new sink, not just bluetooth | 1 |
| the known set never updates, so it switches repeatedly | 2 |

The first of those came back 0 on the first attempt because the sabotage had not applied. I checked the substitution landed before believing the number.

Documented in the README under a new Audio section, and in the FAQ with the mechanism, how to see what is pinned, and how to switch by hand on an install that predates this.